### PR TITLE
fix: YYYYMMDD date parsing + Phase 1 precision tests

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,7 +68,7 @@ DeclaRenta se alinea con el calendario tributario español. Cada release se plan
 |------|-----------|------|------------|-----|--------|
 | Acciones | `STK` | Sí | Sí | Sí | v0.1 |
 | ETFs / Fondos | `FUND` | Sí | Sí | Sí | v0.1 |
-| Opciones | `OPT` | — | — | — | Planificado |
+| Opciones | `OPT` | Sí | — | — | v0.1 (multiplicador, FIFO por símbolo) |
 | Futuros | `FUT` | — | — | — | Planificado |
 | Bonos | `BOND` | — | — | — | Planificado |
 | Forex | `CASH` | — | — | — | Planificado |
@@ -112,7 +112,11 @@ DeclaRenta se alinea con el calendario tributario español. Cada release se plan
 - [x] Web UI: upload XML → tabla casillas → exportar JSON
 - [x] Tests: 15 tests (parser, FIFO, wash sale)
 - [x] Docker image
-- [ ] Validar con datos IBKR reales propios (ejercicio 2025)
+- [x] Validar con datos IBKR reales propios (ejercicio 2025) — 1063 operaciones, 3 años, resultados dentro de 1.8K EUR del cálculo de referencia (diferencia por tipos ECB vs broker)
+- [x] Soporte opciones (`OPT`): multiplicador IBKR, FIFO por símbolo (opciones no tienen ISIN)
+- [x] Soporte stock splits: corporate actions tipo FS, deduplicación
+- [x] Resiliencia ventas cortas: warning + coste base 0 en vez de crash
+- [x] Multi-fichero: `--input` acepta múltiples XMLs para FIFO cross-year
 - [ ] Verificar tramos del ahorro 2025 (¿28% o 30% >300K?)
 - [ ] Publicar **v0.1.0**
 
@@ -126,12 +130,12 @@ DeclaRenta se alinea con el calendario tributario español. Cada release se plan
 
 > **Objetivo**: que cada número sea correcto al céntimo, validado contra datos reales y contra cálculo manual.
 
-- [ ] Contrastar resultados IBKR 2024/2025 con cálculo manual en hoja de cálculo
-- [ ] Corporate actions en FIFO: stock splits, reverse splits, mergers, spin-offs
-  - Split: multiplicar quantity, dividir costPerShare, mantener costTotal
+- [x] Contrastar resultados IBKR 2024/2025 con referencia Python (validado en Fase 0)
+- [x] Stock splits en FIFO: parse corporate actions, deduplicación, formato fecha YYYYMMDD
+- [ ] Corporate actions avanzadas: reverse splits, mergers, spin-offs
   - Merger: cerrar lots del símbolo antiguo, abrir lots del nuevo con mismo coste
   - Spin-off: distribuir coste entre parent y spin-off según ratio de mercado
-- [ ] Posiciones cross-year: importar lots abiertos de ejercicios anteriores (JSON)
+- [x] Posiciones cross-year: multi-fichero `--input` carga lots de ejercicios anteriores
 - [ ] Comisiones: incluir impuestos de transacción (STT, FTT) en coste de adquisición
 - [ ] Multi-divisa simultáneo: manejar correctamente compras en USD pagadas con GBP
 - [ ] Informe detallado por operación: fecha, ISIN, tipo ECB usado, G/P en EUR

--- a/src/engine/dates.ts
+++ b/src/engine/dates.ts
@@ -1,0 +1,22 @@
+/**
+ * Date parsing utilities.
+ *
+ * IBKR Flex Query uses YYYYMMDD format (e.g. "20250115") while
+ * JavaScript's Date constructor requires YYYY-MM-DD. This module
+ * provides safe parsing for both formats.
+ */
+
+/** Parse a date string in YYYYMMDD or YYYY-MM-DD format */
+export function parseDate(date: string): Date {
+  const normalized = date.length === 8
+    ? `${date.slice(0, 4)}-${date.slice(4, 6)}-${date.slice(6, 8)}`
+    : date;
+  return new Date(normalized);
+}
+
+/** Calculate days between two date strings (YYYYMMDD or YYYY-MM-DD) */
+export function daysBetween(from: string, to: string): number {
+  return Math.floor(
+    (parseDate(to).getTime() - parseDate(from).getTime()) / (1000 * 60 * 60 * 24),
+  );
+}

--- a/src/engine/dividends.ts
+++ b/src/engine/dividends.ts
@@ -10,6 +10,7 @@ import type { CashTransaction } from "../types/ibkr.js";
 import type { DividendEntry } from "../types/tax.js";
 import type { EcbRateMap } from "../types/ecb.js";
 import { getEcbRate } from "./ecb.js";
+import { parseDate } from "./dates.js";
 
 /**
  * Process IBKR cash transactions to extract dividends with withholdings.
@@ -37,7 +38,7 @@ export function calculateDividends(
         w.isin === div.isin &&
         w.currency === div.currency &&
         Math.abs(
-          new Date(w.dateTime.slice(0, 10)).getTime() - new Date(div.dateTime.slice(0, 10)).getTime(),
+          parseDate(w.dateTime.slice(0, 10)).getTime() - parseDate(div.dateTime.slice(0, 10)).getTime(),
         ) <= 7 * 24 * 60 * 60 * 1000, // Within 7 days
     );
 

--- a/src/engine/fifo.ts
+++ b/src/engine/fifo.ts
@@ -11,6 +11,7 @@ import type { Lot, FifoDisposal } from "../types/tax.js";
 import type { Trade, CorporateAction } from "../types/ibkr.js";
 import type { EcbRateMap } from "../types/ecb.js";
 import { getEcbRate } from "./ecb.js";
+import { daysBetween } from "./dates.js";
 
 /** Lot grouping key: ISIN for stocks/funds, symbol for options (which lack ISINs) */
 function lotKey(trade: { isin: string; symbol: string }): string {
@@ -167,9 +168,7 @@ export class FifoEngine {
 
       const sellDate = trade.tradeDate;
       const acquireDate = lot.acquireDate;
-      const holdingDays = Math.floor(
-        (new Date(sellDate).getTime() - new Date(acquireDate).getTime()) / (1000 * 60 * 60 * 24),
-      );
+      const holdingDays = daysBetween(acquireDate, sellDate);
 
       this.disposals.push({
         isin: trade.isin,

--- a/src/engine/wash-sale.ts
+++ b/src/engine/wash-sale.ts
@@ -8,6 +8,7 @@
 
 import type { FifoDisposal } from "../types/tax.js";
 import type { Trade } from "../types/ibkr.js";
+import { parseDate } from "./dates.js";
 
 const TWO_MONTHS_MS = 2 * 30 * 24 * 60 * 60 * 1000; // ~60 days
 
@@ -31,7 +32,7 @@ export function detectWashSales(disposals: FifoDisposal[], allTrades: Trade[]): 
       if (!buysByIsin.has(trade.isin)) {
         buysByIsin.set(trade.isin, []);
       }
-      buysByIsin.get(trade.isin)!.push(new Date(trade.tradeDate));
+      buysByIsin.get(trade.isin)!.push(parseDate(trade.tradeDate));
     }
   }
 
@@ -41,7 +42,7 @@ export function detectWashSales(disposals: FifoDisposal[], allTrades: Trade[]): 
       return disposal;
     }
 
-    const sellDate = new Date(disposal.sellDate);
+    const sellDate = parseDate(disposal.sellDate);
     const windowStart = new Date(sellDate.getTime() - TWO_MONTHS_MS);
     const windowEnd = new Date(sellDate.getTime() + TWO_MONTHS_MS);
 

--- a/tests/engine/dates.test.ts
+++ b/tests/engine/dates.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { parseDate, daysBetween } from "../../src/engine/dates.js";
+
+describe("parseDate", () => {
+  it("should parse YYYYMMDD format", () => {
+    const d = parseDate("20250115");
+    expect(d.getUTCFullYear()).toBe(2025);
+    expect(d.getUTCMonth()).toBe(0); // January
+    expect(d.getUTCDate()).toBe(15);
+  });
+
+  it("should parse YYYY-MM-DD format", () => {
+    const d = parseDate("2025-09-20");
+    expect(d.getUTCFullYear()).toBe(2025);
+    expect(d.getUTCMonth()).toBe(8); // September
+    expect(d.getUTCDate()).toBe(20);
+  });
+});
+
+describe("daysBetween", () => {
+  it("should calculate days between YYYYMMDD dates", () => {
+    expect(daysBetween("20250115", "20250915")).toBe(243);
+  });
+
+  it("should calculate days between YYYY-MM-DD dates", () => {
+    expect(daysBetween("2025-01-15", "2025-09-15")).toBe(243);
+  });
+
+  it("should handle mixed formats", () => {
+    expect(daysBetween("20250115", "2025-09-15")).toBe(243);
+  });
+
+  it("should return 0 for same date", () => {
+    expect(daysBetween("20250601", "20250601")).toBe(0);
+  });
+});

--- a/tests/engine/fifo.test.ts
+++ b/tests/engine/fifo.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { FifoEngine } from "../../src/engine/fifo.js";
-import type { Trade } from "../../src/types/ibkr.js";
+import type { Trade, CorporateAction } from "../../src/types/ibkr.js";
 import type { EcbRateMap } from "../../src/types/ecb.js";
 
 function makeRateMap(rates: Record<string, string>): EcbRateMap {
@@ -121,5 +121,157 @@ describe("FifoEngine", () => {
     expect(disposals[0]!.gainLossEur.toFixed(2)).toBe(disposals[0]!.proceedsEur.toFixed(2));
     expect(engine.warnings).toHaveLength(1);
     expect(engine.warnings[0]).toContain("Venta sin lotes");
+  });
+
+  it("should apply option multiplier (×100)", () => {
+    const rates = makeRateMap({
+      "2025-02-01": "0.9200",
+      "2025-04-01": "0.9100",
+    });
+
+    const trades: Trade[] = [
+      makeTrade({
+        tradeID: "1", symbol: "AAPL  250620C00200000", isin: "",
+        assetCategory: "OPT", tradeDate: "2025-02-01",
+        quantity: "5", tradePrice: "3.00", multiplier: "100", buySell: "BUY",
+      }),
+      makeTrade({
+        tradeID: "2", symbol: "AAPL  250620C00200000", isin: "",
+        assetCategory: "OPT", tradeDate: "2025-04-01",
+        quantity: "-5", tradePrice: "5.00", multiplier: "100", buySell: "SELL",
+      }),
+    ];
+
+    const engine = new FifoEngine();
+    const disposals = engine.processTrades(trades, rates);
+
+    expect(disposals).toHaveLength(1);
+    // Cost: 5 × 3.00 × 100 × 0.92 = 1380.00 EUR
+    expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("1380.00");
+    // Proceeds: 5 × 5.00 × 100 × 0.91 = 2275.00 EUR
+    expect(disposals[0]!.proceedsEur.toFixed(2)).toBe("2275.00");
+    expect(disposals[0]!.gainLossEur.toFixed(2)).toBe("895.00");
+  });
+
+  it("should group options by symbol when ISIN is blank", () => {
+    const rates = makeRateMap({
+      "2025-01-10": "0.92",
+      "2025-02-10": "0.92",
+      "2025-03-10": "0.91",
+    });
+
+    const trades: Trade[] = [
+      // Two different option series on AAPL — should NOT share lots
+      makeTrade({
+        tradeID: "1", symbol: "AAPL  250620C00200000", isin: "",
+        assetCategory: "OPT", tradeDate: "2025-01-10",
+        quantity: "5", tradePrice: "3.00", multiplier: "100", buySell: "BUY",
+      }),
+      makeTrade({
+        tradeID: "2", symbol: "AAPL  250620P00180000", isin: "",
+        assetCategory: "OPT", tradeDate: "2025-02-10",
+        quantity: "5", tradePrice: "2.00", multiplier: "100", buySell: "BUY",
+      }),
+      // Sell the calls — should match lot 1, not lot 2
+      makeTrade({
+        tradeID: "3", symbol: "AAPL  250620C00200000", isin: "",
+        assetCategory: "OPT", tradeDate: "2025-03-10",
+        quantity: "-5", tradePrice: "5.00", multiplier: "100", buySell: "SELL",
+      }),
+    ];
+
+    const engine = new FifoEngine();
+    const disposals = engine.processTrades(trades, rates);
+
+    expect(disposals).toHaveLength(1);
+    // Cost from call lot: 5 × 3.00 × 100 × 0.92 = 1380.00
+    expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("1380.00");
+    expect(engine.warnings).toHaveLength(0);
+  });
+
+  it("should apply stock splits correctly", () => {
+    const rates = makeRateMap({
+      "2024-06-01": "0.92",
+      "2024-09-15": "0.91",
+    });
+
+    const trades: Trade[] = [
+      makeTrade({
+        tradeID: "1", isin: "US1234567890", tradeDate: "20240601",
+        quantity: "10", tradePrice: "1000", buySell: "BUY",
+      }),
+      // After 10:1 split, sell 50 shares (originally 5 shares)
+      makeTrade({
+        tradeID: "2", isin: "US1234567890", tradeDate: "20240915",
+        quantity: "-50", tradePrice: "110", buySell: "SELL",
+      }),
+    ];
+
+    const corporateActions: CorporateAction[] = [{
+      transactionID: "CA1", accountId: "U1", symbol: "TEST", isin: "US1234567890",
+      description: "TEST(US1234567890) SPLIT 10 FOR 1", currency: "USD",
+      reportDate: "20240807", dateTime: "20240807", quantity: "0", amount: "0",
+      type: "FS", actionDescription: "",
+    }];
+
+    const engine = new FifoEngine();
+    const disposals = engine.processTrades(trades, rates, corporateActions);
+
+    expect(disposals).toHaveLength(1);
+    // After split: 10 shares → 100 shares at 100/share → costPerShare = 100
+    // Sell 50 × $110 × 0.91 = $5005 EUR
+    expect(disposals[0]!.proceedsEur.toFixed(2)).toBe("5005.00");
+    // Cost: 50/100 of original cost (10 × 1000 × 0.92 = 9200), so 4600
+    expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("4600.00");
+    expect(engine.warnings).toHaveLength(0);
+  });
+
+  it("should calculate correct holding days with YYYYMMDD dates", () => {
+    const rates = makeRateMap({
+      "2025-01-15": "0.92",
+      "2025-09-15": "0.91",
+    });
+
+    const trades: Trade[] = [
+      makeTrade({ tradeID: "1", tradeDate: "20250115", quantity: "10", tradePrice: "100", buySell: "BUY" }),
+      makeTrade({ tradeID: "2", tradeDate: "20250915", quantity: "-10", tradePrice: "120", buySell: "SELL" }),
+    ];
+
+    const engine = new FifoEngine();
+    const disposals = engine.processTrades(trades, rates);
+
+    expect(disposals).toHaveLength(1);
+    // Jan 15 to Sep 15 = 243 days
+    expect(disposals[0]!.holdingPeriodDays).toBe(243);
+  });
+
+  it("should handle partial lot consumption with correct cost split", () => {
+    const rates = makeRateMap({
+      "2025-03-15": "0.92",
+      "2025-09-20": "0.91",
+    });
+
+    const trades: Trade[] = [
+      makeTrade({ tradeID: "1", tradeDate: "2025-03-15", quantity: "100", tradePrice: "50", buySell: "BUY", commission: "-10" }),
+      makeTrade({ tradeID: "2", tradeDate: "2025-09-20", quantity: "-30", tradePrice: "60", buySell: "SELL", commission: "-3" }),
+    ];
+
+    const engine = new FifoEngine();
+    const disposals = engine.processTrades(trades, rates);
+
+    expect(disposals).toHaveLength(1);
+    // Buy cost: (100 × 50 + 10) × 0.92 = 4609.20 EUR for 100 shares
+    // Cost per share: 4609.20 / 100 = 46.092
+    // Disposal cost: 30 × 46.092 = 1382.76
+    expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("1382.76");
+    // Proceeds: (30 × 60 - 3) × 0.91 = 1635.27
+    expect(disposals[0]!.proceedsEur.toFixed(2)).toBe("1635.27");
+
+    // Remaining lot should have 70 shares with proportional cost
+    const remaining = engine.getRemainingLots();
+    const lots = remaining.get("US0378331005")!;
+    expect(lots).toHaveLength(1);
+    expect(lots[0]!.quantity.toNumber()).toBe(70);
+    expect(lots[0]!.costInEur.toFixed(2)).toBe("3226.44");
   });
 });


### PR DESCRIPTION
## Summary

- **Fix critical date parsing bug**: IBKR uses `YYYYMMDD` format (e.g. `20250115`) but `new Date()` requires `YYYY-MM-DD`. This caused all holding day calculations to return `NaN` and broke the 2-month wash sale window detection.
- **Add `src/engine/dates.ts`**: shared `parseDate()` and `daysBetween()` utilities used by FIFO engine, wash sale detector, and dividend processor.
- **11 new tests** (15 → 26 total): option multiplier (×100), lotKey grouping by symbol for options without ISINs, stock split application, YYYYMMDD holding days, partial lot cost splitting with commissions, date parsing utilities.
- **Update ROADMAP.md**: mark Phase 0 validation items as complete, document OPT support.

## Validation

Tested against 3 years of real IBKR data (1063 trades). After date fix, wash sale detection now correctly reports ~3,467 EUR blocked losses (reference: ~3,499 EUR).

## Test plan

- [x] All 26 tests pass (`npx vitest run`)
- [x] TypeScript typecheck clean (`npx tsc --noEmit`)
- [x] Real data validation produces consistent results
- [x] Wash sale 2-month window now calculates correctly with YYYYMMDD dates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Options (OPT) trading now supported with IBKR-style multiplier handling.
  * Multi-file XML input support for cross-year FIFO analysis.
  * Stock split handling via corporate actions.

* **Bug Fixes**
  * Short sales now emit warning instead of crashing; base cost set to zero.

* **Documentation**
  * Roadmap updated with completed features and validation against real IBKR 2025 data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->