### PR TITLE
test: dividend + double taxation coverage, strict ESLint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
-# DeclaRenta
+<p align="center">
+  <img src="docs/images/banner.svg" alt="DeclaRenta banner" width="900"/>
+</p>
 
-[![codecov](https://codecov.io/gh/GeiserX/DeclaRenta/graph/badge.svg)](https://codecov.io/gh/GeiserX/DeclaRenta)
-[![listed on awesome-spain](https://img.shields.io/badge/listed%20on-awesome--spain-c60b1e?style=flat-square&logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMCIgaGVpZ2h0PSIxNCIgdmlld0JveD0iMCAwIDIwIDE0Ij48cmVjdCB3aWR0aD0iMjAiIGhlaWdodD0iMTQiIGZpbGw9IiNjNjBiMWUiLz48cmVjdCB5PSIzLjUiIHdpZHRoPSIyMCIgaGVpZ2h0PSI3IiBmaWxsPSIjZmZjNDAwIi8+PC9zdmc+&labelColor=ffc400)](https://github.com/GeiserX/awesome-spain#readme)
+<h1 align="center">DeclaRenta</h1>
 
-**Convierte reportes de brokers extranjeros en tu declaración de la renta española.**
+<p align="center">
+  <strong>Convierte reportes de brokers extranjeros en tu declaración de la renta española.</strong>
+</p>
+
+<p align="center">
+  <a href="https://github.com/GeiserX/DeclaRenta/blob/main/LICENSE"><img src="https://img.shields.io/github/license/GeiserX/DeclaRenta?style=flat-square&color=dc2626" alt="License"/></a>
+  <a href="https://codecov.io/gh/GeiserX/DeclaRenta"><img src="https://img.shields.io/codecov/c/github/GeiserX/DeclaRenta?style=flat-square&color=f59e0b" alt="Codecov"/></a>
+  <a href="https://github.com/GeiserX/DeclaRenta/actions"><img src="https://img.shields.io/github/actions/workflow/status/GeiserX/DeclaRenta/ci.yml?style=flat-square&label=CI" alt="CI"/></a>
+  <a href="https://github.com/GeiserX/DeclaRenta/stargazers"><img src="https://img.shields.io/github/stars/GeiserX/DeclaRenta?style=flat-square&color=f59e0b" alt="Stars"/></a>
+  <a href="https://github.com/GeiserX/awesome-spain#readme"><img src="https://img.shields.io/badge/listed%20on-awesome--spain-c60b1e?style=flat-square&logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMCIgaGVpZ2h0PSIxNCIgdmlld0JveD0iMCAwIDIwIDE0Ij48cmVjdCB3aWR0aD0iMjAiIGhlaWdodD0iMTQiIGZpbGw9IiNjNjBiMWUiLz48cmVjdCB5PSIzLjUiIHdpZHRoPSIyMCIgaGVpZ2h0PSI3IiBmaWxsPSIjZmZjNDAwIi8+PC9zdmc+&labelColor=ffc400" alt="awesome-spain"/></a>
+</p>
 
 IBKR, Degiro, Trade Republic → Modelo 100 (IRPF), Modelo 720, D-6.
 

--- a/docs/images/banner.svg
+++ b/docs/images/banner.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 300">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0f172a"/>
+      <stop offset="50%" style="stop-color:#1e293b"/>
+      <stop offset="100%" style="stop-color:#0f172a"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626"/>
+      <stop offset="50%" style="stop-color:#f59e0b"/>
+      <stop offset="100%" style="stop-color:#dc2626"/>
+    </linearGradient>
+    <linearGradient id="glow" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#dc2626;stop-opacity:0.2"/>
+      <stop offset="50%" style="stop-color:#f59e0b;stop-opacity:0.4"/>
+      <stop offset="100%" style="stop-color:#dc2626;stop-opacity:0.2"/>
+    </linearGradient>
+    <linearGradient id="chart" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" style="stop-color:#22c55e;stop-opacity:0.1"/>
+      <stop offset="100%" style="stop-color:#22c55e;stop-opacity:0.4"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="900" height="300" fill="url(#bg)" rx="16"/>
+
+  <!-- Decorative grid lines (spreadsheet/tax form feel) -->
+  <line x1="100" y1="60" x2="100" y2="240" stroke="#334155" stroke-width="0.5" opacity="0.3"/>
+  <line x1="200" y1="60" x2="200" y2="240" stroke="#334155" stroke-width="0.5" opacity="0.3"/>
+  <line x1="700" y1="60" x2="700" y2="240" stroke="#334155" stroke-width="0.5" opacity="0.3"/>
+  <line x1="800" y1="60" x2="800" y2="240" stroke="#334155" stroke-width="0.5" opacity="0.3"/>
+
+  <!-- Mini chart (gains) on left -->
+  <polyline points="60,210 90,195 120,200 150,180 180,165 210,175 240,155"
+    fill="none" stroke="#22c55e" stroke-width="2" opacity="0.6"/>
+  <polyline points="60,210 90,195 120,200 150,180 180,165 210,175 240,155 240,210 60,210"
+    fill="url(#chart)" stroke="none"/>
+
+  <!-- Mini chart (losses) on right -->
+  <polyline points="660,170 690,180 720,175 750,195 780,200 810,190 840,205"
+    fill="none" stroke="#ef4444" stroke-width="2" opacity="0.6"/>
+
+  <!-- Casilla boxes decoration -->
+  <rect x="70" y="220" width="40" height="18" rx="2" fill="none" stroke="#475569" stroke-width="1" opacity="0.4"/>
+  <text x="90" y="233" text-anchor="middle" font-family="monospace" font-size="8" fill="#64748b" opacity="0.5">0327</text>
+  <rect x="120" y="220" width="40" height="18" rx="2" fill="none" stroke="#475569" stroke-width="1" opacity="0.4"/>
+  <text x="140" y="233" text-anchor="middle" font-family="monospace" font-size="8" fill="#64748b" opacity="0.5">0328</text>
+  <rect x="740" y="220" width="40" height="18" rx="2" fill="none" stroke="#475569" stroke-width="1" opacity="0.4"/>
+  <text x="760" y="233" text-anchor="middle" font-family="monospace" font-size="8" fill="#64748b" opacity="0.5">0588</text>
+  <rect x="790" y="220" width="40" height="18" rx="2" fill="none" stroke="#475569" stroke-width="1" opacity="0.4"/>
+  <text x="810" y="233" text-anchor="middle" font-family="monospace" font-size="8" fill="#64748b" opacity="0.5">0029</text>
+
+  <!-- EUR symbols floating -->
+  <text x="155" y="95" font-family="system-ui" font-size="24" fill="#f59e0b" opacity="0.15" transform="rotate(-15 155 95)">EUR</text>
+  <text x="730" y="110" font-family="system-ui" font-size="20" fill="#f59e0b" opacity="0.12" transform="rotate(10 730 110)">USD</text>
+
+  <!-- Top accent line -->
+  <rect x="275" y="40" width="350" height="3" rx="1.5" fill="url(#accent)" opacity="0.8"/>
+
+  <!-- Title -->
+  <text x="450" y="112" text-anchor="middle" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="56" font-weight="700" fill="white" letter-spacing="-1">DeclaRenta</text>
+
+  <!-- Subtitle -->
+  <text x="450" y="142" text-anchor="middle" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="15" fill="#94a3b8" letter-spacing="4" font-weight="400">DECLARACIONES FISCALES OPEN SOURCE</text>
+
+  <!-- Bottom accent line -->
+  <rect x="275" y="235" width="350" height="3" rx="1.5" fill="url(#accent)" opacity="0.8"/>
+
+  <!-- Tagline -->
+  <text x="450" y="262" text-anchor="middle" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="13" fill="#64748b">Broker extranjero &#x2192; Modelo 100 + 720 + D-6 | Privacidad total, todo en tu navegador</text>
+</svg>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,7 +1,33 @@
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  ...tseslint.configs.recommended,
+  ...tseslint.configs.strictTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        project: "./tsconfig.eslint.json",
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      "@typescript-eslint/restrict-template-expressions": "off",
+      "@typescript-eslint/no-non-null-assertion": "off",
+    },
+  },
+  {
+    files: ["src/parsers/**/*.ts"],
+    rules: {
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+    },
+  },
+  {
+    files: ["src/web/**/*.ts"],
+    rules: {
+      "@typescript-eslint/no-confusing-void-expression": "off",
+      "@typescript-eslint/no-floating-promises": "off",
+    },
+  },
   {
     ignores: ["dist/", "node_modules/"],
   },

--- a/tests/engine/dividends.test.ts
+++ b/tests/engine/dividends.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import { calculateDividends } from "../../src/engine/dividends.js";
+import type { CashTransaction } from "../../src/types/ibkr.js";
+import type { EcbRateMap } from "../../src/types/ecb.js";
+
+function makeRateMap(rates: Record<string, Record<string, string>>): EcbRateMap {
+  const map: EcbRateMap = new Map();
+  for (const [date, currencies] of Object.entries(rates)) {
+    map.set(date, new Map(Object.entries(currencies)));
+  }
+  return map;
+}
+
+function makeCashTx(overrides: Partial<CashTransaction>): CashTransaction {
+  return {
+    transactionID: "1",
+    accountId: "U1",
+    symbol: "AAPL",
+    description: "APPLE INC",
+    isin: "US0378331005",
+    currency: "USD",
+    dateTime: "20250601",
+    settleDate: "20250603",
+    amount: "100",
+    fxRateToBase: "0.92",
+    type: "Dividends",
+    ...overrides,
+  };
+}
+
+describe("calculateDividends", () => {
+  it("should calculate dividend with matching withholding tax", () => {
+    const rates = makeRateMap({ "2025-06-01": { USD: "0.92" } });
+
+    const transactions: CashTransaction[] = [
+      makeCashTx({ transactionID: "1", amount: "100", type: "Dividends" }),
+      makeCashTx({ transactionID: "2", amount: "-15", type: "Withholding Tax" }),
+    ];
+
+    const entries = calculateDividends(transactions, rates);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.grossAmountEur.toFixed(2)).toBe("92.00");
+    expect(entries[0]!.withholdingTaxEur.toFixed(2)).toBe("13.80");
+    expect(entries[0]!.symbol).toBe("AAPL");
+  });
+
+  it("should handle dividend without withholding", () => {
+    const rates = makeRateMap({ "2025-06-01": { USD: "0.92" } });
+
+    const transactions: CashTransaction[] = [
+      makeCashTx({ transactionID: "1", amount: "50", type: "Dividends" }),
+    ];
+
+    const entries = calculateDividends(transactions, rates);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.withholdingTaxEur.toFixed(2)).toBe("0.00");
+  });
+
+  it("should handle EUR dividends (rate = 1)", () => {
+    const rates: EcbRateMap = new Map();
+
+    const transactions: CashTransaction[] = [
+      makeCashTx({ transactionID: "1", currency: "EUR", amount: "200", type: "Dividends" }),
+      makeCashTx({ transactionID: "2", currency: "EUR", amount: "-30", type: "Withholding Tax" }),
+    ];
+
+    const entries = calculateDividends(transactions, rates);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.grossAmountEur.toFixed(2)).toBe("200.00");
+    expect(entries[0]!.withholdingTaxEur.toFixed(2)).toBe("30.00");
+  });
+
+  it("should handle Payment In Lieu of Dividends", () => {
+    const rates = makeRateMap({ "2025-06-01": { USD: "0.92" } });
+
+    const transactions: CashTransaction[] = [
+      makeCashTx({ transactionID: "1", amount: "75", type: "Payment In Lieu Of Dividends" }),
+    ];
+
+    const entries = calculateDividends(transactions, rates);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.grossAmountEur.toFixed(2)).toBe("69.00");
+  });
+
+  it("should match withholding by ISIN and date proximity", () => {
+    const rates = makeRateMap({
+      "2025-06-01": { USD: "0.92" },
+      "2025-06-03": { USD: "0.91" },
+    });
+
+    const transactions: CashTransaction[] = [
+      makeCashTx({ transactionID: "1", dateTime: "20250601", amount: "100", type: "Dividends" }),
+      // Withholding 2 days later — should match (within 7 days)
+      makeCashTx({ transactionID: "2", dateTime: "20250603", amount: "-15", type: "Withholding Tax" }),
+    ];
+
+    const entries = calculateDividends(transactions, rates);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.withholdingTaxEur.toFixed(2)).toBe("13.80");
+  });
+
+  it("should not match withholding with different ISIN", () => {
+    const rates = makeRateMap({ "2025-06-01": { USD: "0.92" } });
+
+    const transactions: CashTransaction[] = [
+      makeCashTx({ transactionID: "1", isin: "US0378331005", amount: "100", type: "Dividends" }),
+      makeCashTx({ transactionID: "2", isin: "US5949181045", amount: "-15", type: "Withholding Tax" }),
+    ];
+
+    const entries = calculateDividends(transactions, rates);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.withholdingTaxEur.toFixed(2)).toBe("0.00");
+  });
+
+  it("should ignore non-dividend transaction types", () => {
+    const rates = makeRateMap({ "2025-06-01": { USD: "0.92" } });
+
+    const transactions: CashTransaction[] = [
+      makeCashTx({ transactionID: "1", type: "Broker Interest Received", amount: "50" }),
+      makeCashTx({ transactionID: "2", type: "Dividends", amount: "100" }),
+    ];
+
+    const entries = calculateDividends(transactions, rates);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.grossAmountEur.toFixed(2)).toBe("92.00");
+  });
+});

--- a/tests/engine/double-taxation.test.ts
+++ b/tests/engine/double-taxation.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import Decimal from "decimal.js";
+import { calculateDoubleTaxation } from "../../src/engine/double-taxation.js";
+import type { DividendEntry } from "../../src/types/tax.js";
+
+function makeEntry(overrides: Partial<DividendEntry>): DividendEntry {
+  return {
+    isin: "US0378331005",
+    symbol: "AAPL",
+    description: "APPLE INC",
+    payDate: "2025-06-01",
+    grossAmountEur: new Decimal(100),
+    withholdingTaxEur: new Decimal(15),
+    withholdingCountry: "US",
+    currency: "USD",
+    ecbRate: new Decimal(0.92),
+    ...overrides,
+  };
+}
+
+describe("calculateDoubleTaxation", () => {
+  it("should calculate deduction capped by Spanish tax", () => {
+    const entries = [
+      makeEntry({ grossAmountEur: new Decimal(1000), withholdingTaxEur: new Decimal(300) }),
+    ];
+
+    const result = calculateDoubleTaxation(entries);
+
+    // Spanish tax on 1000 EUR: 19% of 1000 = 190
+    // Foreign tax: 300, Spanish tax: 190 → deduction = min(300, 190) = 190
+    expect(result.total.toFixed(2)).toBe("190.00");
+    expect(result.byCountry["US"]!.taxPaid.toFixed(2)).toBe("300.00");
+    expect(result.byCountry["US"]!.deductionAllowed.toFixed(2)).toBe("190.00");
+  });
+
+  it("should allow full deduction when foreign tax is lower", () => {
+    const entries = [
+      makeEntry({ grossAmountEur: new Decimal(1000), withholdingTaxEur: new Decimal(100) }),
+    ];
+
+    const result = calculateDoubleTaxation(entries);
+
+    // Spanish tax on 1000: 190. Foreign: 100. Deduction = min(100, 190) = 100
+    expect(result.total.toFixed(2)).toBe("100.00");
+  });
+
+  it("should aggregate by country", () => {
+    const entries = [
+      makeEntry({ withholdingCountry: "US", grossAmountEur: new Decimal(500), withholdingTaxEur: new Decimal(75) }),
+      makeEntry({ withholdingCountry: "US", grossAmountEur: new Decimal(500), withholdingTaxEur: new Decimal(75) }),
+      makeEntry({ withholdingCountry: "DE", grossAmountEur: new Decimal(200), withholdingTaxEur: new Decimal(52) }),
+    ];
+
+    const result = calculateDoubleTaxation(entries);
+
+    expect(Object.keys(result.byCountry)).toHaveLength(2);
+    // US: gross 1000, tax 150, Spanish tax 190 → deduction 150
+    expect(result.byCountry["US"]!.deductionAllowed.toFixed(2)).toBe("150.00");
+    // DE: gross 200, tax 52, Spanish tax 38 → deduction 38
+    expect(result.byCountry["DE"]!.deductionAllowed.toFixed(2)).toBe("38.00");
+    expect(result.total.toFixed(2)).toBe("188.00");
+  });
+
+  it("should return empty when no withholdings", () => {
+    const entries = [
+      makeEntry({ withholdingTaxEur: new Decimal(0) }),
+    ];
+
+    const result = calculateDoubleTaxation(entries);
+    expect(result.total.toFixed(2)).toBe("0.00");
+    expect(Object.keys(result.byCountry)).toHaveLength(0);
+  });
+
+  it("should handle empty input", () => {
+    const result = calculateDoubleTaxation([]);
+    expect(result.total.toFixed(2)).toBe("0.00");
+    expect(Object.keys(result.byCountry)).toHaveLength(0);
+  });
+
+  it("should use progressive savings brackets for large amounts", () => {
+    const entries = [
+      makeEntry({
+        grossAmountEur: new Decimal(10000),
+        withholdingTaxEur: new Decimal(5000),
+      }),
+    ];
+
+    const result = calculateDoubleTaxation(entries);
+
+    // Spanish tax on 10000:
+    // 6000 × 19% = 1140
+    // 4000 × 21% = 840
+    // Total = 1980
+    // Foreign: 5000, deduction = min(5000, 1980) = 1980
+    expect(result.total.toFixed(2)).toBe("1980.00");
+  });
+});

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- **13 new tests** (26 → 39 total): dividends (7) and double taxation (6) — covers the `parseDate` gap flagged by Codecov, withholding tax matching, Payment In Lieu, progressive savings brackets, country aggregation
- **ESLint upgraded** to `strictTypeChecked` with dedicated `tsconfig.eslint.json` for test inclusion
- Parser `any` suppressed (XML parsing is inherently untyped), web void/promises suppressed

## Test plan

- [x] 39 tests pass across 6 test files
- [x] TypeScript typecheck clean
- [x] ESLint: 0 errors, 0 warnings
- [x] Covers `src/engine/dividends.ts` parseDate lines flagged by Codecov