### PR TITLE
test: improve patch coverage — CSV + FIFO edge cases

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,6 +17,7 @@ import type { EcbRateMap } from "../types/ecb.js";
 import { fetchEcbRates } from "../engine/ecb.js";
 import { generateTaxReport } from "../generators/report.js";
 import { generateModelo720 } from "../generators/modelo720.js";
+import { formatCsv } from "../generators/csv.js";
 
 // Configure Decimal.js for financial precision
 Decimal.set({ precision: 20, rounding: Decimal.ROUND_HALF_UP });
@@ -225,55 +226,6 @@ function formatReport(report: ReturnType<typeof generateTaxReport>) {
       pais: d.withholdingCountry,
     })),
   };
-}
-
-function escapeCsv(val: string): string {
-  if (val.includes(",") || val.includes('"') || val.includes("\n")) {
-    return `"${val.replace(/"/g, '""')}"`;
-  }
-  return val;
-}
-
-function formatCsv(report: ReturnType<typeof generateTaxReport>): string {
-  const lines: string[] = [];
-
-  // Capital gains section
-  lines.push("# GANANCIAS PATRIMONIALES");
-  lines.push("ISIN,Simbolo,Descripcion,Fecha_Compra,Fecha_Venta,Cantidad,Coste_EUR,Venta_EUR,Ganancia_EUR,Dias,Bloqueada_Antichurning");
-  for (const d of report.capitalGains.disposals) {
-    lines.push([
-      d.isin, d.symbol, escapeCsv(d.description), d.acquireDate, d.sellDate,
-      d.quantity.toString(), d.costBasisEur.toFixed(2), d.proceedsEur.toFixed(2),
-      d.gainLossEur.toFixed(2), d.holdingPeriodDays.toString(), d.washSaleBlocked ? "SI" : "NO",
-    ].join(","));
-  }
-
-  lines.push("");
-
-  // Dividends section
-  lines.push("# DIVIDENDOS");
-  lines.push("ISIN,Simbolo,Descripcion,Fecha,Bruto_EUR,Retencion_EUR,Pais,Divisa");
-  for (const d of report.dividends.entries) {
-    lines.push([
-      d.isin, d.symbol, escapeCsv(d.description), d.payDate,
-      d.grossAmountEur.toFixed(2), d.withholdingTaxEur.toFixed(2),
-      d.withholdingCountry, d.currency,
-    ].join(","));
-  }
-
-  lines.push("");
-
-  // Summary section
-  lines.push("# RESUMEN CASILLAS");
-  lines.push("Casilla,Concepto,Valor_EUR");
-  lines.push(`0327,Valor de transmision,${report.capitalGains.transmissionValue.toFixed(2)}`);
-  lines.push(`0328,Valor de adquisicion,${report.capitalGains.acquisitionValue.toFixed(2)}`);
-  lines.push(`0029,Dividendos brutos,${report.dividends.grossIncome.toFixed(2)}`);
-  lines.push(`0032,Gastos deducibles (intereses),${report.interest.paid.toFixed(2)}`);
-  lines.push(`0033,Intereses de cuentas,${report.interest.earned.toFixed(2)}`);
-  lines.push(`0588,Deduccion doble imposicion,${report.doubleTaxation.deduction.toFixed(2)}`);
-
-  return lines.join("\n") + "\n";
 }
 
 function printSummary(report: ReturnType<typeof generateTaxReport>) {

--- a/src/generators/csv.ts
+++ b/src/generators/csv.ts
@@ -1,0 +1,56 @@
+/**
+ * CSV report generator.
+ *
+ * Exports per-operation detail as CSV for import into spreadsheets.
+ */
+
+import type { TaxSummary } from "../types/tax.js";
+
+export function escapeCsv(val: string): string {
+  if (val.includes(",") || val.includes('"') || val.includes("\n")) {
+    return `"${val.replace(/"/g, '""')}"`;
+  }
+  return val;
+}
+
+export function formatCsv(report: TaxSummary): string {
+  const lines: string[] = [];
+
+  // Capital gains section
+  lines.push("# GANANCIAS PATRIMONIALES");
+  lines.push("ISIN,Simbolo,Descripcion,Fecha_Compra,Fecha_Venta,Cantidad,Coste_EUR,Venta_EUR,Ganancia_EUR,Dias,Bloqueada_Antichurning");
+  for (const d of report.capitalGains.disposals) {
+    lines.push([
+      d.isin, d.symbol, escapeCsv(d.description), d.acquireDate, d.sellDate,
+      d.quantity.toString(), d.costBasisEur.toFixed(2), d.proceedsEur.toFixed(2),
+      d.gainLossEur.toFixed(2), d.holdingPeriodDays.toString(), d.washSaleBlocked ? "SI" : "NO",
+    ].join(","));
+  }
+
+  lines.push("");
+
+  // Dividends section
+  lines.push("# DIVIDENDOS");
+  lines.push("ISIN,Simbolo,Descripcion,Fecha,Bruto_EUR,Retencion_EUR,Pais,Divisa");
+  for (const d of report.dividends.entries) {
+    lines.push([
+      d.isin, d.symbol, escapeCsv(d.description), d.payDate,
+      d.grossAmountEur.toFixed(2), d.withholdingTaxEur.toFixed(2),
+      d.withholdingCountry, d.currency,
+    ].join(","));
+  }
+
+  lines.push("");
+
+  // Summary section
+  lines.push("# RESUMEN CASILLAS");
+  lines.push("Casilla,Concepto,Valor_EUR");
+  lines.push(`0327,Valor de transmision,${report.capitalGains.transmissionValue.toFixed(2)}`);
+  lines.push(`0328,Valor de adquisicion,${report.capitalGains.acquisitionValue.toFixed(2)}`);
+  lines.push(`0029,Dividendos brutos,${report.dividends.grossIncome.toFixed(2)}`);
+  lines.push(`0032,Gastos deducibles (intereses),${report.interest.paid.toFixed(2)}`);
+  lines.push(`0033,Intereses de cuentas,${report.interest.earned.toFixed(2)}`);
+  lines.push(`0588,Deduccion doble imposicion,${report.doubleTaxation.deduction.toFixed(2)}`);
+
+  return lines.join("\n") + "\n";
+}

--- a/tests/engine/fifo.test.ts
+++ b/tests/engine/fifo.test.ts
@@ -275,6 +275,50 @@ describe("FifoEngine", () => {
     expect(lots[0]!.costInEur.toFixed(2)).toBe("3226.44");
   });
 
+  it("should include taxes in short-sale proceeds (no lots)", () => {
+    const rates = makeRateMap({ "2025-09-20": "0.91" });
+    const trades: Trade[] = [
+      makeTrade({ tradeID: "1", tradeDate: "2025-09-20", quantity: "-10", tradePrice: "120", buySell: "SELL", commission: "-5", taxes: "-3" }),
+    ];
+
+    const engine = new FifoEngine();
+    const disposals = engine.processTrades(trades, rates);
+
+    expect(disposals).toHaveLength(1);
+    expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("0.00");
+    // Proceeds: (10 × 120 - 5 - 3) × 0.91 = 1192 × 0.91 = 1084.72
+    expect(disposals[0]!.proceedsEur.toFixed(2)).toBe("1084.72");
+    expect(engine.warnings).toHaveLength(1);
+  });
+
+  it("should include taxes in insufficient-lots fallback", () => {
+    const rates = makeRateMap({
+      "2025-03-15": "0.92",
+      "2025-09-20": "0.91",
+    });
+
+    const trades: Trade[] = [
+      makeTrade({ tradeID: "1", tradeDate: "2025-03-15", quantity: "5", tradePrice: "100", buySell: "BUY" }),
+      // Sell 10 but only 5 lots available — 5 go through FIFO, 5 hit the fallback
+      makeTrade({ tradeID: "2", tradeDate: "2025-09-20", quantity: "-10", tradePrice: "120", buySell: "SELL", commission: "-10", taxes: "-4" }),
+    ];
+
+    const engine = new FifoEngine();
+    const disposals = engine.processTrades(trades, rates);
+
+    // 2 disposals: 5 from lot + 5 from insufficient-lots fallback
+    expect(disposals).toHaveLength(2);
+    expect(engine.warnings).toHaveLength(1);
+    expect(engine.warnings[0]).toContain("Lotes insuficientes");
+
+    // Fallback disposal: 5 shares, fraction = 5/10 = 0.5
+    // commission share = 10 × 0.5 = 5, taxes share = 4 × 0.5 = 2
+    // proceeds = (5 × 120 - 5 - 2) × 0.91 = 593 × 0.91 = 539.63
+    const fallback = disposals[1]!;
+    expect(fallback.costBasisEur.toFixed(2)).toBe("0.00");
+    expect(fallback.proceedsEur.toFixed(2)).toBe("539.63");
+  });
+
   it("should include transaction taxes in cost and proceeds", () => {
     const rates = makeRateMap({
       "2025-03-15": "0.92",

--- a/tests/generators/csv.test.ts
+++ b/tests/generators/csv.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import Decimal from "decimal.js";
+import { escapeCsv, formatCsv } from "../../src/generators/csv.js";
+import type { TaxSummary } from "../../src/types/tax.js";
+
+describe("escapeCsv", () => {
+  it("should return plain strings unchanged", () => {
+    expect(escapeCsv("AAPL")).toBe("AAPL");
+  });
+
+  it("should wrap strings with commas in quotes", () => {
+    expect(escapeCsv("APPLE INC, Class A")).toBe('"APPLE INC, Class A"');
+  });
+
+  it("should escape double quotes by doubling them", () => {
+    expect(escapeCsv('She said "hello"')).toBe('"She said ""hello"""');
+  });
+
+  it("should wrap strings with newlines in quotes", () => {
+    expect(escapeCsv("line1\nline2")).toBe('"line1\nline2"');
+  });
+});
+
+function makeReport(overrides?: Partial<TaxSummary>): TaxSummary {
+  return {
+    year: 2025,
+    warnings: [],
+    capitalGains: {
+      transmissionValue: new Decimal(1000),
+      acquisitionValue: new Decimal(800),
+      netGainLoss: new Decimal(200),
+      blockedLosses: new Decimal(0),
+      disposals: [
+        {
+          isin: "US0378331005",
+          symbol: "AAPL",
+          description: "APPLE INC",
+          sellDate: "20250920",
+          acquireDate: "20250315",
+          quantity: new Decimal(10),
+          proceedsEur: new Decimal(1000),
+          costBasisEur: new Decimal(800),
+          gainLossEur: new Decimal(200),
+          holdingPeriodDays: 189,
+          washSaleBlocked: false,
+        },
+      ],
+    },
+    dividends: {
+      grossIncome: new Decimal(50),
+      deductibleExpenses: new Decimal(0),
+      entries: [
+        {
+          isin: "US0378331005",
+          symbol: "AAPL",
+          description: "APPLE INC",
+          payDate: "20250601",
+          grossAmountEur: new Decimal(50),
+          withholdingTaxEur: new Decimal(7.5),
+          withholdingCountry: "US",
+          currency: "USD",
+          ecbRate: new Decimal("0.92"),
+        },
+      ],
+    },
+    interest: {
+      earned: new Decimal(10),
+      paid: new Decimal(2),
+      entries: [],
+    },
+    doubleTaxation: {
+      deduction: new Decimal(7.5),
+      byCountry: {},
+    },
+    ...overrides,
+  };
+}
+
+describe("formatCsv", () => {
+  it("should produce capital gains, dividends, and summary sections", () => {
+    const csv = formatCsv(makeReport());
+
+    expect(csv).toContain("# GANANCIAS PATRIMONIALES");
+    expect(csv).toContain("# DIVIDENDOS");
+    expect(csv).toContain("# RESUMEN CASILLAS");
+  });
+
+  it("should include disposal rows with correct fields", () => {
+    const csv = formatCsv(makeReport());
+
+    // Header + 1 data row in capital gains
+    const lines = csv.split("\n");
+    const header = lines.find((l) => l.startsWith("ISIN,Simbolo"))!;
+    expect(header).toContain("Bloqueada_Antichurning");
+
+    const dataLine = lines.find((l) => l.startsWith("US0378331005,AAPL"))!;
+    expect(dataLine).toContain("1000.00"); // proceeds
+    expect(dataLine).toContain("800.00"); // cost
+    expect(dataLine).toContain("200.00"); // gain
+    expect(dataLine).toContain("189"); // holding days
+    expect(dataLine).toContain("NO"); // not blocked
+  });
+
+  it("should include dividend rows", () => {
+    const csv = formatCsv(makeReport());
+
+    const lines = csv.split("\n");
+    const divLine = lines.find((l) => l.includes("50.00") && l.includes("US"))!;
+    expect(divLine).toContain("7.50"); // withholding
+    expect(divLine).toContain("USD");
+  });
+
+  it("should include casilla summary values", () => {
+    const csv = formatCsv(makeReport());
+
+    expect(csv).toContain("0327,Valor de transmision,1000.00");
+    expect(csv).toContain("0328,Valor de adquisicion,800.00");
+    expect(csv).toContain("0029,Dividendos brutos,50.00");
+    expect(csv).toContain("0588,Deduccion doble imposicion,7.50");
+  });
+
+  it("should escape descriptions with commas", () => {
+    const report = makeReport();
+    report.capitalGains.disposals[0]!.description = "BERKSHIRE HATHAWAY, CL B";
+    const csv = formatCsv(report);
+
+    expect(csv).toContain('"BERKSHIRE HATHAWAY, CL B"');
+  });
+
+  it("should show SI for wash-sale blocked disposals", () => {
+    const report = makeReport();
+    report.capitalGains.disposals[0]!.washSaleBlocked = true;
+    const csv = formatCsv(report);
+
+    const lines = csv.split("\n");
+    const dataLine = lines.find((l) => l.startsWith("US0378331005"))!;
+    expect(dataLine.endsWith("SI")).toBe(true);
+  });
+
+  it("should handle empty disposals and dividends", () => {
+    const report = makeReport();
+    report.capitalGains.disposals = [];
+    report.dividends.entries = [];
+    const csv = formatCsv(report);
+
+    expect(csv).toContain("# GANANCIAS PATRIMONIALES");
+    expect(csv).toContain("# RESUMEN CASILLAS");
+    // Should still have headers but no data rows
+    const lines = csv.split("\n").filter((l) => l.startsWith("US"));
+    expect(lines).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Addresses Codecov feedback from PR #8 (patch coverage was 18.3%, 58 lines missing).

- **Extract `formatCsv`/`escapeCsv`** from `src/cli/index.ts` to `src/generators/csv.ts` — now testable
- **11 CSV tests**: escape logic, section headers, disposal rows, dividends, casilla summary, comma escaping, wash-sale flag, empty data
- **2 new FIFO tests**: transaction taxes in short-sale path (no lots) and insufficient-lots fallback — covers the 2 missing lines in `fifo.ts`
- **54 tests total**, ESLint clean, build passing

## Test plan

- [x] 54 tests passing
- [x] ESLint strictTypeChecked clean
- [x] Build succeeds
- [ ] CI passes
- [ ] Codecov patch coverage improves

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tax calculations now correctly include taxes in EUR proceeds calculations for trade disposals, ensuring accurate cost-basis and proceeds reporting.

* **Refactor**
  * Reorganized CSV export functionality for improved maintainability and code organization.

* **Tests**
  * Added comprehensive test coverage for FIFO trade processing with tax inclusion and CSV report generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->