### PR TITLE
ci: automated release pipeline with auto-tag and changelog

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,58 @@
+name: Auto Tag
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Bump patch version
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PAT }}
+
+      - name: Get latest tag and bump patch
+        id: bump
+        run: |
+          LATEST=$(git tag -l "v*" --sort=-version:refname | head -1)
+          if [ -z "$LATEST" ]; then
+            echo "new_tag=v0.0.1" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          # Strip v prefix, split into major.minor.patch
+          VERSION="${LATEST#v}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          PATCH=$(echo "$VERSION" | cut -d. -f3)
+          NEW_PATCH=$((PATCH + 1))
+          echo "new_tag=v${MAJOR}.${MINOR}.${NEW_PATCH}" >> $GITHUB_OUTPUT
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Sync package.json version and create tag
+        run: |
+          NEW_TAG="${{ steps.bump.outputs.new_tag }}"
+          VERSION="${NEW_TAG#v}"
+          # Tag the current HEAD (the actual code) BEFORE the version bump.
+          git tag "$NEW_TAG"
+          CURRENT=$(node -p "require('./package.json').version")
+          if [ "$CURRENT" != "$VERSION" ]; then
+            npm version "$VERSION" --no-git-tag-version
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add package.json package-lock.json
+            git commit -m "chore: bump version to $NEW_TAG [skip ci]"
+            git push origin main
+          fi
+          git push origin "$NEW_TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: GitHub Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Generate changelog
+        id: changelog
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          PREV_TAG=$(git tag -l "v*" --sort=-version:refname | sed -n '2p')
+
+          if [ -z "$PREV_TAG" ]; then
+            PREV_TAG=$(git rev-list --max-parents=0 HEAD)
+          fi
+
+          {
+            echo "## What's Changed"
+            echo ""
+
+            FEATURES=$(git log $PREV_TAG..$VERSION --pretty=format:"- %s" --grep="^feat" 2>/dev/null || true)
+            if [ -n "$FEATURES" ]; then
+              echo "### Features"
+              echo "$FEATURES" | head -20
+              echo ""
+            fi
+
+            FIXES=$(git log $PREV_TAG..$VERSION --pretty=format:"- %s" --grep="^fix" 2>/dev/null || true)
+            if [ -n "$FIXES" ]; then
+              echo "### Bug Fixes"
+              echo "$FIXES" | head -20
+              echo ""
+            fi
+
+            OTHERS=$(git log $PREV_TAG..$VERSION --pretty=format:"- %s" --invert-grep --grep="^feat" --invert-grep --grep="^fix" 2>/dev/null | head -10 || true)
+            if [ -n "$OTHERS" ]; then
+              echo "### Other Changes"
+              echo "$OTHERS"
+              echo ""
+            fi
+
+            echo "---"
+            echo ""
+            echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/$PREV_TAG...$VERSION"
+          } > changelog.md
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: changelog.md
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,6 +19,9 @@ import { generateTaxReport } from "../generators/report.js";
 import { generateModelo720 } from "../generators/modelo720.js";
 import { formatCsv } from "../generators/csv.js";
 
+// Read version from package.json (single source of truth)
+const pkg = JSON.parse(readFileSync(new URL("../../package.json", import.meta.url), "utf-8")) as { version: string };
+
 // Configure Decimal.js for financial precision
 Decimal.set({ precision: 20, rounding: Decimal.ROUND_HALF_UP });
 
@@ -27,7 +30,7 @@ const program = new Command();
 program
   .name("declarenta")
   .description("Convert foreign broker reports into Spanish tax declarations")
-  .version("0.1.0");
+  .version(pkg.version);
 
 program
   .command("convert")
@@ -38,7 +41,7 @@ program
   .option("-f, --format <format>", "Output format: json or csv", "json")
   .action(async (opts: { input: string[]; year: number; output?: string; format: string }) => {
     try {
-      console.error(`DeclaRenta v0.2.0 - Ejercicio ${opts.year}, ${opts.input.length} fichero(s)...`);
+      console.error(`DeclaRenta v${pkg.version} - Ejercicio ${opts.year}, ${opts.input.length} fichero(s)...`);
 
       // 1. Parse all IBKR XMLs and merge into a single statement
       const merged: FlexStatement = {


### PR DESCRIPTION
## Summary
- **auto-tag.yml**: On every push to `main`, bumps patch version (e.g., v0.2.0 → v0.2.1), syncs `package.json`, creates git tag
- **release.yml**: On tag push, generates changelog from conventional commits and creates GitHub Release via `softprops/action-gh-release`
- **CLI reads version from `package.json`** — single source of truth, no more hardcoded version strings

Follows the same pattern as Pumperly and CashPilot.

## Required setup
- Add `PAT` repository secret (same token as Pumperly) for auto-tag to push commits and tags

## How it works
1. PR merged → push to `main`
2. `auto-tag.yml` runs → creates `vX.Y.Z` tag + bumps `package.json` with `[skip ci]`
3. Tag push triggers `release.yml` → creates GitHub Release with auto-generated changelog
4. Minor/major bumps: manually set `package.json` version before merge — auto-tag picks up from latest tag

## Test plan
- [ ] Verify CI passes (build, lint, tests)
- [ ] Add PAT secret to repo
- [ ] After merge, confirm auto-tag creates v0.2.1 tag
- [ ] Confirm release.yml creates GitHub Release with changelog