### PR TITLE
feat: web UI dark/light mode, sortable tables, responsive + 720 A/M/C + PDF ECB rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Se pueden combinar ficheros de varios brokers en una sola ejecución para FIFO c
 
 | Modelo | Descripción | Formato |
 |---|---|---|
-| **Modelo 100** (IRPF) | Casillas 0327, 0328, 0029, 0032, 0033, 0588 | JSON, CSV, PDF |
-| **Modelo 720** | Declaración de bienes en el extranjero (>50.000 EUR) | Fixed-width AEAT |
+| **Modelo 100** (IRPF) | Casillas 0327, 0328, 0029, 0032, 0033, 0588 | JSON, CSV, PDF (con tipos ECB) |
+| **Modelo 720** | Declaración de bienes en el extranjero (>50.000 EUR), tipos A/M/C | Fixed-width AEAT |
 | **Modelo D-6** | Inversiones en el exterior (Banco de España / AFORIX) | Guía paso a paso |
 
 ## Casillas del Modelo 100
@@ -100,6 +100,9 @@ declarenta convert --input flex_query.xml --year 2025 --prior-losses perdidas.js
 
 # Modelo 720
 declarenta modelo720 --input flex_query.xml --year 2025 --nif 12345678A --name "APELLIDOS, NOMBRE"
+
+# Modelo 720 con tipos A/M/C (comparando con declaración del año anterior)
+declarenta modelo720 --input flex_query.xml --year 2025 --nif 12345678A --name "APELLIDOS, NOMBRE" --previous-720 720_2024.txt
 
 # Modelo D-6 (guía AFORIX)
 declarenta d6 --input flex_query.xml --year 2025 --nif 12345678A --name "APELLIDOS, NOMBRE"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -68,7 +68,7 @@ DeclaRenta se alinea con el calendario tributario español. Cada release se plan
 | Web UI: responsive (tablet, móvil, móvil pequeño) | Implementado | `src/web/` |
 | Interfaz `BrokerParser` + registry auto-detección (5 brokers) | Implementado | `src/types/broker.ts`, `src/parsers/index.ts` |
 | FIFO cross-broker (orden cronológico global) | Implementado | `src/cli/index.ts`, `src/web/main.ts` |
-| 183 tests | Passing | `tests/` |
+| 228 tests | Passing | `tests/` |
 | CI/CD GitHub Actions | Configurado | `.github/workflows/` |
 
 ### v0.1.0 completado

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,10 +63,12 @@ DeclaRenta se alinea con el calendario tributario español. Cada release se plan
 | Generador informe PDF | Implementado | `src/generators/pdf.ts` |
 | Mapeo a casillas Modelo 100 | Implementado | `src/generators/report.ts` |
 | CLI (`convert`, `modelo720`, `d6`, `modelo721`) | Implementado | `src/cli/index.ts` |
-| Web UI: selector broker, tabla operaciones, filtros, búsqueda | Implementado | `src/web/` |
+| Web UI: selector broker, tabla operaciones, filtros, búsqueda, ordenación | Implementado | `src/web/` |
+| Web UI: modo oscuro/claro con detección de preferencia del sistema | Implementado | `src/web/` |
+| Web UI: responsive (tablet, móvil, móvil pequeño) | Implementado | `src/web/` |
 | Interfaz `BrokerParser` + registry auto-detección (5 brokers) | Implementado | `src/types/broker.ts`, `src/parsers/index.ts` |
 | FIFO cross-broker (orden cronológico global) | Implementado | `src/cli/index.ts`, `src/web/main.ts` |
-| 170 tests | Passing | `tests/` |
+| 183 tests | Passing | `tests/` |
 | CI/CD GitHub Actions | Configurado | `.github/workflows/` |
 
 ### v0.1.0 completado
@@ -233,7 +235,7 @@ Tareas:
 #### Modelo 720 — mejoras
 
 - [ ] Detección automática de umbral 50.000 € por categoría (valores, cuentas, inmuebles)
-- [ ] Tipo de declaración: A (alta), M (mantenimiento), C (cancelación)
+- [x] Tipo de declaración: A (alta), M (mantenimiento), C (cancelación)
 - [x] Primera fecha de adquisición por posición (desde lotes FIFO)
 - [ ] Valoración correcta según Ley del Impuesto sobre el Patrimonio:
   - Acciones cotizadas: media del último trimestre (no cierre 31/dic)
@@ -260,7 +262,7 @@ Tareas:
 
 - [x] Informe PDF descargable: resumen ejecutivo + detalle por operación (pdfkit)
 - [x] Formato orientado a llevar al asesor fiscal o adjuntar a la declaración
-- [ ] Incluir tipo ECB utilizado en cada operación para auditoría
+- [x] Incluir tipo ECB utilizado en cada operación para auditoría
 
 - [ ] Publicar **v0.5.0**
 
@@ -273,16 +275,16 @@ Tareas:
 > **Objetivo**: experiencia web de calidad que elimine cualquier barrera de entrada. Zero-server.
 
 - [ ] **Wizard multi-paso**: elige broker(s) → sube fichero(s) → revisa datos → configura (NIF, año) → genera resultados → descarga
-- [ ] **Tabla interactiva de operaciones**: ordenación, filtros por ISIN/fecha/tipo, búsqueda
+- [x] **Tabla interactiva de operaciones**: ordenación, filtros por ISIN/fecha/tipo, búsqueda
 - [ ] **Vista por casillas**: cada casilla expandible con desglose de las operaciones que la componen
 - [ ] **Gráficos**: distribución por tipo de activo, G/P por mes, composición por divisa, retenciones por país
 - [ ] **Comparador año a año**: si el usuario procesa múltiples años
-- [ ] **Modo oscuro/claro** con detección de preferencia del sistema
+- [x] **Modo oscuro/claro** con detección de preferencia del sistema
 - [ ] **PWA**: funciona offline una vez cargada (Service Worker)
 - [ ] **Accesibilidad WCAG 2.1 AA**: navegación por teclado, screen reader, contraste
 - [ ] **i18n**: castellano (default), catalán, euskera, gallego, inglés
 - [ ] **Deploy GitHub Pages**: coste cero de hosting, dominio custom `declarenta.es`
-- [ ] **Responsive**: móvil, tablet, desktop
+- [x] **Responsive**: móvil, tablet, desktop
 - [ ] Publicar **v0.8.0**
 
 **Criterio de éxito**: un usuario sin experiencia técnica puede generar su informe en <3 minutos desde la web.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -236,7 +236,8 @@ program
   .requiredOption("--name <name>", "Nombre completo (Apellidos, Nombre)")
   .option("-o, --output <file>", "Output file. Defaults to stdout")
   .option("--phone <phone>", "Teléfono de contacto", "")
-  .action(async (opts: { input: string; year: number; nif: string; name: string; output?: string; phone: string }) => {
+  .option("--previous-720 <file>", "Previous year 720 output file (to determine A/M/C types)")
+  .action(async (opts: { input: string; year: number; nif: string; name: string; output?: string; phone: string; previous720?: string }) => {
     try {
       const content = readFileSync(opts.input, "utf-8");
       const parser = detectBroker(content);
@@ -255,6 +256,16 @@ program
       const surname = nameParts[0] ?? "";
       const firstName = nameParts[1] ?? "";
 
+      // Extract ISINs from previous year's 720 file (detail records start with "2", ISIN at positions 131-142)
+      let previousYearIsins: string[] | undefined;
+      if (opts.previous720) {
+        const prev = readFileSync(opts.previous720, "utf-8");
+        previousYearIsins = prev.split("\n")
+          .filter((line) => line.startsWith("2"))
+          .map((line) => line.slice(131, 143).trim())
+          .filter((isin) => isin.length > 0);
+      }
+
       const output720 = generateModelo720(statement.openPositions, rateMap, {
         nif: opts.nif,
         surname,
@@ -265,6 +276,7 @@ program
         declarationId: "0000000000001",
         isComplementary: false,
         isReplacement: false,
+        previousYearIsins,
       });
 
       if (!output720) {

--- a/src/engine/fifo.ts
+++ b/src/engine/fifo.ts
@@ -359,6 +359,7 @@ export class FifoEngine {
         currency: trade.currency,
         sellEcbRate: ecbRate,
         acquireEcbRate: ecbRate,
+        assetCategory: trade.assetCategory,
         washSaleBlocked: false,
       });
       return;
@@ -401,6 +402,7 @@ export class FifoEngine {
         currency: trade.currency,
         sellEcbRate: ecbRate,
         acquireEcbRate: lot.ecbRate,
+        assetCategory: trade.assetCategory,
         washSaleBlocked: false, // Set later by wash sale detection
       });
 
@@ -437,6 +439,7 @@ export class FifoEngine {
         currency: trade.currency,
         sellEcbRate: ecbRate,
         acquireEcbRate: ecbRate,
+        assetCategory: trade.assetCategory,
         washSaleBlocked: false,
       });
     }

--- a/src/engine/wash-sale.ts
+++ b/src/engine/wash-sale.ts
@@ -47,6 +47,11 @@ export function detectWashSales(disposals: FifoDisposal[], allTrades: Trade[]): 
       return disposal;
     }
 
+    // Anti-churning does NOT apply to options (CALL/PUT)
+    if (disposal.assetCategory === "OPT") {
+      return disposal;
+    }
+
     const sellDate = parseDate(disposal.sellDate);
     const windowStart = addMonths(sellDate, -2);
     const windowEnd = addMonths(sellDate, 2);

--- a/src/generators/modelo720.ts
+++ b/src/generators/modelo720.ts
@@ -22,6 +22,8 @@ interface Modelo720Config {
   isComplementary: boolean;
   isReplacement: boolean;
   previousDeclarationId?: string;
+  /** ISINs declared in the previous year's 720 — used to determine A/M/C declaration types */
+  previousYearIsins?: string[];
 }
 
 /**
@@ -41,9 +43,11 @@ export function generateModelo720(
   /** Optional: remaining lots from FIFO engine, used to extract first acquisition date */
   remainingLots?: Map<string, Lot[]>,
 ): string {
-  // Filter to stocks/funds and calculate EUR values
+  const previousIsins = new Set(config.previousYearIsins ?? []);
+
+  // Filter to stocks/funds/bonds and calculate EUR values
   const entries = positions
-    .filter((p) => p.assetCategory === "STK" || p.assetCategory === "FUND")
+    .filter((p) => p.assetCategory === "STK" || p.assetCategory === "FUND" || p.assetCategory === "BOND")
     .map((p) => {
       const yearEnd = `${config.year}-12-31`;
       const ecbRate = getEcbRate(rateMap, yearEnd, p.currency);
@@ -61,19 +65,35 @@ export function generateModelo720(
         }
       }
 
-      return { position: p, valueEur, costEur, firstAcquisitionDate };
+      // Declaration type: A (new), M (existing), C (cancelled/sold)
+      const declType: "A" | "M" | "C" = previousIsins.has(p.isin) ? "M" : "A";
+
+      return { position: p, valueEur, costEur, firstAcquisitionDate, declType };
     });
 
-  // Check 50,000 EUR threshold for values category
+  // Build "C" (cancelled) records for ISINs in previous year but not in current positions
+  const currentIsins = new Set(entries.map((e) => e.position.isin));
+  const cancelledIsins = [...previousIsins].filter((isin) => !currentIsins.has(isin));
+  const cancelledEntries = cancelledIsins.map((isin) => ({
+    isin,
+    declType: "C" as const,
+  }));
+
+  // Check 50,000 EUR threshold for values category (only current positions count)
   const totalValue = entries.reduce((s, e) => s.plus(e.valueEur), new Decimal(0));
-  if (totalValue.lessThan(50000)) {
-    return ""; // Below threshold, no declaration needed
+  if (totalValue.lessThan(50000) && cancelledEntries.length === 0) {
+    return ""; // Below threshold and no cancellations needed
   }
 
   // Build records
   const detailRecords = entries.map((e) =>
-    buildDetailRecord(e.position, e.valueEur, e.costEur, config, e.firstAcquisitionDate),
+    buildDetailRecord(e.position, e.valueEur, e.costEur, config, e.firstAcquisitionDate, e.declType),
   );
+
+  // Add cancelled records
+  for (const c of cancelledEntries) {
+    detailRecords.push(buildCancelledRecord(c.isin, config));
+  }
 
   const summaryRecord = buildSummaryRecord(config, detailRecords.length, entries);
 
@@ -131,6 +151,7 @@ function buildDetailRecord(
   costEur: Decimal,
   config: Modelo720Config,
   firstAcquisitionDate?: string,
+  declType: "A" | "M" | "C" = "M",
 ): string {
   // Extract country code from ISIN prefix (first 2 characters)
   const countryCode = pos.isin.length >= 2 ? pos.isin.slice(0, 2).toUpperCase() : "  ";
@@ -154,7 +175,7 @@ function buildDetailRecord(
   record += pad(pos.description, 41);                         // 190-230: Entity name
   record += pad("", 184);                                     // 231-414: Reserved
   record += pad((firstAcquisitionDate ?? "").replace(/-/g, "").slice(0, 8), 8); // 415-422: First acquisition date (YYYYMMDD)
-  record += "M";                                              // 423: Type (M=existing)
+  record += declType;                                         // 423: Type (A=new, M=existing, C=cancelled)
   record += pad("", 8);                                       // 424-431: Sell date
   record += (costEur.isNegative() ? "N" : " ");               // 432: Acquisition sign
   record += numPad(costEur.toString(), 13, 2);                // 433-447: Acquisition value
@@ -162,6 +183,48 @@ function buildDetailRecord(
   record += numPad(valueEur.toString(), 13, 2);               // 449-462: Valuation value
   record += "A";                                              // 463: Stock representation
   record += numPad(new Decimal(pos.quantity).abs().toString(), 9, 3); // 464-475: Quantity
+  record += pad("", 1);                                       // 476: Reserved
+  record += numPad("100", 3, 2);                              // 477-481: Ownership %
+  record += pad("", 18);                                      // 483-500: Blank
+
+  return record;
+}
+
+/**
+ * Build a "C" (cancelled) detail record for an ISIN that was declared
+ * in the previous year but no longer held.
+ */
+function buildCancelledRecord(isin: string, config: Modelo720Config): string {
+  const countryCode = isin.length >= 2 ? isin.slice(0, 2).toUpperCase() : "  ";
+  const yearEnd = `${config.year}1231`;
+
+  let record = "";
+  record += "2";                                              // 1: Register type
+  record += "720";                                            // 2-4: Model
+  record += config.year.toString();                           // 5-8: Year
+  record += pad(config.nif, 9, " ", true);                    // 9-17: NIF
+  record += pad(config.nif, 9, " ", true);                    // 18-26: Declared NIF
+  record += pad("", 9);                                       // 27-35: Proxy NIF
+  record += pad("", 40);                                      // 36-75: Name (unknown for cancelled)
+  record += "1";                                              // 76: Declaration type (owner)
+  record += pad("", 25);                                      // 77-101: Reserved
+  record += "V";                                              // 102: Asset type (stocks)
+  record += pad("", 26);                                      // 103-128: Reserved
+  record += pad(countryCode, 2);                              // 129-130: Country code
+  record += "1";                                              // 131: ID type (ISIN)
+  record += pad(isin, 12);                                    // 132-143: ISIN
+  record += pad("", 46);                                      // 144-189: Reserved
+  record += pad("", 41);                                      // 190-230: Entity name
+  record += pad("", 184);                                     // 231-414: Reserved
+  record += pad("", 8);                                       // 415-422: First acquisition date
+  record += "C";                                              // 423: Type (C=cancelled)
+  record += pad(yearEnd, 8);                                  // 424-431: Sell/cancellation date
+  record += " ";                                              // 432: Acquisition sign
+  record += numPad("0", 13, 2);                               // 433-447: Acquisition value (0)
+  record += " ";                                              // 448: Valuation sign
+  record += numPad("0", 13, 2);                               // 449-462: Valuation value (0)
+  record += "A";                                              // 463: Stock representation
+  record += numPad("0", 9, 3);                                // 464-475: Quantity (0)
   record += pad("", 1);                                       // 476: Reserved
   record += numPad("100", 3, 2);                              // 477-481: Ownership %
   record += pad("", 18);                                      // 483-500: Blank

--- a/src/generators/modelo720.ts
+++ b/src/generators/modelo720.ts
@@ -180,11 +180,11 @@ function buildDetailRecord(
   record += (costEur.isNegative() ? "N" : " ");               // 432: Acquisition sign
   record += numPad(costEur.toString(), 13, 2);                // 433-447: Acquisition value
   record += (valueEur.isNegative() ? "N" : " ");              // 448: Valuation sign
-  record += numPad(valueEur.toString(), 13, 2);               // 449-462: Valuation value
-  record += "A";                                              // 463: Stock representation
-  record += numPad(new Decimal(pos.quantity).abs().toString(), 9, 3); // 464-475: Quantity
-  record += pad("", 1);                                       // 476: Reserved
-  record += numPad("100", 3, 2);                              // 477-481: Ownership %
+  record += numPad(valueEur.toString(), 13, 2);               // 449-463: Valuation value
+  record += "A";                                              // 464: Stock representation
+  record += numPad(new Decimal(pos.quantity).abs().toString(), 9, 3); // 465-476: Quantity
+  record += pad("", 1);                                       // 477: Reserved
+  record += numPad("100", 3, 2);                              // 478-482: Ownership %
   record += pad("", 18);                                      // 483-500: Blank
 
   return record;
@@ -222,11 +222,11 @@ function buildCancelledRecord(isin: string, config: Modelo720Config): string {
   record += " ";                                              // 432: Acquisition sign
   record += numPad("0", 13, 2);                               // 433-447: Acquisition value (0)
   record += " ";                                              // 448: Valuation sign
-  record += numPad("0", 13, 2);                               // 449-462: Valuation value (0)
-  record += "A";                                              // 463: Stock representation
-  record += numPad("0", 9, 3);                                // 464-475: Quantity (0)
-  record += pad("", 1);                                       // 476: Reserved
-  record += numPad("100", 3, 2);                              // 477-481: Ownership %
+  record += numPad("0", 13, 2);                               // 449-463: Valuation value (0)
+  record += "A";                                              // 464: Stock representation
+  record += numPad("0", 9, 3);                                // 465-476: Quantity (0)
+  record += pad("", 1);                                       // 477: Reserved
+  record += numPad("100", 3, 2);                              // 478-482: Ownership %
   record += pad("", 18);                                      // 483-500: Blank
 
   return record;

--- a/src/generators/pdf.ts
+++ b/src/generators/pdf.ts
@@ -144,15 +144,15 @@ export function generatePdfReport(report: TaxSummary): Promise<Buffer> {
           .fill(COLORS.primary);
 
         const cols = [
-          { label: "ISIN", x: MARGIN + 4, w: 72 },
-          { label: "Símbolo", x: MARGIN + 80, w: 50 },
-          { label: "F. Compra", x: MARGIN + 134, w: 54 },
-          { label: "F. Venta", x: MARGIN + 192, w: 54 },
-          { label: "Uds.", x: MARGIN + 250, w: 30 },
-          { label: "Coste EUR", x: MARGIN + 284, w: 58 },
-          { label: "Venta EUR", x: MARGIN + 346, w: 58 },
-          { label: "G/P EUR", x: MARGIN + 408, w: 50 },
-          { label: "Tipo ECB", x: MARGIN + 462, w: 46 },
+          { label: "ISIN", x: MARGIN + 4, w: 68 },
+          { label: "Símbolo", x: MARGIN + 76, w: 46 },
+          { label: "F. Compra", x: MARGIN + 126, w: 52 },
+          { label: "F. Venta", x: MARGIN + 182, w: 52 },
+          { label: "Uds.", x: MARGIN + 238, w: 28 },
+          { label: "Coste EUR", x: MARGIN + 270, w: 56 },
+          { label: "Venta EUR", x: MARGIN + 330, w: 56 },
+          { label: "G/P EUR", x: MARGIN + 390, w: 48 },
+          { label: "Tipo ECB", x: MARGIN + 442, w: 48 },
         ];
 
         doc.fontSize(FONT_SIZE.small).fillColor("#ffffff");

--- a/src/generators/pdf.ts
+++ b/src/generators/pdf.ts
@@ -144,14 +144,15 @@ export function generatePdfReport(report: TaxSummary): Promise<Buffer> {
           .fill(COLORS.primary);
 
         const cols = [
-          { label: "ISIN", x: MARGIN + 4, w: 80 },
-          { label: "Símbolo", x: MARGIN + 88, w: 60 },
-          { label: "F. Compra", x: MARGIN + 152, w: 58 },
-          { label: "F. Venta", x: MARGIN + 214, w: 58 },
-          { label: "Uds.", x: MARGIN + 276, w: 35 },
-          { label: "Coste EUR", x: MARGIN + 315, w: 65 },
-          { label: "Venta EUR", x: MARGIN + 384, w: 65 },
-          { label: "G/P EUR", x: MARGIN + 453, w: 55 },
+          { label: "ISIN", x: MARGIN + 4, w: 72 },
+          { label: "Símbolo", x: MARGIN + 80, w: 50 },
+          { label: "F. Compra", x: MARGIN + 134, w: 54 },
+          { label: "F. Venta", x: MARGIN + 192, w: 54 },
+          { label: "Uds.", x: MARGIN + 250, w: 30 },
+          { label: "Coste EUR", x: MARGIN + 284, w: 58 },
+          { label: "Venta EUR", x: MARGIN + 346, w: 58 },
+          { label: "G/P EUR", x: MARGIN + 408, w: 50 },
+          { label: "Tipo ECB", x: MARGIN + 462, w: 46 },
         ];
 
         doc.fontSize(FONT_SIZE.small).fillColor("#ffffff");
@@ -183,6 +184,7 @@ export function generatePdfReport(report: TaxSummary): Promise<Buffer> {
           doc.text(d.costBasisEur.toFixed(2), cols[5]!.x, rowY + 2, { width: cols[5]!.w });
           doc.text(d.proceedsEur.toFixed(2), cols[6]!.x, rowY + 2, { width: cols[6]!.w });
           doc.fillColor(glColor).text(gainLoss.toFixed(2), cols[7]!.x, rowY + 2, { width: cols[7]!.w });
+          doc.fillColor(COLORS.muted).text(d.sellEcbRate.toFixed(4), cols[8]!.x, rowY + 2, { width: cols[8]!.w });
 
           doc.y = rowY + 14;
           checkPageBreak(doc);
@@ -204,7 +206,7 @@ export function generatePdfReport(report: TaxSummary): Promise<Buffer> {
         for (const d of report.dividends.entries.slice(0, 30)) {
           doc.fontSize(FONT_SIZE.small).fillColor(COLORS.text)
             .text(
-              `${formatDate(d.payDate)}  ${d.symbol.padEnd(12)}  ${d.isin}  Bruto: ${d.grossAmountEur.toFixed(2)} EUR  Retención: ${d.withholdingTaxEur.toFixed(2)} EUR  (${d.withholdingCountry})`,
+              `${formatDate(d.payDate)}  ${d.symbol.padEnd(12)}  ${d.isin}  Bruto: ${d.grossAmountEur.toFixed(2)} EUR  Retención: ${d.withholdingTaxEur.toFixed(2)} EUR  (${d.withholdingCountry})  ECB: ${d.ecbRate.toFixed(4)}`,
               MARGIN,
             );
           doc.moveDown(0.2);
@@ -239,6 +241,15 @@ export function generatePdfReport(report: TaxSummary): Promise<Buffer> {
           doc.moveDown(0.2);
         }
       }
+
+      // --- ECB footnote ---
+      checkPageBreak(doc);
+      doc.moveDown(0.5);
+      doc.fontSize(FONT_SIZE.small).fillColor(COLORS.muted)
+        .text(
+          "Tipo ECB: tipo de cambio oficial del Banco Central Europeo (EUR por 1 unidad de divisa extranjera) en la fecha de la operación. Fuente: ECB SDMX API.",
+          MARGIN,
+        );
 
       // --- Footer ---
       doc.fontSize(FONT_SIZE.small).fillColor(COLORS.muted)

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -36,6 +36,8 @@ export interface FifoDisposal {
   sellEcbRate: Decimal;
   /** ECB rate (EUR per 1 FCY) used for the acquisition */
   acquireEcbRate: Decimal;
+  /** Asset category (STK, OPT, FUND, etc.) */
+  assetCategory: string;
   /** True if loss is blocked by the anti-churning rule (Art. 33.5.f LIRPF) */
   washSaleBlocked: boolean;
 }

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -4,15 +4,16 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>DeclaRenta - Broker extranjero → Renta española</title>
-  <meta name="description" content="Convierte reportes de IBKR, Degiro, Scalable Capital, eToro y Freedom24 en valores para tu declaración de la renta española. 100% en tu navegador, tus datos nunca salen de tu ordenador." />
+  <meta name="description" content="Convierte reportes de IBKR, Degiro, Scalable Capital, eToro y Freedom24 en valores para tu declaración de la renta española. Self-hosted, privacidad total." />
   <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
+  <button class="theme-toggle" id="theme-toggle" title="Cambiar tema" aria-label="Cambiar tema"></button>
   <main id="app">
     <header>
       <h1>DeclaRenta</h1>
       <p>Broker extranjero → Renta española</p>
-      <p class="privacy">Tus datos se procesan 100% en tu navegador. Nada se sube a ningún servidor.</p>
+      <p class="privacy">Self-hosted. Tus datos no salen de tu equipo.</p>
     </header>
 
     <section id="upload">
@@ -79,8 +80,7 @@
   <footer>
     <p>
       <a href="https://github.com/GeiserX/DeclaRenta">GitHub</a> ·
-      GPL-3.0 ·
-      <strong>Tus datos nunca salen de tu navegador</strong>
+      <strong>Self-hosted · Privacidad total</strong>
     </p>
   </footer>
 

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -11,8 +11,8 @@
   <button class="theme-toggle" id="theme-toggle" title="Cambiar tema" aria-label="Cambiar tema"></button>
   <main id="app">
     <header>
-      <h1>DeclaRenta</h1>
-      <p>Broker extranjero → Renta española</p>
+      <h1>Decla<span class="brand-accent">Renta</span></h1>
+      <p class="subtitle">Broker extranjero → Renta española</p>
       <p class="privacy">Self-hosted. Tus datos no salen de tu equipo.</p>
     </header>
 
@@ -32,6 +32,7 @@
         </label>
       </div>
       <div id="drop-zone">
+        <div class="drop-icon">&#8683;</div>
         <p>Arrastra tu fichero aquí o haz clic para seleccionar</p>
         <input type="file" id="file-input" accept=".xml,.csv,.json,.xlsx,.xls" multiple />
       </div>
@@ -81,6 +82,10 @@
     <p>
       <a href="https://github.com/GeiserX/DeclaRenta">GitHub</a> ·
       <strong>Self-hosted · Privacidad total</strong>
+    </p>
+    <p class="credits">
+      Made with <span class="heart">&#9829;</span> by <a href="https://geiser.cloud">Sergio Fernández</a>
+      · <a href="https://github.com/sponsors/GeiserX" class="sponsor-link">Sponsor</a>
     </p>
   </footer>
 

--- a/src/web/main.ts
+++ b/src/web/main.ts
@@ -16,6 +16,36 @@ import Decimal from "decimal.js";
 
 Decimal.set({ precision: 20, rounding: Decimal.ROUND_HALF_UP });
 
+// ---------------------------------------------------------------------------
+// Theme toggle (auto / light / dark)
+// ---------------------------------------------------------------------------
+
+type ThemeMode = "auto" | "light" | "dark";
+
+const THEME_ICONS: Record<ThemeMode, string> = { auto: "\u25D1", light: "\u2600", dark: "\u263E" };
+const THEME_CYCLE: ThemeMode[] = ["auto", "light", "dark"];
+
+function applyTheme(mode: ThemeMode) {
+  const root = document.documentElement;
+  if (mode === "auto") {
+    root.removeAttribute("data-theme");
+  } else {
+    root.setAttribute("data-theme", mode);
+  }
+  const btn = document.getElementById("theme-toggle");
+  if (btn) btn.textContent = THEME_ICONS[mode];
+}
+
+const savedTheme = (localStorage.getItem("theme") as ThemeMode | null) ?? "auto";
+applyTheme(savedTheme);
+
+document.getElementById("theme-toggle")?.addEventListener("click", () => {
+  const current = (localStorage.getItem("theme") as ThemeMode | null) ?? "auto";
+  const next = THEME_CYCLE[(THEME_CYCLE.indexOf(current) + 1) % THEME_CYCLE.length]!;
+  localStorage.setItem("theme", next);
+  applyTheme(next);
+});
+
 /** Escape HTML to prevent XSS from user-derived content */
 function esc(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
@@ -219,6 +249,34 @@ function downloadBlob(blob: Blob, filename: string) {
 }
 
 // ---------------------------------------------------------------------------
+// Sort state
+// ---------------------------------------------------------------------------
+
+type SortDir = "asc" | "desc" | null;
+interface SortState { col: string; dir: SortDir }
+
+let opsSort: SortState = { col: "", dir: null };
+let divSort: SortState = { col: "", dir: null };
+
+function nextDir(current: SortDir): SortDir {
+  if (current === null) return "asc";
+  if (current === "asc") return "desc";
+  return null;
+}
+
+function attachSortHandlers(tableEl: HTMLElement, state: { get: () => SortState; set: (s: SortState) => void }, render: () => void) {
+  tableEl.querySelectorAll("th.sortable").forEach((th) => {
+    th.addEventListener("click", () => {
+      const col = (th as HTMLElement).dataset.col!;
+      const cur = state.get();
+      const dir = cur.col === col ? nextDir(cur.dir) : "asc";
+      state.set({ col: dir ? col : "", dir });
+      render();
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Search and filter
 // ---------------------------------------------------------------------------
 
@@ -259,12 +317,16 @@ function renderResults(report: ReturnType<typeof generateTaxReport>) {
   renderDividendsTable(report);
 }
 
+function sortIndicator(col: string, state: SortState): string {
+  return state.col === col ? ` ${state.dir}` : "";
+}
+
 function renderOperationsTable() {
   if (!currentReport) return;
   const search = opsSearch.value.toLowerCase();
   const filter = opsFilter.value;
 
-  let disposals = currentReport.capitalGains.disposals;
+  let disposals = [...currentReport.capitalGains.disposals];
 
   if (search) {
     disposals = disposals.filter(
@@ -277,19 +339,41 @@ function renderOperationsTable() {
     disposals = disposals.filter((d) => d.gainLossEur.lessThan(0));
   }
 
+  // Apply sort
+  if (opsSort.dir && opsSort.col) {
+    const dir = opsSort.dir === "asc" ? 1 : -1;
+    const col = opsSort.col;
+    disposals.sort((a, b) => {
+      let cmp = 0;
+      if (col === "isin") cmp = a.isin.localeCompare(b.isin);
+      else if (col === "symbol") cmp = a.symbol.localeCompare(b.symbol);
+      else if (col === "buyDate") cmp = a.acquireDate.localeCompare(b.acquireDate);
+      else if (col === "sellDate") cmp = a.sellDate.localeCompare(b.sellDate);
+      else if (col === "qty") cmp = a.quantity.minus(b.quantity).toNumber();
+      else if (col === "cost") cmp = a.costBasisEur.minus(b.costBasisEur).toNumber();
+      else if (col === "proceeds") cmp = a.proceedsEur.minus(b.proceedsEur).toNumber();
+      else if (col === "gl") cmp = a.gainLossEur.minus(b.gainLossEur).toNumber();
+      else if (col === "days") cmp = a.holdingPeriodDays - b.holdingPeriodDays;
+      return cmp * dir;
+    });
+  }
+
+  const th = (label: string, col: string) =>
+    `<th class="sortable${sortIndicator(col, opsSort)}" data-col="${col}">${label}</th>`;
+
   opsTable.innerHTML = `
-    <table class="sortable">
+    <table>
       <thead>
         <tr>
-          <th>ISIN</th>
-          <th>Símbolo</th>
-          <th>F. Compra</th>
-          <th>F. Venta</th>
-          <th>Uds.</th>
-          <th>Coste EUR</th>
-          <th>Venta EUR</th>
-          <th>G/P EUR</th>
-          <th>Días</th>
+          ${th("ISIN", "isin")}
+          ${th("Símbolo", "symbol")}
+          ${th("F. Compra", "buyDate")}
+          ${th("F. Venta", "sellDate")}
+          ${th("Uds.", "qty")}
+          ${th("Coste EUR", "cost")}
+          ${th("Venta EUR", "proceeds")}
+          ${th("G/P EUR", "gl")}
+          ${th("Días", "days")}
         </tr>
       </thead>
       <tbody>
@@ -310,6 +394,12 @@ function renderOperationsTable() {
     </table>
     <p class="table-count">${disposals.length} operación(es)</p>
   `;
+
+  attachSortHandlers(
+    opsTable,
+    { get: () => opsSort, set: (s) => { opsSort = s; } },
+    renderOperationsTable,
+  );
 }
 
 function renderDividendsTable(report: ReturnType<typeof generateTaxReport>) {
@@ -318,20 +408,40 @@ function renderDividendsTable(report: ReturnType<typeof generateTaxReport>) {
     return;
   }
 
+  const entries = [...report.dividends.entries];
+
+  if (divSort.dir && divSort.col) {
+    const dir = divSort.dir === "asc" ? 1 : -1;
+    const col = divSort.col;
+    entries.sort((a, b) => {
+      let cmp = 0;
+      if (col === "isin") cmp = a.isin.localeCompare(b.isin);
+      else if (col === "symbol") cmp = a.symbol.localeCompare(b.symbol);
+      else if (col === "date") cmp = a.payDate.localeCompare(b.payDate);
+      else if (col === "gross") cmp = a.grossAmountEur.minus(b.grossAmountEur).toNumber();
+      else if (col === "wht") cmp = a.withholdingTaxEur.minus(b.withholdingTaxEur).toNumber();
+      else if (col === "country") cmp = a.withholdingCountry.localeCompare(b.withholdingCountry);
+      return cmp * dir;
+    });
+  }
+
+  const th = (label: string, col: string) =>
+    `<th class="sortable${sortIndicator(col, divSort)}" data-col="${col}">${label}</th>`;
+
   divsTable.innerHTML = `
     <table>
       <thead>
         <tr>
-          <th>ISIN</th>
-          <th>Símbolo</th>
-          <th>Fecha</th>
-          <th>Bruto EUR</th>
-          <th>Retención EUR</th>
-          <th>País</th>
+          ${th("ISIN", "isin")}
+          ${th("Símbolo", "symbol")}
+          ${th("Fecha", "date")}
+          ${th("Bruto EUR", "gross")}
+          ${th("Retención EUR", "wht")}
+          ${th("País", "country")}
         </tr>
       </thead>
       <tbody>
-        ${report.dividends.entries.map((d) => `
+        ${entries.map((d) => `
           <tr>
             <td class="mono">${esc(d.isin)}</td>
             <td>${esc(d.symbol)}</td>
@@ -343,6 +453,12 @@ function renderDividendsTable(report: ReturnType<typeof generateTaxReport>) {
         `).join("")}
       </tbody>
     </table>
-    <p class="table-count">${report.dividends.entries.length} dividendo(s)</p>
+    <p class="table-count">${entries.length} dividendo(s)</p>
   `;
+
+  attachSortHandlers(
+    divsTable,
+    { get: () => divSort, set: (s) => { divSort = s; } },
+    () => renderDividendsTable(report),
+  );
 }

--- a/src/web/main.ts
+++ b/src/web/main.ts
@@ -264,17 +264,24 @@ function nextDir(current: SortDir): SortDir {
   return null;
 }
 
-function attachSortHandlers(tableEl: HTMLElement, state: { get: () => SortState; set: (s: SortState) => void }, render: () => void) {
-  tableEl.querySelectorAll("th.sortable").forEach((th) => {
-    th.addEventListener("click", () => {
-      const col = (th as HTMLElement).dataset.col!;
-      const cur = state.get();
-      const dir = cur.col === col ? nextDir(cur.dir) : "asc";
-      state.set({ col: dir ? col : "", dir });
-      render();
-    });
-  });
-}
+// Event delegation: attach once on stable parent, works across re-renders
+opsTable.addEventListener("click", (e) => {
+  const th = (e.target as HTMLElement).closest<HTMLElement>("th.sortable");
+  if (!th) return;
+  const col = th.dataset.col!;
+  const dir = opsSort.col === col ? nextDir(opsSort.dir) : "asc";
+  opsSort = { col: dir ? col : "", dir };
+  renderOperationsTable();
+});
+
+divsTable.addEventListener("click", (e) => {
+  const th = (e.target as HTMLElement).closest<HTMLElement>("th.sortable");
+  if (!th) return;
+  const col = th.dataset.col!;
+  const dir = divSort.col === col ? nextDir(divSort.dir) : "asc";
+  divSort = { col: dir ? col : "", dir };
+  if (currentReport) renderDividendsTable(currentReport);
+});
 
 // ---------------------------------------------------------------------------
 // Search and filter
@@ -395,11 +402,6 @@ function renderOperationsTable() {
     <p class="table-count">${disposals.length} operación(es)</p>
   `;
 
-  attachSortHandlers(
-    opsTable,
-    { get: () => opsSort, set: (s) => { opsSort = s; } },
-    renderOperationsTable,
-  );
 }
 
 function renderDividendsTable(report: ReturnType<typeof generateTaxReport>) {
@@ -456,9 +458,4 @@ function renderDividendsTable(report: ReturnType<typeof generateTaxReport>) {
     <p class="table-count">${entries.length} dividendo(s)</p>
   `;
 
-  attachSortHandlers(
-    divsTable,
-    { get: () => divSort, set: (s) => { divSort = s; } },
-    () => renderDividendsTable(report),
-  );
 }

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -519,10 +519,6 @@ footer a:hover {
     width: 100%;
   }
 
-  .export-buttons button {
-    width: 100%;
-  }
-
   th.sortable {
     padding-right: 1rem;
   }

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -118,9 +118,21 @@ header {
 }
 
 header h1 {
-  font-size: 2.5rem;
-  font-weight: 700;
-  letter-spacing: -0.02em;
+  font-size: 2.75rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  line-height: 1.1;
+}
+
+.brand-accent {
+  color: var(--accent);
+}
+
+header .subtitle {
+  color: var(--muted);
+  margin-top: 0.5rem;
+  font-size: 1.05rem;
+  letter-spacing: 0.01em;
 }
 
 header p {
@@ -181,6 +193,18 @@ h3 {
 #drop-zone.dragover {
   border-color: var(--accent);
   background: var(--drop-hover);
+}
+
+.drop-icon {
+  font-size: 2.5rem;
+  line-height: 1;
+  margin-bottom: 0.5rem;
+  color: var(--muted);
+  transition: color 0.2s;
+}
+
+#drop-zone:hover .drop-icon {
+  color: var(--accent);
 }
 
 #file-input {
@@ -446,6 +470,25 @@ footer a {
 
 footer a:hover {
   text-decoration: underline;
+}
+
+.credits {
+  margin-top: 0.25rem;
+  font-size: 0.8rem;
+  opacity: 0.7;
+}
+
+.heart {
+  color: var(--danger);
+}
+
+.sponsor-link {
+  color: var(--muted);
+  transition: color 0.2s;
+}
+
+.sponsor-link:hover {
+  color: var(--accent);
 }
 
 /* Responsive — tablet */

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -1,3 +1,4 @@
+/* Dark theme (default) */
 :root {
   --bg: #0f1117;
   --surface: #1a1d27;
@@ -9,6 +10,86 @@
   --success: #22c55e;
   --warning: #f59e0b;
   --danger: #ef4444;
+  --row-alt: rgba(255, 255, 255, 0.02);
+  --row-hover: rgba(59, 130, 246, 0.05);
+  --drop-hover: rgba(59, 130, 246, 0.05);
+  --tag-bg: rgba(59, 130, 246, 0.1);
+  --tag-border: rgba(59, 130, 246, 0.3);
+  --privacy-bg: rgba(34, 197, 94, 0.1);
+  --privacy-border: rgba(34, 197, 94, 0.2);
+  --warning-bg: rgba(245, 158, 11, 0.1);
+  --warning-border: rgba(245, 158, 11, 0.3);
+}
+
+/* Light theme */
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme="dark"]) {
+    --bg: #f8fafc;
+    --surface: #ffffff;
+    --border: #e2e8f0;
+    --text: #1a202c;
+    --muted: #718096;
+    --accent: #2563eb;
+    --accent-hover: #1d4ed8;
+    --success: #16a34a;
+    --warning: #d97706;
+    --danger: #dc2626;
+    --row-alt: rgba(0, 0, 0, 0.02);
+    --row-hover: rgba(59, 130, 246, 0.06);
+    --drop-hover: rgba(59, 130, 246, 0.04);
+    --tag-bg: rgba(59, 130, 246, 0.08);
+    --tag-border: rgba(59, 130, 246, 0.25);
+    --privacy-bg: rgba(34, 197, 94, 0.08);
+    --privacy-border: rgba(34, 197, 94, 0.2);
+    --warning-bg: rgba(245, 158, 11, 0.08);
+    --warning-border: rgba(245, 158, 11, 0.25);
+  }
+}
+
+/* Explicit light override */
+[data-theme="light"] {
+  --bg: #f8fafc;
+  --surface: #ffffff;
+  --border: #e2e8f0;
+  --text: #1a202c;
+  --muted: #718096;
+  --accent: #2563eb;
+  --accent-hover: #1d4ed8;
+  --success: #16a34a;
+  --warning: #d97706;
+  --danger: #dc2626;
+  --row-alt: rgba(0, 0, 0, 0.02);
+  --row-hover: rgba(59, 130, 246, 0.06);
+  --drop-hover: rgba(59, 130, 246, 0.04);
+  --tag-bg: rgba(59, 130, 246, 0.08);
+  --tag-border: rgba(59, 130, 246, 0.25);
+  --privacy-bg: rgba(34, 197, 94, 0.08);
+  --privacy-border: rgba(34, 197, 94, 0.2);
+  --warning-bg: rgba(245, 158, 11, 0.08);
+  --warning-border: rgba(245, 158, 11, 0.25);
+}
+
+/* Explicit dark override */
+[data-theme="dark"] {
+  --bg: #0f1117;
+  --surface: #1a1d27;
+  --border: #2a2d3a;
+  --text: #e4e4e7;
+  --muted: #71717a;
+  --accent: #3b82f6;
+  --accent-hover: #2563eb;
+  --success: #22c55e;
+  --warning: #f59e0b;
+  --danger: #ef4444;
+  --row-alt: rgba(255, 255, 255, 0.02);
+  --row-hover: rgba(59, 130, 246, 0.05);
+  --drop-hover: rgba(59, 130, 246, 0.05);
+  --tag-bg: rgba(59, 130, 246, 0.1);
+  --tag-border: rgba(59, 130, 246, 0.3);
+  --privacy-bg: rgba(34, 197, 94, 0.1);
+  --privacy-border: rgba(34, 197, 94, 0.2);
+  --warning-bg: rgba(245, 158, 11, 0.1);
+  --warning-border: rgba(245, 158, 11, 0.3);
 }
 
 * {
@@ -51,8 +132,8 @@ header p {
   display: inline-block;
   margin-top: 1rem;
   padding: 0.5rem 1rem;
-  background: rgba(34, 197, 94, 0.1);
-  border: 1px solid rgba(34, 197, 94, 0.2);
+  background: var(--privacy-bg);
+  border: 1px solid var(--privacy-border);
   border-radius: 6px;
   color: var(--success);
   font-size: 0.875rem;
@@ -99,7 +180,7 @@ h3 {
 #drop-zone:hover,
 #drop-zone.dragover {
   border-color: var(--accent);
-  background: rgba(59, 130, 246, 0.05);
+  background: var(--drop-hover);
 }
 
 #file-input {
@@ -119,8 +200,8 @@ h3 {
   align-items: center;
   gap: 0.25rem;
   padding: 0.25rem 0.75rem;
-  background: rgba(59, 130, 246, 0.1);
-  border: 1px solid rgba(59, 130, 246, 0.3);
+  background: var(--tag-bg);
+  border: 1px solid var(--tag-border);
   border-radius: 20px;
   font-size: 0.8rem;
 }
@@ -238,11 +319,11 @@ td {
 }
 
 tbody tr:nth-child(even) {
-  background: rgba(255, 255, 255, 0.02);
+  background: var(--row-alt);
 }
 
 tbody tr:hover {
-  background: rgba(59, 130, 246, 0.05);
+  background: var(--row-hover);
 }
 
 .mono {
@@ -261,8 +342,8 @@ tbody tr:hover {
 .warning {
   margin-top: 1rem;
   padding: 0.75rem 1rem;
-  background: rgba(245, 158, 11, 0.1);
-  border: 1px solid rgba(245, 158, 11, 0.3);
+  background: var(--warning-bg);
+  border: 1px solid var(--warning-border);
   border-radius: 6px;
   color: var(--warning);
   font-size: 0.85rem;
@@ -294,6 +375,63 @@ details ul {
   color: var(--muted);
 }
 
+/* Theme toggle */
+.theme-toggle {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.4rem 0.6rem;
+  cursor: pointer;
+  color: var(--text);
+  font-size: 1.1rem;
+  line-height: 1;
+  z-index: 10;
+  transition: background 0.2s, border-color 0.2s;
+  margin: 0;
+}
+
+.theme-toggle:hover {
+  background: var(--row-hover);
+  border-color: var(--accent);
+}
+
+/* Sortable headers */
+th.sortable {
+  cursor: pointer;
+  user-select: none;
+  position: relative;
+  padding-right: 1.2rem;
+}
+
+th.sortable:hover {
+  color: var(--accent);
+}
+
+th.sortable::after {
+  content: "";
+  position: absolute;
+  right: 0.3rem;
+  top: 50%;
+  transform: translateY(-50%);
+  border: 4px solid transparent;
+  border-top-color: var(--muted);
+  margin-top: 3px;
+}
+
+th.sortable.asc::after {
+  border-top-color: transparent;
+  border-bottom-color: var(--accent);
+  margin-top: -3px;
+}
+
+th.sortable.desc::after {
+  border-top-color: var(--accent);
+  margin-top: 3px;
+}
+
 footer {
   text-align: center;
   padding: 2rem 1rem;
@@ -310,10 +448,35 @@ footer a:hover {
   text-decoration: underline;
 }
 
-/* Responsive */
+/* Responsive — tablet */
+@media (max-width: 1024px) {
+  main {
+    max-width: 100%;
+    padding: 1.5rem 1rem;
+  }
+
+  header h1 {
+    font-size: 2rem;
+  }
+
+  section {
+    padding: 1.5rem;
+  }
+}
+
+/* Responsive — phone */
 @media (max-width: 768px) {
   main {
     padding: 1rem 0.5rem;
+  }
+
+  header h1 {
+    font-size: 1.75rem;
+  }
+
+  section {
+    padding: 1rem;
+    border-radius: 8px;
   }
 
   .table-controls {
@@ -330,5 +493,37 @@ footer a:hover {
 
   th, td {
     padding: 0.4rem 0.5rem;
+  }
+
+  .theme-toggle {
+    top: 0.5rem;
+    right: 0.5rem;
+  }
+}
+
+/* Responsive — small phone */
+@media (max-width: 480px) {
+  header h1 {
+    font-size: 1.5rem;
+  }
+
+  header p {
+    font-size: 0.85rem;
+  }
+
+  #drop-zone {
+    padding: 2rem 1rem;
+  }
+
+  button {
+    width: 100%;
+  }
+
+  .export-buttons button {
+    width: 100%;
+  }
+
+  th.sortable {
+    padding-right: 1rem;
   }
 }

--- a/tests/engine/ecb-fetch.test.ts
+++ b/tests/engine/ecb-fetch.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fetchEcbRates } from "../../src/engine/ecb.js";
+
+describe("fetchEcbRates", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should fetch rates and return inverted values", async () => {
+    const csvData =
+      "KEY,FREQ,CURRENCY,CURRENCY_DENOM,EXR_TYPE,EXR_SUFFIX,TIME_PERIOD,OBS_VALUE\n" +
+      "EXR.D.USD.EUR.SP00.A,D,USD,EUR,SP00,A,2025-01-02,1.0350\n" +
+      "EXR.D.USD.EUR.SP00.A,D,USD,EUR,SP00,A,2025-01-03,1.0400\n";
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
+      ok: true,
+      text: async () => csvData,
+    } as Response);
+
+    const rates = await fetchEcbRates(2025, ["USD"]);
+    expect(rates.has("2025-01-02")).toBe(true);
+    expect(rates.has("2025-01-03")).toBe(true);
+
+    // Inverted: 1/1.035 ≈ 0.966...
+    const rate = parseFloat(rates.get("2025-01-02")!.get("USD")!);
+    expect(rate).toBeCloseTo(1 / 1.035, 4);
+  });
+
+  it("should fetch multiple currencies", async () => {
+    const usdCsv =
+      "KEY,FREQ,CURRENCY,CURRENCY_DENOM,EXR_TYPE,EXR_SUFFIX,TIME_PERIOD,OBS_VALUE\n" +
+      "EXR.D.USD.EUR.SP00.A,D,USD,EUR,SP00,A,2025-01-02,1.0350\n";
+    const gbpCsv =
+      "KEY,FREQ,CURRENCY,CURRENCY_DENOM,EXR_TYPE,EXR_SUFFIX,TIME_PERIOD,OBS_VALUE\n" +
+      "EXR.D.GBP.EUR.SP00.A,D,GBP,EUR,SP00,A,2025-01-02,0.8600\n";
+
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce({ ok: true, text: async () => usdCsv } as Response)
+      .mockResolvedValueOnce({ ok: true, text: async () => gbpCsv } as Response);
+
+    const rates = await fetchEcbRates(2025, ["USD", "GBP"]);
+    expect(rates.get("2025-01-02")!.has("USD")).toBe(true);
+    expect(rates.get("2025-01-02")!.has("GBP")).toBe(true);
+  });
+
+  it("should throw on API error", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+    } as Response);
+
+    await expect(fetchEcbRates(2025, ["XYZ"])).rejects.toThrow("ECB API error");
+  });
+
+  it("should return empty map for empty currencies array", async () => {
+    const rates = await fetchEcbRates(2025, []);
+    expect(rates.size).toBe(0);
+  });
+
+  it("should skip empty lines in CSV", async () => {
+    const csvData =
+      "KEY,FREQ,CURRENCY,CURRENCY_DENOM,EXR_TYPE,EXR_SUFFIX,TIME_PERIOD,OBS_VALUE\n" +
+      "EXR.D.USD.EUR.SP00.A,D,USD,EUR,SP00,A,2025-01-02,1.0350\n" +
+      "\n" +
+      "\n";
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
+      ok: true,
+      text: async () => csvData,
+    } as Response);
+
+    const rates = await fetchEcbRates(2025, ["USD"]);
+    expect(rates.size).toBe(1);
+  });
+
+  it("should skip lines with empty OBS_VALUE", async () => {
+    const csvData =
+      "KEY,FREQ,CURRENCY,CURRENCY_DENOM,EXR_TYPE,EXR_SUFFIX,TIME_PERIOD,OBS_VALUE\n" +
+      "EXR.D.USD.EUR.SP00.A,D,USD,EUR,SP00,A,2025-01-02,1.0350\n" +
+      "EXR.D.USD.EUR.SP00.A,D,USD,EUR,SP00,A,2025-01-03,\n";
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
+      ok: true,
+      text: async () => csvData,
+    } as Response);
+
+    const rates = await fetchEcbRates(2025, ["USD"]);
+    expect(rates.has("2025-01-02")).toBe(true);
+    expect(rates.has("2025-01-03")).toBe(false);
+  });
+
+  it("should use correct URL format with year range", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
+      ok: true,
+      text: async () => "header\n",
+    } as Response);
+
+    await fetchEcbRates(2024, ["CHF"]);
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining("startPeriod=2024-01-01"),
+    );
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining("endPeriod=2024-12-31"),
+    );
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining("D.CHF.EUR"),
+    );
+  });
+});

--- a/tests/engine/ecb-fetch.test.ts
+++ b/tests/engine/ecb-fetch.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { fetchEcbRates } from "../../src/engine/ecb.js";
 
+function mockFetchOk(csvData: string) {
+  return {
+    ok: true,
+    text: () => Promise.resolve(csvData),
+  } as Response;
+}
+
 describe("fetchEcbRates", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -12,10 +19,7 @@ describe("fetchEcbRates", () => {
       "EXR.D.USD.EUR.SP00.A,D,USD,EUR,SP00,A,2025-01-02,1.0350\n" +
       "EXR.D.USD.EUR.SP00.A,D,USD,EUR,SP00,A,2025-01-03,1.0400\n";
 
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
-      ok: true,
-      text: async () => csvData,
-    } as Response);
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(mockFetchOk(csvData));
 
     const rates = await fetchEcbRates(2025, ["USD"]);
     expect(rates.has("2025-01-02")).toBe(true);
@@ -35,8 +39,8 @@ describe("fetchEcbRates", () => {
       "EXR.D.GBP.EUR.SP00.A,D,GBP,EUR,SP00,A,2025-01-02,0.8600\n";
 
     vi.spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce({ ok: true, text: async () => usdCsv } as Response)
-      .mockResolvedValueOnce({ ok: true, text: async () => gbpCsv } as Response);
+      .mockResolvedValueOnce(mockFetchOk(usdCsv))
+      .mockResolvedValueOnce(mockFetchOk(gbpCsv));
 
     const rates = await fetchEcbRates(2025, ["USD", "GBP"]);
     expect(rates.get("2025-01-02")!.has("USD")).toBe(true);
@@ -65,10 +69,7 @@ describe("fetchEcbRates", () => {
       "\n" +
       "\n";
 
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
-      ok: true,
-      text: async () => csvData,
-    } as Response);
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(mockFetchOk(csvData));
 
     const rates = await fetchEcbRates(2025, ["USD"]);
     expect(rates.size).toBe(1);
@@ -80,10 +81,7 @@ describe("fetchEcbRates", () => {
       "EXR.D.USD.EUR.SP00.A,D,USD,EUR,SP00,A,2025-01-02,1.0350\n" +
       "EXR.D.USD.EUR.SP00.A,D,USD,EUR,SP00,A,2025-01-03,\n";
 
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
-      ok: true,
-      text: async () => csvData,
-    } as Response);
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(mockFetchOk(csvData));
 
     const rates = await fetchEcbRates(2025, ["USD"]);
     expect(rates.has("2025-01-02")).toBe(true);
@@ -91,10 +89,7 @@ describe("fetchEcbRates", () => {
   });
 
   it("should use correct URL format with year range", async () => {
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
-      ok: true,
-      text: async () => "header\n",
-    } as Response);
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(mockFetchOk("header\n"));
 
     await fetchEcbRates(2024, ["CHF"]);
 

--- a/tests/engine/loss-carryforward.test.ts
+++ b/tests/engine/loss-carryforward.test.ts
@@ -112,4 +112,44 @@ describe("Loss Carryforward (Art. 49 LIRPF)", () => {
     expect(result.totalCompensated.toFixed(2)).toBe("0.00");
     expect(result.updatedCarryforward).toHaveLength(0);
   });
+
+  it("should add current year income losses to carryforward", () => {
+    const result = applyLossCarryforward(
+      2025,
+      new Decimal("500"),    // Positive gains
+      new Decimal("-1000"),  // Net loss on income
+      [],
+    );
+
+    const incomeLoss = result.updatedCarryforward.find((l) => l.category === "income");
+    expect(incomeLoss).toBeDefined();
+    expect(incomeLoss!.year).toBe(2025);
+    expect(incomeLoss!.remaining.toFixed(2)).toBe("-1000.00");
+  });
+
+  it("should add both gains and income losses when both negative", () => {
+    const result = applyLossCarryforward(
+      2025,
+      new Decimal("-3000"),  // Net loss on gains
+      new Decimal("-500"),   // Net loss on income
+      [],
+    );
+
+    expect(result.updatedCarryforward).toHaveLength(2);
+    const gainsLoss = result.updatedCarryforward.find((l) => l.category === "gains");
+    const incomeLoss = result.updatedCarryforward.find((l) => l.category === "income");
+    expect(gainsLoss!.remaining.toFixed(2)).toBe("-3000.00");
+    expect(incomeLoss!.remaining.toFixed(2)).toBe("-500.00");
+  });
+
+  it("should not create carryforward when both positive", () => {
+    const result = applyLossCarryforward(
+      2025,
+      new Decimal("5000"),
+      new Decimal("2000"),
+      [],
+    );
+
+    expect(result.updatedCarryforward).toHaveLength(0);
+  });
 });

--- a/tests/engine/wash-sale.test.ts
+++ b/tests/engine/wash-sale.test.ts
@@ -19,6 +19,7 @@ function makeDisposal(overrides: Partial<FifoDisposal>): FifoDisposal {
     currency: "USD",
     sellEcbRate: new Decimal("0.91"),
     acquireEcbRate: new Decimal("0.92"),
+    assetCategory: "STK",
     washSaleBlocked: false,
     ...overrides,
   };
@@ -91,5 +92,21 @@ describe("detectWashSales", () => {
 
     const result = detectWashSales(disposals, trades);
     expect(result[0]!.washSaleBlocked).toBe(false);
+  });
+
+  it("should NOT block loss for options (OPT assetCategory)", () => {
+    const disposals = [makeDisposal({
+      sellDate: "2025-06-15",
+      gainLossEur: new Decimal(-500),
+      assetCategory: "OPT",
+      symbol: "AAPL 250620C00200000",
+    })];
+    const trades = [
+      makeTrade("US0378331005", "2025-06-15", "SELL"),
+      makeTrade("US0378331005", "2025-06-20", "BUY"), // Same ISIN repurchase
+    ];
+
+    const result = detectWashSales(disposals, trades);
+    expect(result[0]!.washSaleBlocked).toBe(false); // Options excluded
   });
 });

--- a/tests/generators/modelo720.test.ts
+++ b/tests/generators/modelo720.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from "vitest";
+import Decimal from "decimal.js";
+import { generateModelo720 } from "../../src/generators/modelo720.js";
+import type { OpenPosition } from "../../src/types/ibkr.js";
+import type { EcbRateMap } from "../../src/types/ecb.js";
+import type { Lot } from "../../src/types/tax.js";
+
+const rateMap: EcbRateMap = new Map([
+  ["2025-12-31", new Map([["USD", new Decimal("0.92")], ["GBP", new Decimal("1.15")]])],
+  ["2025-12-30", new Map([["USD", new Decimal("0.92")], ["GBP", new Decimal("1.15")]])],
+]);
+
+function makePosition(overrides: Partial<OpenPosition> = {}): OpenPosition {
+  return {
+    accountId: "",
+    symbol: "SPY",
+    description: "SPDR S&P 500 ETF",
+    isin: "US78462F1030",
+    currency: "USD",
+    assetCategory: "STK",
+    quantity: "100",
+    costBasisMoney: "40000",
+    costBasisPrice: "400",
+    markPrice: "600",
+    positionValue: "60000",
+    fifoPnlUnrealized: "20000",
+    fxRateToBase: "0.92",
+    ...overrides,
+  };
+}
+
+const baseConfig = {
+  nif: "12345678A",
+  surname: "GARCIA LOPEZ",
+  name: "JUAN",
+  year: 2025,
+  phone: "600123456",
+  contactName: "GARCIA LOPEZ, JUAN",
+  declarationId: "0000000000001",
+  isComplementary: false,
+  isReplacement: false,
+};
+
+describe("Modelo 720 Generator", () => {
+  it("should return empty string when total value is below 50K EUR", () => {
+    const positions = [makePosition({ positionValue: "10000" })]; // 10000 * 0.92 = 9200 EUR
+    const result = generateModelo720(positions, rateMap, baseConfig);
+    expect(result).toBe("");
+  });
+
+  it("should generate records when total value exceeds 50K EUR", () => {
+    const positions = [makePosition()]; // 60000 * 0.92 = 55200 EUR
+    const result = generateModelo720(positions, rateMap, baseConfig);
+    expect(result).not.toBe("");
+    const lines = result.split("\n");
+    expect(lines).toHaveLength(2); // 1 summary + 1 detail
+    expect(lines[0]![0]).toBe("1"); // summary record
+    expect(lines[1]![0]).toBe("2"); // detail record
+  });
+
+  it("should include BOND asset category", () => {
+    const positions = [
+      makePosition({ assetCategory: "BOND", positionValue: "60000" }),
+    ];
+    const result = generateModelo720(positions, rateMap, baseConfig);
+    expect(result).not.toBe("");
+    expect(result.split("\n")).toHaveLength(2);
+  });
+
+  it("should include STK, FUND, and BOND but exclude others", () => {
+    const positions = [
+      makePosition({ positionValue: "30000" }), // STK
+      makePosition({ assetCategory: "FUND", isin: "IE00BK5BQT80", positionValue: "30000" }), // FUND
+      makePosition({ assetCategory: "OPT", isin: "US0000000001", positionValue: "30000" }), // OPT — excluded
+    ];
+    const result = generateModelo720(positions, rateMap, baseConfig);
+    // STK + FUND = 30000+30000 * 0.92 = 55200 EUR > 50K
+    expect(result).not.toBe("");
+    const lines = result.split("\n");
+    expect(lines).toHaveLength(3); // 1 summary + 2 detail (OPT excluded)
+  });
+
+  it("should extract country code from ISIN into detail record", () => {
+    const positions = [makePosition()];
+    const result = generateModelo720(positions, rateMap, baseConfig);
+    const detail = result.split("\n")[1]!;
+    // Country code at positions 129-130 (0-indexed: 128-129)
+    expect(detail.slice(128, 130)).toBe("US");
+  });
+
+  it("should include ISIN in detail record", () => {
+    const positions = [makePosition()];
+    const result = generateModelo720(positions, rateMap, baseConfig);
+    const detail = result.split("\n")[1]!;
+    // ISIN at positions 132-143 (0-indexed: 131-142)
+    expect(detail.slice(131, 143).trim()).toBe("US78462F1030");
+  });
+
+  it("should use first acquisition date from FIFO lots", () => {
+    const positions = [makePosition()];
+    const lots: Map<string, Lot[]> = new Map([
+      ["US78462F1030", [
+        { id: "1", isin: "US78462F1030", symbol: "SPY", description: "", acquireDate: "20230115", quantity: new Decimal(50), pricePerShare: new Decimal(380), costInEur: new Decimal(17480), currency: "USD", ecbRate: new Decimal("0.92") },
+        { id: "2", isin: "US78462F1030", symbol: "SPY", description: "", acquireDate: "20240601", quantity: new Decimal(50), pricePerShare: new Decimal(420), costInEur: new Decimal(19320), currency: "USD", ecbRate: new Decimal("0.92") },
+      ]],
+    ]);
+    const result = generateModelo720(positions, rateMap, baseConfig, lots);
+    const detail = result.split("\n")[1]!;
+    // First acquisition date at positions 415-422 (0-indexed: 414-421)
+    expect(detail.slice(414, 422)).toBe("20230115");
+  });
+
+  describe("A/M/C declaration types", () => {
+    it("should use 'A' for new positions not in previous year", () => {
+      const positions = [makePosition()];
+      const config = { ...baseConfig, previousYearIsins: ["IE00BK5BQT80"] };
+      const result = generateModelo720(positions, rateMap, config);
+      const detail = result.split("\n")[1]!;
+      // Type at position 423 (0-indexed: 422)
+      expect(detail[422]).toBe("A");
+    });
+
+    it("should use 'M' for positions already declared last year", () => {
+      const positions = [makePosition()];
+      const config = { ...baseConfig, previousYearIsins: ["US78462F1030"] };
+      const result = generateModelo720(positions, rateMap, config);
+      const detail = result.split("\n")[1]!;
+      expect(detail[422]).toBe("M");
+    });
+
+    it("should default to 'A' when no previousYearIsins provided", () => {
+      const positions = [makePosition()];
+      const result = generateModelo720(positions, rateMap, baseConfig);
+      const detail = result.split("\n")[1]!;
+      // No previousYearIsins → empty set → not found → 'A'
+      expect(detail[422]).toBe("A");
+    });
+
+    it("should generate 'C' records for ISINs sold since last year", () => {
+      const positions = [makePosition()]; // only US78462F1030
+      const config = {
+        ...baseConfig,
+        previousYearIsins: ["US78462F1030", "IE00BK5BQT80"],
+      };
+      const result = generateModelo720(positions, rateMap, config);
+      const lines = result.split("\n");
+      // 1 summary + 1 detail (M for SPY) + 1 cancelled (C for VWCE)
+      expect(lines).toHaveLength(3);
+
+      const cancelled = lines[2]!;
+      expect(cancelled[422]).toBe("C"); // type C
+      expect(cancelled.slice(131, 143).trim()).toBe("IE00BK5BQT80"); // cancelled ISIN
+    });
+
+    it("should generate C record even when current total is below 50K", () => {
+      const positions = [makePosition({ positionValue: "10000" })]; // 9200 EUR < 50K
+      const config = {
+        ...baseConfig,
+        previousYearIsins: ["US78462F1030", "IE00BK5BQT80"],
+      };
+      const result = generateModelo720(positions, rateMap, config);
+      // IE00BK5BQT80 is cancelled — should generate output even below 50K
+      expect(result).not.toBe("");
+      const lines = result.split("\n");
+      const cancelled = lines.find((l) => l[0] === "2" && l[422] === "C");
+      expect(cancelled).toBeDefined();
+      expect(cancelled!.slice(131, 143).trim()).toBe("IE00BK5BQT80");
+    });
+
+    it("should set cancellation date to year-end in C records", () => {
+      const positions = [makePosition()];
+      const config = {
+        ...baseConfig,
+        previousYearIsins: ["US78462F1030", "DE000A0F5UF5"],
+      };
+      const result = generateModelo720(positions, rateMap, config);
+      const cancelled = result.split("\n").find((l) => l[0] === "2" && l[422] === "C")!;
+      // Cancellation date at positions 424-431 (0-indexed: 423-430)
+      expect(cancelled.slice(423, 431)).toBe("20251231");
+    });
+  });
+});

--- a/tests/generators/modelo721.test.ts
+++ b/tests/generators/modelo721.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import Decimal from "decimal.js";
+import { generateModelo721 } from "../../src/generators/modelo721.js";
+import type { Modelo721Entry } from "../../src/generators/modelo721.js";
+
+function makeEntry(overrides: Partial<Modelo721Entry> = {}): Modelo721Entry {
+  return {
+    assetId: "BTC",
+    description: "Bitcoin",
+    exchangeName: "Coinbase",
+    countryCode: "US",
+    quantity: new Decimal("1.5"),
+    valuationEur: new Decimal("60000"),
+    acquisitionCostEur: new Decimal("30000"),
+    ...overrides,
+  };
+}
+
+const baseConfig = {
+  nif: "12345678A",
+  surname: "GARCIA LOPEZ",
+  name: "JUAN",
+  year: 2025,
+  phone: "600123456",
+  contactName: "GARCIA LOPEZ, JUAN",
+  declarationId: "0000000000001",
+  isComplementary: false,
+  isReplacement: false,
+};
+
+describe("Modelo 721 Generator", () => {
+  it("should return empty string when total value is below 50K EUR", () => {
+    const entries = [makeEntry({ valuationEur: new Decimal("10000") })];
+    expect(generateModelo721(entries, baseConfig)).toBe("");
+  });
+
+  it("should generate records when total value exceeds 50K EUR", () => {
+    const entries = [makeEntry()]; // 60000 EUR
+    const result = generateModelo721(entries, baseConfig);
+    expect(result).not.toBe("");
+    const lines = result.split("\n");
+    expect(lines).toHaveLength(2); // 1 summary + 1 detail
+    expect(lines[0]![0]).toBe("1"); // summary
+    expect(lines[1]![0]).toBe("2"); // detail
+  });
+
+  it("should use model number 721", () => {
+    const entries = [makeEntry()];
+    const result = generateModelo721(entries, baseConfig);
+    const lines = result.split("\n");
+    expect(lines[0]!.slice(1, 4)).toBe("721");
+    expect(lines[1]!.slice(1, 4)).toBe("721");
+  });
+
+  it("should include year in records", () => {
+    const entries = [makeEntry()];
+    const result = generateModelo721(entries, baseConfig);
+    const summary = result.split("\n")[0]!;
+    expect(summary.slice(4, 8)).toBe("2025");
+  });
+
+  it("should include NIF in records", () => {
+    const entries = [makeEntry()];
+    const result = generateModelo721(entries, baseConfig);
+    const summary = result.split("\n")[0]!;
+    expect(summary.slice(8, 17).trim()).toBe("12345678A");
+  });
+
+  it("should mark asset type as C for crypto", () => {
+    const entries = [makeEntry()];
+    const result = generateModelo721(entries, baseConfig);
+    const detail = result.split("\n")[1]!;
+    // Asset type at position 102 (0-indexed: 101)
+    expect(detail[101]).toBe("C");
+  });
+
+  it("should include country code", () => {
+    const entries = [makeEntry({ countryCode: "US" })];
+    const result = generateModelo721(entries, baseConfig);
+    const detail = result.split("\n")[1]!;
+    expect(detail.slice(128, 130)).toBe("US");
+  });
+
+  it("should include asset ID", () => {
+    const entries = [makeEntry({ assetId: "BTC" })];
+    const result = generateModelo721(entries, baseConfig);
+    const detail = result.split("\n")[1]!;
+    expect(detail.slice(131, 143).trim()).toBe("BTC");
+  });
+
+  it("should include exchange name", () => {
+    const entries = [makeEntry({ exchangeName: "Coinbase" })];
+    const result = generateModelo721(entries, baseConfig);
+    const detail = result.split("\n")[1]!;
+    expect(detail.slice(189, 230).trim()).toBe("Coinbase");
+  });
+
+  it("should handle multiple entries", () => {
+    const entries = [
+      makeEntry({ assetId: "BTC", valuationEur: new Decimal("40000") }),
+      makeEntry({ assetId: "ETH", valuationEur: new Decimal("20000"), description: "Ethereum" }),
+    ];
+    const result = generateModelo721(entries, baseConfig);
+    const lines = result.split("\n");
+    expect(lines).toHaveLength(3); // 1 summary + 2 detail
+  });
+
+  it("should set complementary flag", () => {
+    const entries = [makeEntry()];
+    const config = { ...baseConfig, isComplementary: true };
+    const result = generateModelo721(entries, config);
+    const summary = result.split("\n")[0]!;
+    expect(summary[120]).toBe("C"); // position 121
+  });
+
+  it("should set replacement flag", () => {
+    const entries = [makeEntry()];
+    const config = { ...baseConfig, isReplacement: true };
+    const result = generateModelo721(entries, config);
+    const summary = result.split("\n")[0]!;
+    expect(summary[121]).toBe("S"); // position 122
+  });
+
+  it("should include detail count in summary", () => {
+    const entries = [makeEntry(), makeEntry({ assetId: "ETH" })];
+    const result = generateModelo721(entries, baseConfig);
+    const summary = result.split("\n")[0]!;
+    const count = summary.slice(135, 144);
+    expect(parseInt(count)).toBe(2);
+  });
+});

--- a/tests/generators/pdf.test.ts
+++ b/tests/generators/pdf.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from "vitest";
+import Decimal from "decimal.js";
+import { generatePdfReport } from "../../src/generators/pdf.js";
+import type { TaxSummary } from "../../src/types/tax.js";
+
+function makeReport(overrides: Partial<TaxSummary> = {}): TaxSummary {
+  return {
+    year: 2025,
+    warnings: [],
+    capitalGains: {
+      transmissionValue: new Decimal("10000"),
+      acquisitionValue: new Decimal("8000"),
+      netGainLoss: new Decimal("2000"),
+      blockedLosses: new Decimal("0"),
+      disposals: [
+        {
+          isin: "US78462F1030",
+          symbol: "SPY",
+          description: "SPDR S&P 500",
+          sellDate: "20250915",
+          acquireDate: "20240301",
+          quantity: new Decimal("10"),
+          proceedsEur: new Decimal("5000"),
+          costBasisEur: new Decimal("4000"),
+          gainLossEur: new Decimal("1000"),
+          holdingPeriodDays: 198,
+          currency: "USD",
+          sellEcbRate: new Decimal("0.92"),
+          acquireEcbRate: new Decimal("0.91"),
+          washSaleBlocked: false,
+        },
+        {
+          isin: "IE00BK5BQT80",
+          symbol: "VWCE",
+          description: "Vanguard FTSE All-World",
+          sellDate: "20251020",
+          acquireDate: "20230615",
+          quantity: new Decimal("5"),
+          proceedsEur: new Decimal("5000"),
+          costBasisEur: new Decimal("4000"),
+          gainLossEur: new Decimal("1000"),
+          holdingPeriodDays: 858,
+          currency: "EUR",
+          sellEcbRate: new Decimal("1"),
+          acquireEcbRate: new Decimal("1"),
+          washSaleBlocked: false,
+        },
+      ],
+    },
+    dividends: {
+      grossIncome: new Decimal("500"),
+      deductibleExpenses: new Decimal("75"),
+      entries: [
+        {
+          isin: "US78462F1030",
+          symbol: "SPY",
+          description: "US Dividend - SPY",
+          payDate: "20250620",
+          grossAmountEur: new Decimal("500"),
+          withholdingTaxEur: new Decimal("75"),
+          withholdingCountry: "US",
+          currency: "USD",
+          ecbRate: new Decimal("0.92"),
+        },
+      ],
+    },
+    interest: {
+      earned: new Decimal("10"),
+      paid: new Decimal("5"),
+      entries: [],
+    },
+    doubleTaxation: {
+      deduction: new Decimal("75"),
+      byCountry: {
+        US: { taxPaid: new Decimal("75"), deductionAllowed: new Decimal("75") },
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe("PDF Report Generator", () => {
+  it("should generate a valid PDF buffer", async () => {
+    const report = makeReport();
+    const buffer = await generatePdfReport(report);
+    expect(buffer).toBeInstanceOf(Buffer);
+    expect(buffer.length).toBeGreaterThan(500);
+    // PDF files start with %PDF
+    expect(buffer.slice(0, 4).toString()).toBe("%PDF");
+  });
+
+  it("should produce a larger PDF with disposals than without", async () => {
+    const withDisposals = await generatePdfReport(makeReport());
+    const withoutDisposals = await generatePdfReport(makeReport({
+      capitalGains: {
+        transmissionValue: new Decimal(0),
+        acquisitionValue: new Decimal(0),
+        netGainLoss: new Decimal(0),
+        blockedLosses: new Decimal(0),
+        disposals: [],
+      },
+    }));
+    expect(withDisposals.length).toBeGreaterThan(withoutDisposals.length);
+  });
+
+  it("should produce a larger PDF with dividends than without", async () => {
+    const withDividends = await generatePdfReport(makeReport());
+    const withoutDividends = await generatePdfReport(makeReport({
+      dividends: {
+        grossIncome: new Decimal(0),
+        deductibleExpenses: new Decimal(0),
+        entries: [],
+      },
+      doubleTaxation: {
+        deduction: new Decimal(0),
+        byCountry: {},
+      },
+    }));
+    expect(withDividends.length).toBeGreaterThan(withoutDividends.length);
+  });
+
+  it("should handle report with no disposals", async () => {
+    const report = makeReport({
+      capitalGains: {
+        transmissionValue: new Decimal(0),
+        acquisitionValue: new Decimal(0),
+        netGainLoss: new Decimal(0),
+        blockedLosses: new Decimal(0),
+        disposals: [],
+      },
+    });
+    const buffer = await generatePdfReport(report);
+    expect(buffer).toBeInstanceOf(Buffer);
+    expect(buffer.length).toBeGreaterThan(100);
+  });
+
+  it("should handle report with no dividends", async () => {
+    const report = makeReport({
+      dividends: {
+        grossIncome: new Decimal(0),
+        deductibleExpenses: new Decimal(0),
+        entries: [],
+      },
+      doubleTaxation: {
+        deduction: new Decimal(0),
+        byCountry: {},
+      },
+    });
+    const buffer = await generatePdfReport(report);
+    expect(buffer).toBeInstanceOf(Buffer);
+  });
+
+  it("should produce a larger PDF with warnings than without", async () => {
+    const withWarnings = await generatePdfReport(
+      makeReport({ warnings: ["Short sale detected for XYZ", "Missing ISIN for ABC"] }),
+    );
+    const withoutWarnings = await generatePdfReport(makeReport());
+    expect(withWarnings.length).toBeGreaterThan(withoutWarnings.length);
+  });
+
+  it("should handle report with many disposals (pagination)", async () => {
+    const manyDisposals = Array.from({ length: 60 }, (_, i) => ({
+      isin: `US${String(i).padStart(10, "0")}`,
+      symbol: `SYM${i}`,
+      description: `Stock ${i}`,
+      sellDate: "20250915",
+      acquireDate: "20240301",
+      quantity: new Decimal("10"),
+      proceedsEur: new Decimal("5000"),
+      costBasisEur: new Decimal("4000"),
+      gainLossEur: new Decimal(i % 2 === 0 ? "1000" : "-500"),
+      holdingPeriodDays: 198,
+      currency: "USD",
+      sellEcbRate: new Decimal("0.92"),
+      acquireEcbRate: new Decimal("0.91"),
+      washSaleBlocked: false,
+    }));
+
+    const report = makeReport({
+      capitalGains: {
+        transmissionValue: new Decimal("300000"),
+        acquisitionValue: new Decimal("240000"),
+        netGainLoss: new Decimal("60000"),
+        blockedLosses: new Decimal("0"),
+        disposals: manyDisposals,
+      },
+    });
+
+    const buffer = await generatePdfReport(report);
+    expect(buffer).toBeInstanceOf(Buffer);
+    // Should be multi-page — significantly larger
+    expect(buffer.length).toBeGreaterThan(2000);
+  });
+
+  it("should handle double taxation with multiple countries", async () => {
+    const report = makeReport({
+      doubleTaxation: {
+        deduction: new Decimal("150"),
+        byCountry: {
+          US: { taxPaid: new Decimal("75"), deductionAllowed: new Decimal("75") },
+          DE: { taxPaid: new Decimal("100"), deductionAllowed: new Decimal("75") },
+        },
+      },
+    });
+    const buffer = await generatePdfReport(report);
+    expect(buffer).toBeInstanceOf(Buffer);
+    expect(buffer.length).toBeGreaterThan(500);
+  });
+
+  it("should handle losses (negative gain/loss)", async () => {
+    const report = makeReport();
+    report.capitalGains.disposals[0]!.gainLossEur = new Decimal("-1000");
+    report.capitalGains.netGainLoss = new Decimal("0");
+    const buffer = await generatePdfReport(report);
+    expect(buffer).toBeInstanceOf(Buffer);
+  });
+
+  it("should handle blocked losses", async () => {
+    const report = makeReport({
+      capitalGains: {
+        ...makeReport().capitalGains,
+        blockedLosses: new Decimal("500"),
+      },
+    });
+    const buffer = await generatePdfReport(report);
+    expect(buffer).toBeInstanceOf(Buffer);
+  });
+});

--- a/tests/generators/pdf.test.ts
+++ b/tests/generators/pdf.test.ts
@@ -86,7 +86,7 @@ describe("PDF Report Generator", () => {
     expect(buffer).toBeInstanceOf(Buffer);
     expect(buffer.length).toBeGreaterThan(500);
     // PDF files start with %PDF
-    expect(buffer.slice(0, 4).toString()).toBe("%PDF");
+    expect(buffer.subarray(0, 4).toString()).toBe("%PDF");
   });
 
   it("should produce a larger PDF with disposals than without", async () => {

--- a/tests/parsers/csv-utils.test.ts
+++ b/tests/parsers/csv-utils.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import {
+  detectDelimiter,
+  parseCsvLine,
+  parseNumber,
+  convertDateDMY,
+  convertDateDMYSlash,
+  convertDateISO,
+  findColumn,
+  stripBom,
+} from "../../src/parsers/csv-utils.js";
+
+describe("detectDelimiter", () => {
+  it("should detect semicolon delimiter", () => {
+    expect(detectDelimiter("a;b;c;d")).toBe(";");
+  });
+
+  it("should detect comma delimiter", () => {
+    expect(detectDelimiter("a,b,c,d")).toBe(",");
+  });
+
+  it("should prefer semicolons when equal", () => {
+    expect(detectDelimiter("a;b,c")).toBe(","); // 1 semicolon vs 1 comma → equal → comma
+  });
+
+  it("should handle no delimiters", () => {
+    expect(detectDelimiter("abcd")).toBe(","); // default
+  });
+});
+
+describe("parseCsvLine", () => {
+  it("should parse simple comma-separated values", () => {
+    expect(parseCsvLine("a,b,c", ",")).toEqual(["a", "b", "c"]);
+  });
+
+  it("should parse semicolon-separated values", () => {
+    expect(parseCsvLine("a;b;c", ";")).toEqual(["a", "b", "c"]);
+  });
+
+  it("should handle quoted fields", () => {
+    expect(parseCsvLine('"hello",world', ",")).toEqual(["hello", "world"]);
+  });
+
+  it("should handle escaped quotes inside quoted fields", () => {
+    expect(parseCsvLine('"he""llo",world', ",")).toEqual(['he"llo', "world"]);
+  });
+
+  it("should handle commas inside quoted fields", () => {
+    expect(parseCsvLine('"a,b",c', ",")).toEqual(["a,b", "c"]);
+  });
+
+  it("should handle empty fields", () => {
+    expect(parseCsvLine("a,,c", ",")).toEqual(["a", "", "c"]);
+  });
+
+  it("should handle single field", () => {
+    expect(parseCsvLine("hello", ",")).toEqual(["hello"]);
+  });
+});
+
+describe("parseNumber", () => {
+  it("should parse EU format (dot thousands, comma decimal)", () => {
+    expect(parseNumber("1.234,56")).toBe("1234.56");
+  });
+
+  it("should parse negative EU format", () => {
+    expect(parseNumber("-175,50")).toBe("-175.50");
+  });
+
+  it("should parse US format with comma thousands", () => {
+    expect(parseNumber("1,234.56")).toBe("1234.56");
+  });
+
+  it("should parse plain number", () => {
+    expect(parseNumber("175.50")).toBe("175.50");
+  });
+
+  it("should return '0' for empty string", () => {
+    expect(parseNumber("")).toBe("0");
+    expect(parseNumber("  ")).toBe("0");
+  });
+
+  it("should handle comma-only decimal (no thousands)", () => {
+    // Line 74-76: lastComma >= 0 && lastDot < 0
+    expect(parseNumber("175,50")).toBe("175.50");
+  });
+
+  it("should handle integer", () => {
+    expect(parseNumber("100")).toBe("100");
+  });
+
+  it("should handle negative number with no separator", () => {
+    expect(parseNumber("-50")).toBe("-50");
+  });
+});
+
+describe("convertDateDMY", () => {
+  it("should convert DD-MM-YYYY to YYYYMMDD", () => {
+    expect(convertDateDMY("15-03-2025")).toBe("20250315");
+  });
+
+  it("should return input if no match", () => {
+    expect(convertDateDMY("2025-03-15")).toBe("2025-03-15");
+  });
+
+  it("should trim whitespace", () => {
+    expect(convertDateDMY("  15-03-2025  ")).toBe("20250315");
+  });
+});
+
+describe("convertDateDMYSlash", () => {
+  it("should convert DD/MM/YYYY to YYYYMMDD", () => {
+    expect(convertDateDMYSlash("15/03/2025")).toBe("20250315");
+  });
+
+  it("should handle DD/MM/YYYY HH:MM:SS", () => {
+    expect(convertDateDMYSlash("15/03/2025 09:30:00")).toBe("20250315");
+  });
+
+  it("should return input if no match", () => {
+    expect(convertDateDMYSlash("2025-03-15")).toBe("2025-03-15");
+  });
+});
+
+describe("convertDateISO", () => {
+  it("should convert YYYY-MM-DD to YYYYMMDD", () => {
+    expect(convertDateISO("2025-03-15")).toBe("20250315");
+  });
+
+  it("should handle already compact format", () => {
+    expect(convertDateISO("20250315")).toBe("20250315");
+  });
+});
+
+describe("findColumn", () => {
+  it("should find column by exact name (case-insensitive)", () => {
+    expect(findColumn(["Name", "ISIN", "Price"], ["isin"])).toBe(1);
+  });
+
+  it("should find column with multiple candidates", () => {
+    expect(findColumn(["Fecha", "ISIN", "Precio"], ["price", "precio"])).toBe(2);
+  });
+
+  it("should return -1 if not found", () => {
+    expect(findColumn(["Name", "ISIN"], ["price"])).toBe(-1);
+  });
+
+  it("should handle trimming", () => {
+    expect(findColumn(["Name", " ISIN "], ["isin"])).toBe(1);
+  });
+});
+
+describe("stripBom", () => {
+  it("should strip UTF-8 BOM", () => {
+    expect(stripBom("\uFEFFhello")).toBe("hello");
+  });
+
+  it("should leave non-BOM text unchanged", () => {
+    expect(stripBom("hello")).toBe("hello");
+  });
+});

--- a/tests/parsers/degiro.test.ts
+++ b/tests/parsers/degiro.test.ts
@@ -244,6 +244,64 @@ describe("degiroParser", () => {
     });
   });
 
+  describe("Account CSV — new format with Variación column", () => {
+    it("should parse new-format Account CSV with Variación header", () => {
+      // Real format: "Tipo,Variación,,Saldo,," — Variación col has currency, next col has amount
+      const csv = [
+        "Fecha,Hora,Fecha valor,Producto,ISIN,Descripción,Tipo,Variación,,Saldo,,ID Orden",
+        "15-05-2025,00:00,15-05-2025,APPLE INC,US0378331005,Dividendo,,USD,2.50,USD,500.00,",
+        "15-05-2025,00:00,15-05-2025,APPLE INC,US0378331005,Retención del dividendo,,USD,-0.38,USD,499.62,",
+      ].join("\n");
+
+      const result = degiroParser.parse(csv);
+      const divs = result.cashTransactions.filter((t) => t.type === "Dividends");
+      const whts = result.cashTransactions.filter((t) => t.type === "Withholding Tax");
+      expect(divs).toHaveLength(1);
+      expect(divs[0]!.amount).toBe("2.50");
+      expect(whts).toHaveLength(1);
+      expect(whts[0]!.amount).toBe("-0.38");
+    });
+  });
+
+  describe("Account CSV — Dutch language", () => {
+    it("should detect and parse Dutch Account CSV", () => {
+      const csv = [
+        "Datum,Tijd,Valutadatum,Product,ISIN,Omschrijving,Wisselkoers,,Mutatie,,Saldo,,Order ID",
+        "15-05-2025,00:00,15-05-2025,APPLE INC,US0378331005,Dividend,,USD,2.50,USD,500.00,USD,",
+      ].join("\n");
+
+      expect(degiroParser.detect(csv)).toBe(true);
+      const result = degiroParser.parse(csv);
+      expect(result.cashTransactions).toHaveLength(1);
+      expect(result.cashTransactions[0]!.type).toBe("Dividends");
+    });
+  });
+
+  describe("Account CSV — German language", () => {
+    it("should detect and parse German Account CSV", () => {
+      const csv = [
+        "Datum,Uhrzeit,Wertdatum,Produkt,ISIN,Beschreibung,Währung,,Änderung,,Kontostand,,Auftrags-ID",
+        "15-05-2025,00:00,15-05-2025,APPLE INC,US0378331005,Dividend,,USD,2.50,USD,500.00,USD,",
+      ].join("\n");
+
+      expect(degiroParser.detect(csv)).toBe(true);
+      const result = degiroParser.parse(csv);
+      expect(result.cashTransactions).toHaveLength(1);
+    });
+  });
+
+  describe("Transactions CSV — edge cases", () => {
+    it("should handle BOM in CSV", () => {
+      const csv = "\uFEFF" + TRANSACTIONS_CSV_EN;
+      const result = degiroParser.parse(csv);
+      expect(result.trades).toHaveLength(2);
+    });
+
+    it("should detect semicolon-delimited CSV", () => {
+      expect(degiroParser.detect(TRANSACTIONS_CSV_SEMICOLON)).toBe(true);
+    });
+  });
+
   describe("error handling", () => {
     it("should throw on empty input", () => {
       expect(() => degiroParser.parse("")).toThrow("vacío");

--- a/tests/parsers/etoro-xlsx.test.ts
+++ b/tests/parsers/etoro-xlsx.test.ts
@@ -23,8 +23,8 @@ function buildEtoroWorkbook(opts: {
   }
 
   // Write workbook to a buffer
-  const buf = XLSX.write(wb, { type: "buffer", bookType: "xlsx" });
-  return new Uint8Array(buf);
+  const buf = XLSX.write(wb, { type: "buffer", bookType: "xlsx" }) as Uint8Array;
+  return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
 }
 
 // ---------------------------------------------------------------------------
@@ -214,8 +214,8 @@ describe("eToro XLSX parsing", () => {
       const wb = XLSX.utils.book_new();
       const ws = XLSX.utils.aoa_to_sheet([["Dummy"]]);
       XLSX.utils.book_append_sheet(wb, ws, "Other");
-      const buf = XLSX.write(wb, { type: "buffer", bookType: "xlsx" });
-      const data = new Uint8Array(buf);
+      const buf = XLSX.write(wb, { type: "buffer", bookType: "xlsx" }) as Uint8Array;
+      const data = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
 
       const result = await parseEtoroXlsx(data);
       expect(result.trades).toHaveLength(0);

--- a/tests/parsers/etoro-xlsx.test.ts
+++ b/tests/parsers/etoro-xlsx.test.ts
@@ -249,4 +249,132 @@ describe("eToro XLSX parsing", () => {
       expect(result.trades).toHaveLength(0);
     });
   });
+
+  describe("parseEtoroXlsx — date format edge cases", () => {
+    it("should handle ISO date format (YYYY-MM-DD)", async () => {
+      const data = buildEtoroWorkbook({
+        closedPositions: [
+          CLOSED_POSITIONS_HEADER,
+          ["Buy AAPL", "1000", "5", "180", "195", "82.50", "2025-03-15 09:30:00", "2025-09-20 14:00:00", "Stocks", "1", "US0378331005"],
+        ],
+      });
+
+      const result = await parseEtoroXlsx(data);
+      expect(result.trades).toHaveLength(2);
+      expect(result.trades[0]!.tradeDate).toBe("20250315");
+      expect(result.trades[1]!.tradeDate).toBe("20250920");
+    });
+
+    it("should handle fallback date format (no match)", async () => {
+      const data = buildEtoroWorkbook({
+        closedPositions: [
+          CLOSED_POSITIONS_HEADER,
+          ["Buy AAPL", "1000", "5", "180", "195", "82.50", "20250315", "20250920", "Stocks", "1", "US0378331005"],
+        ],
+      });
+
+      const result = await parseEtoroXlsx(data);
+      expect(result.trades).toHaveLength(2);
+      expect(result.trades[0]!.tradeDate).toBe("20250315");
+    });
+  });
+
+  describe("parseEtoroXlsx — filtering edge cases", () => {
+    it("should skip rows with unparseable action", async () => {
+      const data = buildEtoroWorkbook({
+        closedPositions: [
+          CLOSED_POSITIONS_HEADER,
+          ["INVALID ACTION", "1000", "5", "180", "195", "82.50", "15/03/2025", "20/09/2025", "Stocks", "1", "US0378331005"],
+        ],
+      });
+
+      const result = await parseEtoroXlsx(data);
+      expect(result.trades).toHaveLength(0);
+    });
+
+    it("should skip rows with NaN units", async () => {
+      const data = buildEtoroWorkbook({
+        closedPositions: [
+          CLOSED_POSITIONS_HEADER,
+          ["Buy AAPL", "1000", "abc", "180", "195", "82.50", "15/03/2025", "20/09/2025", "Stocks", "1", "US0378331005"],
+        ],
+      });
+
+      const result = await parseEtoroXlsx(data);
+      expect(result.trades).toHaveLength(0);
+    });
+
+    it("should skip ETF-like type that doesn't match", async () => {
+      const data = buildEtoroWorkbook({
+        closedPositions: [
+          CLOSED_POSITIONS_HEADER,
+          ["Buy GOLD", "1000", "5", "180", "195", "82.50", "15/03/2025", "20/09/2025", "Commodity", "1", "XS0000000001"],
+        ],
+      });
+
+      const result = await parseEtoroXlsx(data);
+      expect(result.trades).toHaveLength(0);
+    });
+
+    it("should accept ETF type", async () => {
+      const data = buildEtoroWorkbook({
+        closedPositions: [
+          CLOSED_POSITIONS_HEADER,
+          ["Buy VWCE", "2000", "10", "100", "110", "100", "15/03/2025", "20/09/2025", "ETF", "1", "IE00BK5BQT80"],
+        ],
+      });
+
+      const result = await parseEtoroXlsx(data);
+      expect(result.trades).toHaveLength(2);
+    });
+
+    it("should handle row with no type column (missing column)", async () => {
+      const data = buildEtoroWorkbook({
+        closedPositions: [
+          // Header without Type and Leverage columns
+          ["Action", "Amount", "Units", "Open Rate", "Close Rate", "Profit(USD)", "Open Date", "Close Date", "ISIN"],
+          ["Buy AAPL", "1000", "5", "180", "195", "82.50", "15/03/2025", "20/09/2025", "US0378331005"],
+        ],
+      });
+
+      const result = await parseEtoroXlsx(data);
+      // Should still parse — no type/leverage filtering when columns missing
+      expect(result.trades).toHaveLength(2);
+    });
+
+    it("should handle Sell action", async () => {
+      const data = buildEtoroWorkbook({
+        closedPositions: [
+          CLOSED_POSITIONS_HEADER,
+          ["Sell AAPL", "1000", "5", "195", "180", "-82.50", "15/03/2025", "20/09/2025", "Stocks", "1", "US0378331005"],
+        ],
+      });
+
+      const result = await parseEtoroXlsx(data);
+      expect(result.trades).toHaveLength(2);
+      // eToro still creates buy + sell legs regardless of action direction
+      const buy = result.trades.find((t) => t.buySell === "BUY");
+      const sell = result.trades.find((t) => t.buySell === "SELL");
+      expect(buy).toBeDefined();
+      expect(sell).toBeDefined();
+    });
+  });
+
+  describe("parseEtoroXlsx — Spanish sheet names", () => {
+    it("should find sheets with Spanish names", async () => {
+      const wb = XLSX.utils.book_new();
+
+      const closedSheet = XLSX.utils.aoa_to_sheet([
+        CLOSED_POSITIONS_HEADER,
+        ["Buy AAPL", "1000", "5", "180", "195", "82.50", "15/03/2025", "20/09/2025", "Stocks", "1", "US0378331005"],
+      ]);
+      XLSX.utils.book_append_sheet(wb, closedSheet, "Posiciones Cerradas");
+
+      const buf = XLSX.write(wb, { type: "buffer", bookType: "xlsx" }) as Uint8Array;
+      const data = new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+
+      const result = await parseEtoroXlsx(data);
+      expect(result.trades).toHaveLength(2);
+    });
+  });
 });

--- a/tests/parsers/etoro-xlsx.test.ts
+++ b/tests/parsers/etoro-xlsx.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect } from "vitest";
+import { parseEtoroXlsx, detectEtoroXlsx } from "../../src/parsers/etoro.js";
+import * as XLSX from "xlsx";
+
+// ---------------------------------------------------------------------------
+// Helper: build a minimal eToro-like XLSX workbook in memory
+// ---------------------------------------------------------------------------
+
+function buildEtoroWorkbook(opts: {
+  closedPositions?: string[][];
+  dividends?: string[][];
+}): Uint8Array {
+  const wb = XLSX.utils.book_new();
+
+  if (opts.closedPositions) {
+    const ws = XLSX.utils.aoa_to_sheet(opts.closedPositions);
+    XLSX.utils.book_append_sheet(wb, ws, "Closed Positions");
+  }
+
+  if (opts.dividends) {
+    const ws = XLSX.utils.aoa_to_sheet(opts.dividends);
+    XLSX.utils.book_append_sheet(wb, ws, "Dividends");
+  }
+
+  // Write workbook to a buffer
+  const buf = XLSX.write(wb, { type: "buffer", bookType: "xlsx" });
+  return new Uint8Array(buf);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("eToro XLSX parsing", () => {
+  describe("detectEtoroXlsx", () => {
+    it("should detect a valid eToro XLSX", () => {
+      const data = buildEtoroWorkbook({
+        closedPositions: [
+          ["Action", "Amount", "Units", "Open Rate", "Close Rate", "Profit(USD)", "Open Date", "Close Date", "Type", "Leverage", "ISIN"],
+          ["Buy AAPL", "1000", "5", "180", "195", "82.50", "15/03/2025 09:30:00", "20/09/2025 14:00:00", "Stocks", "1", "US0378331005"],
+        ],
+      });
+      expect(detectEtoroXlsx(data)).toBe(true);
+    });
+
+    it("should reject non-ZIP data", () => {
+      const data = new Uint8Array([0x00, 0x01, 0x02, 0x03]);
+      expect(detectEtoroXlsx(data)).toBe(false);
+    });
+
+    it("should reject empty data", () => {
+      const data = new Uint8Array(0);
+      expect(detectEtoroXlsx(data)).toBe(false);
+    });
+  });
+
+  describe("parseEtoroXlsx — closed positions", () => {
+    it("should parse basic stock trades", async () => {
+      const data = buildEtoroWorkbook({
+        closedPositions: [
+          ["Action", "Amount", "Units", "Open Rate", "Close Rate", "Profit(USD)", "Open Date", "Close Date", "Type", "Leverage", "ISIN"],
+          ["Buy AAPL", "1000.00", "5.5", "180.00", "195.00", "82.50", "15/03/2025 09:30:00", "20/09/2025 14:00:00", "Stocks", "1", "US0378331005"],
+        ],
+      });
+
+      const result = await parseEtoroXlsx(data);
+      expect(result.trades).toHaveLength(2); // 1 buy + 1 sell
+      expect(result.trades[0]!.buySell).toBe("BUY");
+      expect(result.trades[0]!.symbol).toBe("AAPL");
+      expect(result.trades[0]!.isin).toBe("US0378331005");
+      expect(result.trades[1]!.buySell).toBe("SELL");
+    });
+
+    it("should skip CFDs (leverage > 1)", async () => {
+      const data = buildEtoroWorkbook({
+        closedPositions: [
+          ["Action", "Amount", "Units", "Open Rate", "Close Rate", "Profit(USD)", "Open Date", "Close Date", "Type", "Leverage", "ISIN"],
+          ["Buy AAPL", "1000", "5", "180", "195", "82.50", "15/03/2025 09:30:00", "20/09/2025 14:00:00", "Stocks", "1", "US0378331005"],
+          ["Buy EURUSD", "1000", "1000", "1.08", "1.09", "10", "01/04/2025", "01/05/2025", "CFD", "2", ""],
+        ],
+      });
+
+      const result = await parseEtoroXlsx(data);
+      // Only AAPL (stock, leverage 1) — CFD filtered out
+      expect(result.trades).toHaveLength(2); // 1 buy + 1 sell for AAPL only
+      expect(result.trades[0]!.symbol).toBe("AAPL");
+    });
+
+    it("should skip crypto", async () => {
+      const data = buildEtoroWorkbook({
+        closedPositions: [
+          ["Action", "Amount", "Units", "Open Rate", "Close Rate", "Profit(USD)", "Open Date", "Close Date", "Type", "Leverage", "ISIN"],
+          ["Buy BTC", "500", "0.01", "50000", "55000", "50", "01/01/2025", "01/03/2025", "Crypto", "1", ""],
+        ],
+      });
+
+      const result = await parseEtoroXlsx(data);
+      expect(result.trades).toHaveLength(0); // crypto filtered out
+    });
+
+    it("should handle multiple trades", async () => {
+      const data = buildEtoroWorkbook({
+        closedPositions: [
+          ["Action", "Amount", "Units", "Open Rate", "Close Rate", "Profit(USD)", "Open Date", "Close Date", "Type", "Leverage", "ISIN"],
+          ["Buy AAPL", "1000", "5", "180", "195", "82.50", "15/03/2025 09:30:00", "20/09/2025 14:00:00", "Stocks", "1", "US0378331005"],
+          ["Buy TSLA", "2000", "10", "200", "180", "-200", "01/02/2025", "15/06/2025", "Stocks", "1", "US88160R1014"],
+        ],
+      });
+
+      const result = await parseEtoroXlsx(data);
+      expect(result.trades).toHaveLength(4); // 2 buys + 2 sells
+      const symbols = result.trades.map((t) => t.symbol);
+      expect(symbols).toContain("AAPL");
+      expect(symbols).toContain("TSLA");
+    });
+
+    it("should parse dates in DD/MM/YYYY format", async () => {
+      const data = buildEtoroWorkbook({
+        closedPositions: [
+          ["Action", "Amount", "Units", "Open Rate", "Close Rate", "Profit(USD)", "Open Date", "Close Date", "Type", "Leverage", "ISIN"],
+          ["Buy AAPL", "1000", "5", "180", "195", "82.50", "15/03/2025 09:30:00", "20/09/2025 14:00:00", "Stocks", "1", "US0378331005"],
+        ],
+      });
+
+      const result = await parseEtoroXlsx(data);
+      expect(result.trades[0]!.tradeDate).toBe("20250315");
+      expect(result.trades[1]!.tradeDate).toBe("20250920");
+    });
+
+    it("should calculate proceeds from amount + profit", async () => {
+      const data = buildEtoroWorkbook({
+        closedPositions: [
+          ["Action", "Amount", "Units", "Open Rate", "Close Rate", "Profit(USD)", "Open Date", "Close Date", "Type", "Leverage", "ISIN"],
+          ["Buy AAPL", "1000", "5", "180", "195", "82.50", "15/03/2025", "20/09/2025", "Stocks", "1", "US0378331005"],
+        ],
+      });
+
+      const result = await parseEtoroXlsx(data);
+      const sell = result.trades[1]!;
+      // proceeds = amount + profit = 1000 + 82.50 = 1082.50
+      expect(sell.proceeds).toBe("1082.5");
+    });
+  });
+
+  describe("parseEtoroXlsx — dividends", () => {
+    it("should parse dividend entries", async () => {
+      const data = buildEtoroWorkbook({
+        closedPositions: [
+          ["Action", "Amount", "Units", "Open Rate", "Close Rate", "Profit(USD)", "Open Date", "Close Date", "Type", "Leverage", "ISIN"],
+        ],
+        dividends: [
+          ["Date of Payment", "Instrument Name", "Net Dividend Received (USD)", "Withholding Tax Amount (USD)", "ISIN"],
+          ["15/06/2025", "AAPL", "42.50", "7.50", "US0378331005"],
+          ["20/09/2025", "MSFT", "30.00", "5.30", "US5949181045"],
+        ],
+      });
+
+      const result = await parseEtoroXlsx(data);
+      const divs = result.cashTransactions.filter((c) => c.type === "Dividends");
+      const whts = result.cashTransactions.filter((c) => c.type === "Withholding Tax");
+
+      expect(divs).toHaveLength(2);
+      expect(whts).toHaveLength(2);
+      expect(divs[0]!.symbol).toBe("AAPL");
+      expect(divs[0]!.isin).toBe("US0378331005");
+    });
+
+    it("should include ISIN country code in dividend description", async () => {
+      const data = buildEtoroWorkbook({
+        dividends: [
+          ["Date of Payment", "Instrument Name", "Net Dividend Received (USD)", "Withholding Tax Amount (USD)", "ISIN"],
+          ["15/06/2025", "AAPL", "42.50", "7.50", "US0378331005"],
+        ],
+      });
+
+      const result = await parseEtoroXlsx(data);
+      const div = result.cashTransactions.find((c) => c.type === "Dividends")!;
+      expect(div.description).toContain("US");
+      expect(div.description).toContain("Dividend");
+    });
+
+    it("should compute gross from net + withholding", async () => {
+      const data = buildEtoroWorkbook({
+        dividends: [
+          ["Date of Payment", "Instrument Name", "Net Dividend Received (USD)", "Withholding Tax Amount (USD)", "ISIN"],
+          ["15/06/2025", "AAPL", "42.50", "7.50", "US0378331005"],
+        ],
+      });
+
+      const result = await parseEtoroXlsx(data);
+      const div = result.cashTransactions.find((c) => c.type === "Dividends")!;
+      // gross = net + abs(wht) = 42.50 + 7.50 = 50.00
+      expect(parseFloat(div.amount)).toBeCloseTo(50.00, 2);
+    });
+
+    it("should handle dividend with no withholding", async () => {
+      const data = buildEtoroWorkbook({
+        dividends: [
+          ["Date of Payment", "Instrument Name", "Net Dividend Received (USD)", "Withholding Tax Amount (USD)", "ISIN"],
+          ["15/06/2025", "VWCE", "100.00", "0", "IE00BK5BQT80"],
+        ],
+      });
+
+      const result = await parseEtoroXlsx(data);
+      const divs = result.cashTransactions.filter((c) => c.type === "Dividends");
+      const whts = result.cashTransactions.filter((c) => c.type === "Withholding Tax");
+      expect(divs).toHaveLength(1);
+      expect(whts).toHaveLength(0); // no withholding → no WHT entry
+    });
+  });
+
+  describe("parseEtoroXlsx — empty workbook", () => {
+    it("should handle workbook with no matching sheets", async () => {
+      const wb = XLSX.utils.book_new();
+      const ws = XLSX.utils.aoa_to_sheet([["Dummy"]]);
+      XLSX.utils.book_append_sheet(wb, ws, "Other");
+      const buf = XLSX.write(wb, { type: "buffer", bookType: "xlsx" });
+      const data = new Uint8Array(buf);
+
+      const result = await parseEtoroXlsx(data);
+      expect(result.trades).toHaveLength(0);
+      expect(result.cashTransactions).toHaveLength(0);
+    });
+
+    it("should handle empty closed positions sheet", async () => {
+      const data = buildEtoroWorkbook({
+        closedPositions: [
+          ["Action", "Amount", "Units", "Open Rate", "Close Rate", "Profit(USD)", "Open Date", "Close Date", "Type", "Leverage", "ISIN"],
+        ],
+      });
+
+      const result = await parseEtoroXlsx(data);
+      expect(result.trades).toHaveLength(0);
+    });
+  });
+});

--- a/tests/parsers/etoro-xlsx.test.ts
+++ b/tests/parsers/etoro-xlsx.test.ts
@@ -3,6 +3,20 @@ import { parseEtoroXlsx, detectEtoroXlsx } from "../../src/parsers/etoro.js";
 import * as XLSX from "xlsx";
 
 // ---------------------------------------------------------------------------
+// Shared constants
+// ---------------------------------------------------------------------------
+
+const CLOSED_POSITIONS_HEADER = [
+  "Action", "Amount", "Units", "Open Rate", "Close Rate", "Profit(USD)",
+  "Open Date", "Close Date", "Type", "Leverage", "ISIN",
+];
+
+const DIVIDENDS_HEADER = [
+  "Date of Payment", "Instrument Name", "Net Dividend Received (USD)",
+  "Withholding Tax Amount (USD)", "ISIN",
+];
+
+// ---------------------------------------------------------------------------
 // Helper: build a minimal eToro-like XLSX workbook in memory
 // ---------------------------------------------------------------------------
 
@@ -36,7 +50,7 @@ describe("eToro XLSX parsing", () => {
     it("should detect a valid eToro XLSX", () => {
       const data = buildEtoroWorkbook({
         closedPositions: [
-          ["Action", "Amount", "Units", "Open Rate", "Close Rate", "Profit(USD)", "Open Date", "Close Date", "Type", "Leverage", "ISIN"],
+          CLOSED_POSITIONS_HEADER,
           ["Buy AAPL", "1000", "5", "180", "195", "82.50", "15/03/2025 09:30:00", "20/09/2025 14:00:00", "Stocks", "1", "US0378331005"],
         ],
       });
@@ -58,23 +72,25 @@ describe("eToro XLSX parsing", () => {
     it("should parse basic stock trades", async () => {
       const data = buildEtoroWorkbook({
         closedPositions: [
-          ["Action", "Amount", "Units", "Open Rate", "Close Rate", "Profit(USD)", "Open Date", "Close Date", "Type", "Leverage", "ISIN"],
+          CLOSED_POSITIONS_HEADER,
           ["Buy AAPL", "1000.00", "5.5", "180.00", "195.00", "82.50", "15/03/2025 09:30:00", "20/09/2025 14:00:00", "Stocks", "1", "US0378331005"],
         ],
       });
 
       const result = await parseEtoroXlsx(data);
       expect(result.trades).toHaveLength(2); // 1 buy + 1 sell
-      expect(result.trades[0]!.buySell).toBe("BUY");
-      expect(result.trades[0]!.symbol).toBe("AAPL");
-      expect(result.trades[0]!.isin).toBe("US0378331005");
-      expect(result.trades[1]!.buySell).toBe("SELL");
+      const buy = result.trades.find((t) => t.buySell === "BUY");
+      const sell = result.trades.find((t) => t.buySell === "SELL");
+      expect(buy).toBeDefined();
+      expect(buy!.symbol).toBe("AAPL");
+      expect(buy!.isin).toBe("US0378331005");
+      expect(sell).toBeDefined();
     });
 
     it("should skip CFDs (leverage > 1)", async () => {
       const data = buildEtoroWorkbook({
         closedPositions: [
-          ["Action", "Amount", "Units", "Open Rate", "Close Rate", "Profit(USD)", "Open Date", "Close Date", "Type", "Leverage", "ISIN"],
+          CLOSED_POSITIONS_HEADER,
           ["Buy AAPL", "1000", "5", "180", "195", "82.50", "15/03/2025 09:30:00", "20/09/2025 14:00:00", "Stocks", "1", "US0378331005"],
           ["Buy EURUSD", "1000", "1000", "1.08", "1.09", "10", "01/04/2025", "01/05/2025", "CFD", "2", ""],
         ],
@@ -89,7 +105,7 @@ describe("eToro XLSX parsing", () => {
     it("should skip crypto", async () => {
       const data = buildEtoroWorkbook({
         closedPositions: [
-          ["Action", "Amount", "Units", "Open Rate", "Close Rate", "Profit(USD)", "Open Date", "Close Date", "Type", "Leverage", "ISIN"],
+          CLOSED_POSITIONS_HEADER,
           ["Buy BTC", "500", "0.01", "50000", "55000", "50", "01/01/2025", "01/03/2025", "Crypto", "1", ""],
         ],
       });
@@ -101,7 +117,7 @@ describe("eToro XLSX parsing", () => {
     it("should handle multiple trades", async () => {
       const data = buildEtoroWorkbook({
         closedPositions: [
-          ["Action", "Amount", "Units", "Open Rate", "Close Rate", "Profit(USD)", "Open Date", "Close Date", "Type", "Leverage", "ISIN"],
+          CLOSED_POSITIONS_HEADER,
           ["Buy AAPL", "1000", "5", "180", "195", "82.50", "15/03/2025 09:30:00", "20/09/2025 14:00:00", "Stocks", "1", "US0378331005"],
           ["Buy TSLA", "2000", "10", "200", "180", "-200", "01/02/2025", "15/06/2025", "Stocks", "1", "US88160R1014"],
         ],
@@ -117,7 +133,7 @@ describe("eToro XLSX parsing", () => {
     it("should parse dates in DD/MM/YYYY format", async () => {
       const data = buildEtoroWorkbook({
         closedPositions: [
-          ["Action", "Amount", "Units", "Open Rate", "Close Rate", "Profit(USD)", "Open Date", "Close Date", "Type", "Leverage", "ISIN"],
+          CLOSED_POSITIONS_HEADER,
           ["Buy AAPL", "1000", "5", "180", "195", "82.50", "15/03/2025 09:30:00", "20/09/2025 14:00:00", "Stocks", "1", "US0378331005"],
         ],
       });
@@ -130,7 +146,7 @@ describe("eToro XLSX parsing", () => {
     it("should calculate proceeds from amount + profit", async () => {
       const data = buildEtoroWorkbook({
         closedPositions: [
-          ["Action", "Amount", "Units", "Open Rate", "Close Rate", "Profit(USD)", "Open Date", "Close Date", "Type", "Leverage", "ISIN"],
+          CLOSED_POSITIONS_HEADER,
           ["Buy AAPL", "1000", "5", "180", "195", "82.50", "15/03/2025", "20/09/2025", "Stocks", "1", "US0378331005"],
         ],
       });
@@ -146,10 +162,10 @@ describe("eToro XLSX parsing", () => {
     it("should parse dividend entries", async () => {
       const data = buildEtoroWorkbook({
         closedPositions: [
-          ["Action", "Amount", "Units", "Open Rate", "Close Rate", "Profit(USD)", "Open Date", "Close Date", "Type", "Leverage", "ISIN"],
+          CLOSED_POSITIONS_HEADER,
         ],
         dividends: [
-          ["Date of Payment", "Instrument Name", "Net Dividend Received (USD)", "Withholding Tax Amount (USD)", "ISIN"],
+          DIVIDENDS_HEADER,
           ["15/06/2025", "AAPL", "42.50", "7.50", "US0378331005"],
           ["20/09/2025", "MSFT", "30.00", "5.30", "US5949181045"],
         ],
@@ -168,7 +184,7 @@ describe("eToro XLSX parsing", () => {
     it("should include ISIN country code in dividend description", async () => {
       const data = buildEtoroWorkbook({
         dividends: [
-          ["Date of Payment", "Instrument Name", "Net Dividend Received (USD)", "Withholding Tax Amount (USD)", "ISIN"],
+          DIVIDENDS_HEADER,
           ["15/06/2025", "AAPL", "42.50", "7.50", "US0378331005"],
         ],
       });
@@ -182,7 +198,7 @@ describe("eToro XLSX parsing", () => {
     it("should compute gross from net + withholding", async () => {
       const data = buildEtoroWorkbook({
         dividends: [
-          ["Date of Payment", "Instrument Name", "Net Dividend Received (USD)", "Withholding Tax Amount (USD)", "ISIN"],
+          DIVIDENDS_HEADER,
           ["15/06/2025", "AAPL", "42.50", "7.50", "US0378331005"],
         ],
       });
@@ -196,7 +212,7 @@ describe("eToro XLSX parsing", () => {
     it("should handle dividend with no withholding", async () => {
       const data = buildEtoroWorkbook({
         dividends: [
-          ["Date of Payment", "Instrument Name", "Net Dividend Received (USD)", "Withholding Tax Amount (USD)", "ISIN"],
+          DIVIDENDS_HEADER,
           ["15/06/2025", "VWCE", "100.00", "0", "IE00BK5BQT80"],
         ],
       });
@@ -225,7 +241,7 @@ describe("eToro XLSX parsing", () => {
     it("should handle empty closed positions sheet", async () => {
       const data = buildEtoroWorkbook({
         closedPositions: [
-          ["Action", "Amount", "Units", "Open Rate", "Close Rate", "Profit(USD)", "Open Date", "Close Date", "Type", "Leverage", "ISIN"],
+          CLOSED_POSITIONS_HEADER,
         ],
       });
 

--- a/tests/parsers/etoro.test.ts
+++ b/tests/parsers/etoro.test.ts
@@ -46,9 +46,52 @@ describe("etoroParser", () => {
     });
   });
 
+  describe("text mode parse — section detection", () => {
+    it("should parse trades from text with section markers", () => {
+      const text = [
+        "Closed Positions",
+        "Action,Amount,Units,Open Rate,Close Rate,Profit(USD),Open Date,Close Date,Type,Leverage,ISIN",
+        "Buy AAPL,1000.00,5.5,180.00,195.00,82.50,15/03/2025 09:30:00,20/09/2025 14:00:00,Stocks,1,US0378331005",
+      ].join("\n");
+
+      const result = etoroParser.parse(text);
+      expect(result.trades.length).toBeGreaterThanOrEqual(0);
+    });
+
+    it("should parse dividend section markers", () => {
+      const text = [
+        "Dividends",
+        "Date of Payment,Instrument Name,Net Dividend Received (USD),Withholding Tax Amount (USD),ISIN",
+        "15/06/2025,AAPL,42.50,7.50,US0378331005",
+      ].join("\n");
+
+      const result = etoroParser.parse(text);
+      expect(result).toBeDefined();
+    });
+
+    it("should handle Spanish section markers", () => {
+      const text = [
+        "Posiciones cerradas",
+        "Acción,Importe,Unidades,Tipo de apertura,Tipo de cierre,Ganancia,Fecha de apertura,Fecha de cierre,Tipo,Apalancamiento,ISIN",
+        "Comprar AAPL,1000.00,5,180.00,195.00,82.50,15/03/2025,20/09/2025,Stocks,1,US0378331005",
+      ].join("\n");
+
+      const result = etoroParser.parse(text);
+      expect(result).toBeDefined();
+    });
+
+    it("should detect Spanish headers in detect()", () => {
+      expect(etoroParser.detect("posiciones cerradas\ntipo de apertura,action")).toBe(true);
+    });
+  });
+
   describe("error handling", () => {
     it("should throw on empty input", () => {
       expect(() => etoroParser.parse("")).toThrow("vacío");
+    });
+
+    it("should throw on whitespace-only input", () => {
+      expect(() => etoroParser.parse("   \n  ")).toThrow("vacío");
     });
   });
 });

--- a/tests/parsers/ibkr.test.ts
+++ b/tests/parsers/ibkr.test.ts
@@ -113,4 +113,131 @@ describe("parseIbkrFlexXml", () => {
     expect(result.trades).toHaveLength(0);
     expect(result.cashTransactions).toHaveLength(0);
   });
+
+  it("should throw on missing FlexStatement", () => {
+    const xml = `<?xml version="1.0"?>
+    <FlexQueryResponse queryName="Test" type="AF">
+      <FlexStatements count="0">
+      </FlexStatements>
+    </FlexQueryResponse>`;
+
+    expect(() => parseIbkrFlexXml(xml)).toThrow("missing FlexStatement");
+  });
+
+  it("should parse corporate actions", () => {
+    const xml = `<?xml version="1.0"?>
+    <FlexQueryResponse queryName="Test" type="AF">
+      <FlexStatements count="1">
+        <FlexStatement accountId="U1234567" fromDate="20250101" toDate="20251231" period="LastYear">
+          <Trades />
+          <CashTransactions />
+          <CorporateActions>
+            <CorporateAction transactionID="CA001" accountId="U1234567" symbol="AAPL" description="AAPL Split 4:1"
+                             isin="US0378331005" currency="USD" reportDate="20250601" dateTime="20250601"
+                             quantity="30" amount="0" type="SO" actionDescription="AAPL(US0378331005) SPLIT 4 FOR 1" />
+          </CorporateActions>
+          <OpenPositions />
+          <SecuritiesInfo />
+        </FlexStatement>
+      </FlexStatements>
+    </FlexQueryResponse>`;
+
+    const result = parseIbkrFlexXml(xml);
+    expect(result.corporateActions).toHaveLength(1);
+    expect(result.corporateActions[0]!.symbol).toBe("AAPL");
+    expect(result.corporateActions[0]!.type).toBe("SO");
+    expect(result.corporateActions[0]!.quantity).toBe("30");
+    expect(result.corporateActions[0]!.actionDescription).toContain("SPLIT");
+  });
+
+  it("should parse open positions", () => {
+    const xml = `<?xml version="1.0"?>
+    <FlexQueryResponse queryName="Test" type="AF">
+      <FlexStatements count="1">
+        <FlexStatement accountId="U1234567" fromDate="20250101" toDate="20251231" period="LastYear">
+          <Trades />
+          <CashTransactions />
+          <CorporateActions />
+          <OpenPositions>
+            <OpenPosition accountId="U1234567" symbol="AAPL" description="APPLE INC"
+                          isin="US0378331005" currency="USD" assetCategory="STK"
+                          quantity="100" costBasisMoney="17500" costBasisPrice="175"
+                          markPrice="195" positionValue="19500" fifoPnlUnrealized="2000"
+                          fxRateToBase="0.92" />
+          </OpenPositions>
+          <SecuritiesInfo />
+        </FlexStatement>
+      </FlexStatements>
+    </FlexQueryResponse>`;
+
+    const result = parseIbkrFlexXml(xml);
+    expect(result.openPositions).toHaveLength(1);
+    expect(result.openPositions[0]!.symbol).toBe("AAPL");
+    expect(result.openPositions[0]!.quantity).toBe("100");
+    expect(result.openPositions[0]!.markPrice).toBe("195");
+    expect(result.openPositions[0]!.assetCategory).toBe("STK");
+  });
+
+  it("should parse multiple corporate actions as array", () => {
+    const xml = `<?xml version="1.0"?>
+    <FlexQueryResponse queryName="Test" type="AF">
+      <FlexStatements count="1">
+        <FlexStatement accountId="U1234567" fromDate="20250101" toDate="20251231" period="LastYear">
+          <Trades />
+          <CashTransactions />
+          <CorporateActions>
+            <CorporateAction transactionID="CA001" accountId="U1234567" symbol="OLD" description="Merger"
+                             isin="US1111111111" currency="USD" reportDate="20250601" dateTime="20250601"
+                             quantity="-100" amount="0" type="TC" actionDescription="TENDER" />
+            <CorporateAction transactionID="CA002" accountId="U1234567" symbol="NEW" description="Merger"
+                             isin="US2222222222" currency="USD" reportDate="20250601" dateTime="20250601"
+                             quantity="100" amount="0" type="TC" actionDescription="TENDER" />
+          </CorporateActions>
+          <OpenPositions />
+          <SecuritiesInfo />
+        </FlexStatement>
+      </FlexStatements>
+    </FlexQueryResponse>`;
+
+    const result = parseIbkrFlexXml(xml);
+    expect(result.corporateActions).toHaveLength(2);
+  });
+
+  it("should handle defaults for missing attributes", () => {
+    const xml = `<?xml version="1.0"?>
+    <FlexQueryResponse queryName="Test" type="AF">
+      <FlexStatements count="1">
+        <FlexStatement>
+          <Trades>
+            <Trade symbol="XYZ" />
+          </Trades>
+          <CashTransactions />
+          <CorporateActions />
+          <OpenPositions>
+            <OpenPosition symbol="XYZ" />
+          </OpenPositions>
+          <SecuritiesInfo>
+            <SecurityInfo symbol="XYZ" />
+          </SecuritiesInfo>
+        </FlexStatement>
+      </FlexStatements>
+    </FlexQueryResponse>`;
+
+    const result = parseIbkrFlexXml(xml);
+    const trade = result.trades[0]!;
+    expect(trade.symbol).toBe("XYZ");
+    expect(trade.isin).toBe("");
+    expect(trade.quantity).toBe("0");
+    expect(trade.buySell).toBe("BUY");
+    expect(trade.fxRateToBase).toBe("1");
+
+    const pos = result.openPositions[0]!;
+    expect(pos.symbol).toBe("XYZ");
+    expect(pos.quantity).toBe("0");
+    expect(pos.fxRateToBase).toBe("1");
+
+    const sec = result.securitiesInfo[0]!;
+    expect(sec.symbol).toBe("XYZ");
+    expect(sec.multiplier).toBe("1");
+  });
 });

--- a/tests/parsers/scalable.test.ts
+++ b/tests/parsers/scalable.test.ts
@@ -118,6 +118,90 @@ describe("scalableParser", () => {
     });
   });
 
+  describe("German status localization", () => {
+    it("should accept 'Ausgeführt' status", () => {
+      const csv = [
+        "date;time;status;reference;description;assetType;type;isin;shares;price;amount;fee;tax;currency",
+        "2025-03-15;09:15;Ausgeführt;REF001;iShares;Security;Buy;IE00B4L5Y983;10;80,00;-800,00;-1,50;0;EUR",
+      ].join("\n");
+      const result = scalableParser.parse(csv);
+      expect(result.trades).toHaveLength(1);
+      expect(result.trades[0]!.buySell).toBe("BUY");
+    });
+  });
+
+  describe("Spanish status localization", () => {
+    it("should accept 'Ejecutada' status", () => {
+      const csv = [
+        "date;time;status;reference;description;assetType;type;isin;shares;price;amount;fee;tax;currency",
+        "2025-03-15;09:15;Ejecutada;REF001;Vanguard;Security;Sell;IE00BK5BQT80;-5;120,00;600,00;-0,99;0;EUR",
+      ].join("\n");
+      const result = scalableParser.parse(csv);
+      expect(result.trades).toHaveLength(1);
+      expect(result.trades[0]!.buySell).toBe("SELL");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should skip rows with no ISIN", () => {
+      const csv = [
+        "date;time;status;reference;description;assetType;type;isin;shares;price;amount;fee;tax;currency",
+        "2025-03-15;09:15;Executed;REF001;Cash deposit;Cash;Deposit;;0;0;500,00;0;0;EUR",
+      ].join("\n");
+      const result = scalableParser.parse(csv);
+      expect(result.trades).toHaveLength(0);
+      expect(result.cashTransactions).toHaveLength(0);
+    });
+
+    it("should skip rows with zero shares for trades", () => {
+      const csv = [
+        "date;time;status;reference;description;assetType;type;isin;shares;price;amount;fee;tax;currency",
+        "2025-03-15;09:15;Executed;REF001;Test;Security;Buy;IE00BK5BQT80;0;100,00;0;0;0;EUR",
+      ].join("\n");
+      const result = scalableParser.parse(csv);
+      expect(result.trades).toHaveLength(0);
+    });
+
+    it("should skip unrecognized trade types", () => {
+      const csv = [
+        "date;time;status;reference;description;assetType;type;isin;shares;price;amount;fee;tax;currency",
+        "2025-03-15;09:15;Executed;REF001;Test;Security;Transfer;IE00BK5BQT80;5;100,00;-500;0;0;EUR",
+      ].join("\n");
+      const result = scalableParser.parse(csv);
+      expect(result.trades).toHaveLength(0);
+    });
+
+    it("should handle distribution with no withholding tax", () => {
+      const csv = [
+        "date;time;status;reference;description;assetType;type;isin;shares;price;amount;fee;tax;currency",
+        "2025-07-15;00:00;Executed;REF005;Vanguard;Security;Distribution;IE00BK5BQT80;0;0;15,50;0;0;EUR",
+      ].join("\n");
+      const result = scalableParser.parse(csv);
+      const divs = result.cashTransactions.filter((t) => t.type === "Dividends");
+      const whts = result.cashTransactions.filter((t) => t.type === "Withholding Tax");
+      expect(divs).toHaveLength(1);
+      expect(whts).toHaveLength(0);
+    });
+
+    it("should handle rows with empty status (treated as executed)", () => {
+      const csv = [
+        "date;time;status;reference;description;assetType;type;isin;shares;price;amount;fee;tax;currency",
+        "2025-03-15;09:15;;REF001;Test;Security;Buy;IE00BK5BQT80;5;100,00;-500;0;0;EUR",
+      ].join("\n");
+      const result = scalableParser.parse(csv);
+      expect(result.trades).toHaveLength(1);
+    });
+
+    it("should handle comma-delimited CSV", () => {
+      const csv = [
+        "date,time,status,reference,description,assetType,type,isin,shares,price,amount,fee,tax,currency",
+        "2025-03-15,09:15,Executed,REF001,iShares,Security,Buy,IE00B4L5Y983,10,80.00,-800.00,-1.50,0,EUR",
+      ].join("\n");
+      const result = scalableParser.parse(csv);
+      expect(result.trades).toHaveLength(1);
+    });
+  });
+
   describe("error handling", () => {
     it("should throw on empty input", () => {
       expect(() => scalableParser.parse("")).toThrow("vacío");


### PR DESCRIPTION
## Summary

- **Web UI dark/light mode**: system preference detection via `prefers-color-scheme`, manual 3-state toggle (auto/light/dark) with localStorage persistence
- **Sortable table columns**: click-to-sort on all operations and dividends table headers with asc/desc/none cycling and visual indicators
- **Enhanced responsive design**: tablet (1024px), phone (768px), and small phone (480px) breakpoints with full-width buttons and stacked controls
- **Modelo 720 A/M/C declaration types**: new `--previous-720` CLI flag compares current positions against prior year to auto-assign A (new), M (existing), or C (cancelled) types; generates "C" records for positions sold since last declaration; adds BOND to asset filter
- **PDF ECB rates**: new "Tipo ECB" column in operations table, ECB rate appended to dividend lines, explanatory footnote
- **Wording cleanup**: self-hosted messaging throughout, removed license references from footer/privacy badge
- **13 new Modelo 720 tests** (183 total, all passing)

## Test plan

- [x] `npm test` — 183 tests passing
- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — 0 errors
- [ ] Manual: verify dark/light mode toggle works in browser
- [ ] Manual: verify table sorting on operations and dividends
- [ ] Manual: verify responsive layout on mobile viewport

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: new --previous-720 option to compare Modelo 720 with prior-year data
  * Theme toggle with system-preference dark/light + responsive layouts
  * Sortable operations and dividends tables with visual indicators

* **Enhancements**
  * Modelo 720: includes bonds and explicit A/M/C (new/modified/cancelled) handling
  * PDF reports: show ECB rate column/fields and ECB footnote

* **Documentation**
  * README and ROADMAP updated (models, quick start, feature status)

* **Tests**
  * New and expanded test suites for parsing, generators, PDF and engine logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->