### PR TITLE
feat: Phase 5 — all asset types (options, futures, forex, bonds, CFDs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </p>
 
 <p align="center">
-  IBKR · Degiro · Scalable Capital · eToro · Freedom24 → Modelo 100 · Modelo 720 · D-6
+  IBKR · Degiro · Scalable Capital · eToro · Freedom24 · Coinbase · Binance · Kraken → Modelo 100 · Modelo 720 · D-6
 </p>
 
 <p align="center">
@@ -46,8 +46,11 @@ DeclaRenta automatiza todo esto.
 | Interactive Brokers | Flex Query XML | Trades, dividendos, corporate actions, posiciones |
 | Degiro | CSV (transacciones + cartera) | Delimitador auto-detectado (coma/punto y coma) |
 | Scalable Capital | CSV (14 columnas) | Incluye savings plans y distribuciones |
-| eToro | XLSX (cuenta completa) | Posiciones cerradas + dividendos, 6+ versiones de cabeceras |
+| eToro | XLSX (cuenta completa) | Posiciones cerradas + dividendos + CFDs, 6+ versiones de cabeceras |
 | Freedom24 | JSON (report export) | Trades, dividendos, retenciones |
+| Coinbase | CSV (historial de transacciones) | Crypto trades y conversiones |
+| Binance | CSV (historial de trades) | Spot trades de criptomonedas |
+| Kraken | CSV (trades/ledger) | Crypto trades y staking |
 
 Se pueden combinar ficheros de varios brokers en una sola ejecución para FIFO cruzado.
 
@@ -113,7 +116,8 @@ El broker se auto-detecta a partir del contenido del fichero. Se puede forzar co
 ## Motor fiscal
 
 - **FIFO estricto** con tipos de cambio ECB oficiales por fecha de operación
-- **Regla anti-churning** (Art. 33.5.f LIRPF): bloqueo de pérdidas si se recompra el mismo valor en 2 meses
+- **Todos los tipos de activo**: acciones, ETFs, opciones, futuros, forex, bonos, CFDs y criptomonedas
+- **Regla anti-churning** (Art. 33.5.f LIRPF): bloqueo de pérdidas si se recompra el mismo valor en 2 meses (aplica a acciones, fondos y bonos; excluye derivados, forex y crypto)
 - **Doble imposición** (Art. 80 LIRPF): deducción por retenciones en origen, desglosado por país
 - **Stock splits**: forward y reverse, con liquidación de fracciones (cash-in-lieu)
 - **Corporate actions**: fusiones (transferencia de coste) y spin-offs (distribución proporcional)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -87,7 +87,7 @@ DeclaRenta se alinea con el calendario tributario español. Cada release se plan
 ### v0.1.0 completado
 
 - [x] Validado con datos IBKR reales (1063 operaciones, 3 ejercicios)
-- [x] Tramos del ahorro 2025 verificados (28% >300K, Ley 7/2024)
+- [x] Tramos del ahorro 2025 verificados (30% >300K, Ley 7/2024)
 - [x] v0.1.0 publicado
 
 ### Tipos de activo soportados
@@ -312,15 +312,15 @@ Tareas:
 #### Opciones y futuros (IBKR)
 
 - [x] Parser de opciones IBKR: strike, expiry, put/call, multiplicador (campos putCall, strike, expiry, underlyingSymbol, underlyingIsin en Trade)
-- [x] Tratamiento fiscal: prima como coste/ingreso, ejercicio vs expiración vs cierre
-- [x] Opciones ejercidas: coste de la prima se suma al coste de adquisición de las acciones
+- [x] Tratamiento fiscal: prima como coste/ingreso, expiración y cierre vía FIFO
+- [ ] Opciones ejercidas: coste de la prima se suma al coste de adquisición de las acciones (pendiente: detectar ejercicio C;O y transferir prima a lote STK)
 - [x] Futuros: FIFO con multiplicador, ganancias/pérdidas como ganancia patrimonial
 
 #### Forex
 
 - [x] Operaciones forex spot: clasificación como ganancia/pérdida patrimonial
 - [x] Conversiones de divisa en IBKR (CASH asset category, FIFO por símbolo)
-- [x] Distinguir entre forex trading y conversiones de divisa para depósitos
+- [ ] Distinguir entre forex trading y conversiones de divisa para depósitos (pendiente: detectar FXCONV vs trades en Flex Query)
 
 #### Bonos y renta fija
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,7 +38,7 @@ DeclaRenta se alinea con el calendario tributario español. Cada release se plan
 
 ---
 
-## Estado actual (v1.0.0-rc)
+## Estado actual (v0.9.0)
 
 ### Lo que ya funciona
 
@@ -133,7 +133,7 @@ DeclaRenta se alinea con el calendario tributario español. Cada release se plan
 - [x] Parser IBKR Flex Query XML (`fast-xml-parser`, manejo de arrays)
 - [x] Motor ECB (SDMX API, cache, fallback festivos/fines de semana)
 - [x] Motor FIFO (lots, consumo parcial, `Decimal.js` everywhere)
-- [x] Detección anti-churning (Art. 33.5.f LIRPF, ventana de 2 meses)
+- [x] Detección anti-churning (Art. 33.5.f LIRPF, ventana de 2 meses — aplica a STK, FUND, BOND; excluye OPT, FUT, CFD, CASH, CRYPTO)
 - [x] Procesamiento dividendos + matching retenciones extranjeras
 - [x] Cálculo doble imposición (Art. 80 LIRPF, tramos del ahorro)
 - [x] Generador Modelo 720 (fixed-width 500 bytes, ISO-8859-15)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -220,7 +220,7 @@ Tareas:
 - [x] **Registry con auto-detección**: `detectBroker()`, `getBroker()`, `--broker` flag en CLI
 - [x] **Parser Degiro**: Transactions CSV (trades) + Account CSV (dividendos/retenciones). Multi-idioma ES/EN/NL/DE, auto-detect delimitador coma/punto y coma, números EU
 - [x] **Parser Scalable Capital**: CSV export (semicolon-delimited, EU numbers, filter `status=Executed`)
-- [x] **Parser eToro**: XLSX Account Statement (acciones y ETFs; excluye CFDs). Soporta 6+ versiones de columnas
+- [x] **Parser eToro**: XLSX Account Statement (acciones, ETFs y CFDs). Soporta 6+ versiones de columnas
 - [x] **Parser Freedom24**: JSON report (`trades.detailed[]`, `corporate_actions.detailed[]`)
 - [x] **FIFO cross-broker**: consolidar lots de múltiples brokers por ISIN
   - Un mismo ISIN comprado en IBKR y Degiro usa una sola cola FIFO

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,7 +38,7 @@ DeclaRenta se alinea con el calendario tributario español. Cada release se plan
 
 ---
 
-## Estado actual (v0.7.0)
+## Estado actual (v1.0.0-rc)
 
 ### Lo que ya funciona
 
@@ -97,11 +97,12 @@ DeclaRenta se alinea con el calendario tributario español. Cada release se plan
 | Acciones | `STK` | Sí | Sí | Sí | v0.1 |
 | ETFs / Fondos | `FUND` | Sí | Sí | Sí | v0.1 |
 | Opciones | `OPT` | Sí | — | — | v0.1 (multiplicador, FIFO por símbolo) |
-| Futuros | `FUT` | — | — | — | Planificado |
-| Bonos | `BOND` | — | — | — | Planificado |
-| Forex | `CASH` | — | — | — | Planificado |
+| Futuros | `FUT` | Sí | — | — | v0.10 |
+| Bonos | `BOND` | Sí | Sí (cupones) | Sí | v0.10 |
+| Forex | `CASH` | Sí | — | — | v0.10 |
 | Warrants | `WAR` | — | — | — | Planificado |
-| Crypto | N/A | — | — | — | Planificado (721) |
+| Crypto | N/A | Sí | — | — (721) | v0.7 |
+| CFDs | N/A | Sí | — | — | v0.10 (eToro) |
 
 ---
 
@@ -114,7 +115,7 @@ DeclaRenta se alinea con el calendario tributario español. Cada release se plan
 | **burocratin** | OSS (AGPL-3.0) | Gratis | IBKR, Degiro | 720, D-6 | Browser (WASM) | Solo genera 720 y D-6, no calcula IRPF; escrito en Rust/WASM (19 stars) |
 | **IBKR-RENTA** | OSS | Gratis | IBKR (CSV) | 100 | Browser | Single-file HTML; solo IBKR CSV (no Flex XML); sin 720/D-6; 1 star, creado mar 2026 |
 | **Asesor fiscal** | Servicio | 150-500 € | Cualquiera | Todos | Datos compartidos | Coste elevado, dependencia de tercero, tiempos de espera |
-| **DeclaRenta** | OSS (GPL-3.0) | **Gratis** | IBKR, Degiro, Scalable, eToro, Freedom24 | **100, 720, D-6** + 721 stub | **Browser-first, zero-server** | En desarrollo; IBKR validado con datos reales |
+| **DeclaRenta** | OSS (GPL-3.0) | **Gratis** | IBKR, Degiro, Scalable, eToro, Freedom24, Coinbase, Binance, Kraken | **100, 720, D-6** + 721 | **Browser-first, zero-server** | En desarrollo activo |
 
 **Hueco que cubre DeclaRenta**: no existe ninguna herramienta open source que cubra el ciclo completo (IRPF + 720 + D-6) con soporte multi-broker y privacidad total. burocratin solo hace 720/D-6. IBKR-RENTA solo hace Modelo 100 desde CSV. TaxDown cobra 239 € y sube los datos a la nube.
 
@@ -171,7 +172,7 @@ DeclaRenta se alinea con el calendario tributario español. Cada release se plan
   - Spin-off: distribuir coste entre parent y spin-off según ratio de mercado
 - [x] Posiciones cross-year: multi-fichero `--input` carga lots de ejercicios anteriores
 - [x] Comisiones: impuestos de transacción (STT, FTT) incluidos en coste/importe
-- [ ] Multi-divisa simultáneo: manejar correctamente compras en USD pagadas con GBP
+- [x] Multi-divisa simultáneo: compras en USD pagadas con GBP manejadas correctamente con tipos ECB separados
 - [x] Informe detallado por operación: divisa, tipo ECB compra/venta en JSON y CSV
 - [x] Dividendos en especie (scrip dividends): lotes con coste base de IBKR
 - [x] Payment In Lieu of Dividends: clasificación correcta como rendimiento
@@ -226,7 +227,7 @@ Tareas:
   - Orden cronológico global, no por broker
 - [x] Web UI: selector de broker → formato esperado → upload multi-fichero
 - [x] Tests por broker con fixtures sintéticos (Scalable 15, Freedom24 16, eToro 5, corporate actions 7)
-- [ ] Publicar **v0.3.0**
+- [x] Publicar **v0.3.0**
 
 **Criterio de éxito**: procesamiento correcto de exports reales de al menos 3 brokers distintos.
 
@@ -277,7 +278,7 @@ Tareas:
 - [x] Formato orientado a llevar al asesor fiscal o adjuntar a la declaración
 - [x] Incluir tipo ECB utilizado en cada operación para auditoría
 
-- [ ] Publicar **v0.5.0**
+- [x] Publicar **v0.5.0**
 
 **Criterio de éxito**: ficheros 720 y D-6 generados pasan validación de formato AEAT/BdE sin errores.
 
@@ -298,7 +299,7 @@ Tareas:
 - [x] **i18n**: castellano (default), catalán, euskera, gallego, inglés — selector de idioma en la UI
 - [x] **Deploy GitHub Pages**: workflow configurado, dominio custom ready
 - [x] **Responsive**: móvil, tablet, desktop
-- [ ] Publicar **v0.8.0**
+- [x] Publicar **v0.8.0**
 
 **Criterio de éxito**: un usuario sin experiencia técnica puede generar su informe en <3 minutos desde la web.
 
@@ -310,30 +311,30 @@ Tareas:
 
 #### Opciones y futuros (IBKR)
 
-- [ ] Parser de opciones IBKR: strike, expiry, put/call, multiplicador
-- [ ] Tratamiento fiscal: prima como coste/ingreso, ejercicio vs expiración vs cierre
-- [ ] Opciones ejercidas: coste de la prima se suma al coste de adquisición de las acciones
-- [ ] Futuros: liquidación diaria, ganancias/pérdidas como rendimiento del capital
+- [x] Parser de opciones IBKR: strike, expiry, put/call, multiplicador (campos putCall, strike, expiry, underlyingSymbol, underlyingIsin en Trade)
+- [x] Tratamiento fiscal: prima como coste/ingreso, ejercicio vs expiración vs cierre
+- [x] Opciones ejercidas: coste de la prima se suma al coste de adquisición de las acciones
+- [x] Futuros: FIFO con multiplicador, ganancias/pérdidas como ganancia patrimonial
 
 #### Forex
 
-- [ ] Operaciones forex spot: clasificación como ganancia/pérdida patrimonial
-- [ ] Conversiones de divisa en IBKR (no son trading, son cambio de base currency)
-- [ ] Distinguir entre forex trading y conversiones de divisa para depósitos
+- [x] Operaciones forex spot: clasificación como ganancia/pérdida patrimonial
+- [x] Conversiones de divisa en IBKR (CASH asset category, FIFO por símbolo)
+- [x] Distinguir entre forex trading y conversiones de divisa para depósitos
 
 #### Bonos y renta fija
 
-- [ ] Cupones: rendimiento del capital mobiliario (Casilla 0033)
-- [ ] Compraventa de bonos: ganancia/pérdida patrimonial
-- [ ] Letras del Tesoro extranjeras: tratamiento fiscal
+- [x] Cupones: rendimiento del capital mobiliario (Casilla 0033) — ya soportado vía Bond Interest Received/Paid
+- [x] Compraventa de bonos: ganancia/pérdida patrimonial vía FIFO
+- [x] Letras del Tesoro extranjeras: tratamiento fiscal como BOND
 
 #### CFDs
 
-- [ ] Nota: los CFDs tributan como ganancia/pérdida patrimonial (no como rendimiento)
-- [ ] Parser específico para eToro y XTB (principales plataformas de CFDs)
-- [ ] Soporte para posiciones cortas
+- [x] CFDs tributan como ganancia/pérdida patrimonial (no como rendimiento)
+- [x] Parser eToro CFDs (tipo CFD detectado por leverage > 1 o type "cfd")
+- [x] Soporte para posiciones cortas (warning + coste base 0)
 
-- [ ] Publicar **v0.9.0**
+- [x] Publicar **v0.9.0**
 
 ---
 

--- a/src/engine/fifo.ts
+++ b/src/engine/fifo.ts
@@ -13,9 +13,9 @@ import type { EcbRateMap } from "../types/ecb.js";
 import { getEcbRate } from "./ecb.js";
 import { daysBetween, normalizeDate } from "./dates.js";
 
-/** Lot grouping key: ISIN for stocks/funds, symbol for options (which lack ISINs) */
-function lotKey(trade: { isin: string; symbol: string }): string {
-  return trade.isin || trade.symbol;
+/** Lot grouping key: ISIN when available; otherwise asset category + symbol to prevent cross-type collisions */
+function lotKey(trade: { isin: string; symbol: string; assetCategory: string }): string {
+  return trade.isin || `${trade.assetCategory}:${trade.symbol}`;
 }
 
 export class FifoEngine {

--- a/src/engine/fifo.ts
+++ b/src/engine/fifo.ts
@@ -13,6 +13,9 @@ import type { EcbRateMap } from "../types/ecb.js";
 import { getEcbRate } from "./ecb.js";
 import { daysBetween, normalizeDate } from "./dates.js";
 
+/** Known asset categories — warn on unknown values to catch future IBKR additions */
+const KNOWN_CATEGORIES: ReadonlySet<string> = new Set(["STK", "OPT", "FUT", "CASH", "BOND", "FUND", "WAR", "CRYPTO", "CFD"]);
+
 /** Lot grouping key: ISIN when available; otherwise asset category + symbol to prevent cross-type collisions */
 function lotKey(trade: { isin: string; symbol: string; assetCategory: string }): string {
   return trade.isin || `${trade.assetCategory}:${trade.symbol}`;
@@ -34,7 +37,12 @@ export class FifoEngine {
     // Process all tradeable asset types (STK, FUND, OPT, FUT, BOND, CASH/forex, CFD, CRYPTO)
     // Only WAR (warrants) is excluded — insufficient data for fiscal treatment
     const sorted = [...trades]
-      .filter((t) => t.assetCategory !== "WAR")
+      .filter((t) => {
+        if (!KNOWN_CATEGORIES.has(t.assetCategory)) {
+          this.warnings.push(`⚠ Categoría de activo desconocida: "${t.assetCategory}" para ${t.symbol}. Se procesará con FIFO genérico.`);
+        }
+        return t.assetCategory !== "WAR";
+      })
       .sort((a, b) => normalizeDate(a.tradeDate).localeCompare(normalizeDate(b.tradeDate)));
 
     // Parse splits from corporate actions (deduplicate by ISIN+date)
@@ -206,7 +214,7 @@ export class FifoEngine {
     }
 
     const direction = split.ratio >= 1 ? "forward" : "reverse";
-    console.error(`  ⚡ Split ${split.isin} ${split.ratio}:1 (${direction}) aplicado (${split.date})`);
+    this.warnings.push(`⚡ Split ${split.isin} ${split.ratio}:1 (${direction}) aplicado (${split.date})`);
   }
 
   private addScripDividendLot(sd: { key: string; isin: string; symbol: string; description: string; date: string; quantity: Decimal; pricePerShare: Decimal; costInEur: Decimal; currency: string; ecbRate: Decimal }): void {

--- a/src/engine/fifo.ts
+++ b/src/engine/fifo.ts
@@ -31,8 +31,10 @@ export class FifoEngine {
    * Buys add lots; sells consume lots via FIFO; splits adjust lots.
    */
   processTrades(trades: Trade[], rateMap: EcbRateMap, corporateActions?: CorporateAction[]): FifoDisposal[] {
+    // Process all tradeable asset types (STK, FUND, OPT, FUT, BOND, CASH/forex, CFD, CRYPTO)
+    // Only WAR (warrants) is excluded — insufficient data for fiscal treatment
     const sorted = [...trades]
-      .filter((t) => t.assetCategory === "STK" || t.assetCategory === "FUND" || t.assetCategory === "OPT")
+      .filter((t) => t.assetCategory !== "WAR")
       .sort((a, b) => normalizeDate(a.tradeDate).localeCompare(normalizeDate(b.tradeDate)));
 
     // Parse splits from corporate actions (deduplicate by ISIN+date)

--- a/src/engine/wash-sale.ts
+++ b/src/engine/wash-sale.ts
@@ -10,6 +10,9 @@ import type { FifoDisposal } from "../types/tax.js";
 import type { Trade } from "../types/ibkr.js";
 import { parseDate } from "./dates.js";
 
+/** Asset categories exempt from anti-churning (not "valores homogéneos" per Art. 33.5.f) */
+const WASH_SALE_EXEMPT: ReadonlySet<string> = new Set(["OPT", "FUT", "CFD", "CASH", "CRYPTO"]);
+
 /** Add/subtract calendar months (Art. 33.5.f says "dos meses", not 60 days). */
 function addMonths(date: Date, months: number): Date {
   const result = new Date(date);
@@ -34,8 +37,8 @@ export function detectWashSales(disposals: FifoDisposal[], allTrades: Trade[]): 
   // Index all buy dates by ISIN
   for (const trade of allTrades) {
     // Anti-churning applies to STK, FUND, and BOND (homogeneous securities)
-    // Excluded: OPT, FUT, CFD, CASH (derivatives and forex are not "valores homogéneos")
-    if (trade.buySell === "BUY" && (trade.assetCategory === "STK" || trade.assetCategory === "FUND" || trade.assetCategory === "BOND")) {
+    // Excluded: OPT, FUT, CFD, CASH, CRYPTO (derivatives, forex, and crypto are not "valores homogéneos")
+    if (trade.buySell === "BUY" && !WASH_SALE_EXEMPT.has(trade.assetCategory)) {
       if (!buysByIsin.has(trade.isin)) {
         buysByIsin.set(trade.isin, []);
       }
@@ -49,9 +52,8 @@ export function detectWashSales(disposals: FifoDisposal[], allTrades: Trade[]): 
       return disposal;
     }
 
-    // Anti-churning does NOT apply to derivatives, forex, or CFDs
-    if (disposal.assetCategory === "OPT" || disposal.assetCategory === "FUT" ||
-        disposal.assetCategory === "CFD" || disposal.assetCategory === "CASH") {
+    // Anti-churning does NOT apply to derivatives, forex, CFDs, or crypto
+    if (WASH_SALE_EXEMPT.has(disposal.assetCategory)) {
       return disposal;
     }
 

--- a/src/engine/wash-sale.ts
+++ b/src/engine/wash-sale.ts
@@ -33,7 +33,9 @@ export function detectWashSales(disposals: FifoDisposal[], allTrades: Trade[]): 
 
   // Index all buy dates by ISIN
   for (const trade of allTrades) {
-    if (trade.buySell === "BUY" && (trade.assetCategory === "STK" || trade.assetCategory === "FUND")) {
+    // Anti-churning applies to STK, FUND, and BOND (homogeneous securities)
+    // Excluded: OPT, FUT, CFD, CASH (derivatives and forex are not "valores homogéneos")
+    if (trade.buySell === "BUY" && (trade.assetCategory === "STK" || trade.assetCategory === "FUND" || trade.assetCategory === "BOND")) {
       if (!buysByIsin.has(trade.isin)) {
         buysByIsin.set(trade.isin, []);
       }
@@ -47,8 +49,9 @@ export function detectWashSales(disposals: FifoDisposal[], allTrades: Trade[]): 
       return disposal;
     }
 
-    // Anti-churning does NOT apply to options (CALL/PUT)
-    if (disposal.assetCategory === "OPT") {
+    // Anti-churning does NOT apply to derivatives, forex, or CFDs
+    if (disposal.assetCategory === "OPT" || disposal.assetCategory === "FUT" ||
+        disposal.assetCategory === "CFD" || disposal.assetCategory === "CASH") {
       return disposal;
     }
 

--- a/src/generators/d6.ts
+++ b/src/generators/d6.ts
@@ -89,7 +89,7 @@ export function generateD6Report(
   const yearEnd = `${year}-12-31`;
 
   const d6Positions: D6Position[] = positions
-    .filter((p) => p.assetCategory === "STK" || p.assetCategory === "FUND")
+    .filter((p) => p.assetCategory === "STK" || p.assetCategory === "FUND" || p.assetCategory === "BOND")
     .filter((p) => {
       // Only foreign positions (non-Spanish ISINs)
       const country = p.isin.slice(0, 2).toUpperCase();

--- a/src/generators/d6.ts
+++ b/src/generators/d6.ts
@@ -46,8 +46,10 @@ export interface D6Report {
   guide: string[];
 }
 
-/** Map ISIN country prefix to AFORIX exchange code (best-effort) */
-function exchangeFromIsin(isin: string): string {
+/** Map ISIN country prefix to AFORIX exchange code (best-effort, equities only) */
+function exchangeFromIsin(isin: string, assetCategory?: string): string {
+  // Bonds trade OTC or on dedicated platforms, not equity exchanges
+  if (assetCategory === "BOND") return "XOTC";
   const country = isin.slice(0, 2).toUpperCase();
   const map: Record<string, string> = {
     US: "XNYS", // NYSE (default for US)
@@ -104,7 +106,7 @@ export function generateD6Report(
         isin: p.isin,
         description: p.description,
         countryCode: p.isin.slice(0, 2).toUpperCase(),
-        exchangeCode: exchangeFromIsin(p.isin),
+        exchangeCode: exchangeFromIsin(p.isin, p.assetCategory),
         sharesAtYearEnd: new Decimal(p.quantity).toString(),
         marketValueEur: valueEur.toFixed(2),
         currency: p.currency,

--- a/src/parsers/etoro.ts
+++ b/src/parsers/etoro.ts
@@ -132,10 +132,12 @@ function parseClosedPositions(xlsx: typeof import("xlsx"), sheet: WorkSheet): Tr
     // Skip unknown/unsupported types (e.g. crypto on eToro — use dedicated crypto parsers)
     if (rowType && !rowType.includes("stock") && !rowType.includes("etf") &&
         !rowType.includes("accion") && !rowType.includes("cfd") &&
-        !rowType.includes("index") && !rowType.includes("indice")) continue;
+        !rowType.includes("index") && !rowType.includes("indice") &&
+        !rowType.includes("commodit")) continue;
 
-    // CFD: leverage > 1 OR type explicitly says "cfd"
-    const isCfd = leverage !== "1" || rowType.includes("cfd");
+    // CFD: leverage > 1 OR type explicitly says "cfd" OR commodity (always derivative on eToro)
+    const leverageNum = parseFloat(leverage);
+    const isCfd = (!isNaN(leverageNum) && leverageNum > 1) || rowType.includes("cfd") || rowType.includes("commodit");
     const assetCat = isCfd ? "CFD" as const : "STK" as const;
 
     const actionStr = row[actionCol] ?? "";

--- a/src/parsers/etoro.ts
+++ b/src/parsers/etoro.ts
@@ -135,7 +135,7 @@ function parseClosedPositions(xlsx: typeof import("xlsx"), sheet: WorkSheet): Tr
         !rowType.includes("index") && !rowType.includes("indice")) continue;
 
     // CFD: leverage > 1 OR type explicitly says "cfd"
-    const isCfd = (leverage && leverage !== "1") || rowType.includes("cfd");
+    const isCfd = leverage !== "1" || rowType.includes("cfd");
     const assetCat = isCfd ? "CFD" as const : "STK" as const;
 
     const actionStr = row[actionCol] ?? "";

--- a/src/parsers/etoro.ts
+++ b/src/parsers/etoro.ts
@@ -131,7 +131,8 @@ function parseClosedPositions(xlsx: typeof import("xlsx"), sheet: WorkSheet): Tr
 
     // Skip unknown/unsupported types (e.g. crypto on eToro — use dedicated crypto parsers)
     if (rowType && !rowType.includes("stock") && !rowType.includes("etf") &&
-        !rowType.includes("accion") && !rowType.includes("cfd")) continue;
+        !rowType.includes("accion") && !rowType.includes("cfd") &&
+        !rowType.includes("index") && !rowType.includes("indice")) continue;
 
     // CFD: leverage > 1 OR type explicitly says "cfd"
     const isCfd = (leverage && leverage !== "1") || rowType.includes("cfd");

--- a/src/parsers/etoro.ts
+++ b/src/parsers/etoro.ts
@@ -125,17 +125,17 @@ function parseClosedPositions(xlsx: typeof import("xlsx"), sheet: WorkSheet): Tr
     const row = rows[i]!;
     if (!row.length) continue;
 
-    // Filter: only real stocks/ETFs (leverage = 1)
-    if (leverageCol >= 0) {
-      const leverage = (row[leverageCol] ?? "").trim();
-      if (leverage && leverage !== "1") continue;
-    }
+    // Determine asset category from type and leverage
+    const leverage = leverageCol >= 0 ? (row[leverageCol] ?? "").trim() : "1";
+    const rowType = typeCol >= 0 ? (row[typeCol] ?? "").toLowerCase().trim() : "";
 
-    // Filter: only stocks and ETFs
-    if (typeCol >= 0) {
-      const type = (row[typeCol] ?? "").toLowerCase().trim();
-      if (type && !type.includes("stock") && !type.includes("etf") && !type.includes("accion")) continue;
-    }
+    // Skip unknown/unsupported types (e.g. crypto on eToro — use dedicated crypto parsers)
+    if (rowType && !rowType.includes("stock") && !rowType.includes("etf") &&
+        !rowType.includes("accion") && !rowType.includes("cfd")) continue;
+
+    // CFD: leverage > 1 OR type explicitly says "cfd"
+    const isCfd = (leverage && leverage !== "1") || rowType.includes("cfd");
+    const assetCat = isCfd ? "CFD" as const : "STK" as const;
 
     const actionStr = row[actionCol] ?? "";
     const parsed = parseAction(actionStr);
@@ -164,7 +164,7 @@ function parseClosedPositions(xlsx: typeof import("xlsx"), sheet: WorkSheet): Tr
       symbol: parsed.symbol,
       description: parsed.symbol,
       isin,
-      assetCategory: "STK",
+      assetCategory: assetCat,
       currency: "USD",
       tradeDate: openDate,
       settlementDate: openDate,
@@ -195,7 +195,7 @@ function parseClosedPositions(xlsx: typeof import("xlsx"), sheet: WorkSheet): Tr
       symbol: parsed.symbol,
       description: parsed.symbol,
       isin,
-      assetCategory: "STK",
+      assetCategory: assetCat,
       currency: "USD",
       tradeDate: closeDate,
       settlementDate: closeDate,

--- a/src/parsers/etoro.ts
+++ b/src/parsers/etoro.ts
@@ -136,7 +136,8 @@ function parseClosedPositions(xlsx: typeof import("xlsx"), sheet: WorkSheet): Tr
         !rowType.includes("commodit")) continue;
 
     // CFD: leverage > 1 OR type explicitly says "cfd" OR commodity (always derivative on eToro)
-    const leverageNum = parseFloat(leverage);
+    // Strip non-numeric prefixes (e.g. "x5", "X10") before parsing
+    const leverageNum = parseFloat(leverage.replace(/^[xX]/, ""));
     const isCfd = (!isNaN(leverageNum) && leverageNum > 1) || rowType.includes("cfd") || rowType.includes("commodit");
     const assetCat = isCfd ? "CFD" as const : "STK" as const;
 

--- a/src/parsers/ibkr.ts
+++ b/src/parsers/ibkr.ts
@@ -101,6 +101,11 @@ function mapTrade(raw: Record<string, string>): Trade {
     commission: raw.commission ?? "0",
     taxes: raw.taxes ?? "0",
     multiplier: raw.multiplier ?? "1",
+    putCall: raw.putCall as Trade["putCall"] | undefined,
+    strike: raw.strike || undefined,
+    expiry: raw.expiry || undefined,
+    underlyingSymbol: raw.underlyingSymbol || undefined,
+    underlyingIsin: raw.underlyingIsin || undefined,
   };
 }
 

--- a/src/parsers/ibkr.ts
+++ b/src/parsers/ibkr.ts
@@ -101,7 +101,7 @@ function mapTrade(raw: Record<string, string>): Trade {
     commission: raw.commission ?? "0",
     taxes: raw.taxes ?? "0",
     multiplier: raw.multiplier ?? "1",
-    putCall: raw.putCall as Trade["putCall"] | undefined,
+    putCall: raw.putCall === "P" || raw.putCall === "C" ? raw.putCall : undefined,
     strike: raw.strike || undefined,
     expiry: raw.expiry || undefined,
     underlyingSymbol: raw.underlyingSymbol || undefined,

--- a/src/types/ibkr.ts
+++ b/src/types/ibkr.ts
@@ -41,6 +41,16 @@ export interface Trade {
   multiplier: string;
   /** Optional: which broker produced this trade (for cross-broker reports) */
   brokerSource?: string;
+  /** Option put/call indicator */
+  putCall?: "P" | "C";
+  /** Option/future strike price */
+  strike?: string;
+  /** Option/future expiry date (YYYYMMDD) */
+  expiry?: string;
+  /** Underlying symbol for derivatives */
+  underlyingSymbol?: string;
+  /** Underlying ISIN for derivatives */
+  underlyingIsin?: string;
 }
 
 export interface CashTransaction {
@@ -111,4 +121,4 @@ export interface SecurityInfo {
   subCategory: string;
 }
 
-export type AssetCategory = "STK" | "OPT" | "FUT" | "CASH" | "BOND" | "FUND" | "WAR" | "CRYPTO";
+export type AssetCategory = "STK" | "OPT" | "FUT" | "CASH" | "BOND" | "FUND" | "WAR" | "CRYPTO" | "CFD";

--- a/src/web/docs.html
+++ b/src/web/docs.html
@@ -6,7 +6,7 @@
   <title>DeclaRenta - Documentación</title>
   <meta name="description" content="Documentación completa de DeclaRenta: brokers soportados, casillas del Modelo 100, FIFO, doble imposición, Modelo 720, D-6 y más." />
   <meta name="theme-color" content="#3b82f6" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://data-api.ecb.europa.eu; img-src 'self' data:; frame-ancestors 'none'" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://data-api.ecb.europa.eu; img-src 'self' data:; frame-ancestors 'none'" />
   <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📊</text></svg>" />
   <link rel="stylesheet" href="./style.css" />
@@ -642,7 +642,7 @@ declarenta d6 --input informe.xml --year 2025 --nif 12345678A --name "Apellidos,
           <li>Si existe recompra, marca la operación como <code>washSaleBlocked = true</code>.</li>
           <li>Las operaciones bloqueadas aparecen resaltadas en la tabla de resultados.</li>
         </ol>
-        <p class="warning">La regla anti-churning <strong>no se aplica a opciones</strong> (categorías OPT/CALL/PUT), solo a acciones (STK) y fondos (FUND).</p>
+        <p class="warning">La regla anti-churning solo se aplica a <strong>valores homogéneos</strong>: acciones (STK), fondos (FUND) y bonos (BOND). <strong>No se aplica</strong> a opciones (OPT), futuros (FUT), CFDs, forex (CASH) ni criptomonedas.</p>
       </section>
 
       <!-- 6. Doble imposición -->

--- a/src/web/docs.html
+++ b/src/web/docs.html
@@ -6,6 +6,8 @@
   <title>DeclaRenta - Documentación</title>
   <meta name="description" content="Documentación completa de DeclaRenta: brokers soportados, casillas del Modelo 100, FIFO, doble imposición, Modelo 720, D-6 y más." />
   <meta name="theme-color" content="#3b82f6" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://data-api.ecb.europa.eu; img-src 'self' data:; frame-ancestors 'none'" />
+  <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📊</text></svg>" />
   <link rel="stylesheet" href="./style.css" />
   <style>
@@ -860,7 +862,7 @@ declarenta d6 --input informe.xml --year 2025 --nif 12345678A --name "Apellidos,
         <p>Las opciones se procesan con FIFO por símbolo (no tienen ISIN). El multiplicador del contrato (normalmente 100) se aplica automáticamente al calcular costes e importes de venta. DeclaRenta extrae los campos <code>putCall</code>, <code>strike</code>, <code>expiry</code> y <code>underlyingSymbol</code> del Flex Query XML de IBKR.</p>
         <ul>
           <li><strong>Compraventa de opciones</strong>: la prima pagada es el coste de adquisición; la prima recibida al vender es el valor de transmisión.</li>
-          <li><strong>Opciones ejercidas</strong>: el coste de la prima se integra en el coste de adquisición de las acciones subyacentes.</li>
+          <li><strong>Opciones ejercidas</strong>: en el futuro, el coste de la prima se integrará en el coste de adquisición de las acciones subyacentes. Actualmente, el ejercicio se procesa como cierre estándar de la posición de opciones.</li>
           <li><strong>Opciones que expiran sin valor</strong>: la prima pagada se declara como pérdida patrimonial total.</li>
         </ul>
         <p class="muted">La regla anti-churning (Art. 33.5.f) no se aplica a opciones.</p>
@@ -871,7 +873,7 @@ declarenta d6 --input informe.xml --year 2025 --nif 12345678A --name "Apellidos,
 
         <h3>Forex (CASH)</h3>
         <p>Las operaciones de compraventa de divisas (forex spot) tributan como ganancias y pérdidas patrimoniales. DeclaRenta las procesa con FIFO por par de divisas (símbolo). Los tipos de cambio ECB se aplican tanto a la compra como a la venta.</p>
-        <p>Las conversiones de divisa en IBKR (cambiar USD a EUR para depositar) se registran como operaciones CASH. Si generas ganancia o pérdida por la fluctuación del tipo de cambio entre la compra y la venta de la divisa, esta se declara como ganancia patrimonial.</p>
+        <p>Las conversiones de divisa en IBKR (cambiar USD a EUR para depositar) se registran como operaciones CASH. Actualmente, DeclaRenta no distingue entre conversiones de divisa (FXCONV) y operaciones de trading de forex; todas se procesan con FIFO. Si generas ganancia o pérdida por la fluctuación del tipo de cambio entre la compra y la venta de la divisa, esta se declara como ganancia patrimonial.</p>
         <p class="muted">La regla anti-churning no se aplica a operaciones forex.</p>
 
         <h3>Bonos y renta fija (BOND)</h3>

--- a/src/web/docs.html
+++ b/src/web/docs.html
@@ -7,7 +7,6 @@
   <meta name="description" content="Documentación completa de DeclaRenta: brokers soportados, casillas del Modelo 100, FIFO, doble imposición, Modelo 720, D-6 y más." />
   <meta name="theme-color" content="#3b82f6" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://data-api.ecb.europa.eu; img-src 'self' data:; frame-ancestors 'none'" />
-  <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📊</text></svg>" />
   <link rel="stylesheet" href="./style.css" />
   <style>
@@ -882,7 +881,7 @@ declarenta d6 --input informe.xml --year 2025 --nif 12345678A --name "Apellidos,
         <p class="muted">La regla anti-churning sí se aplica a bonos (son valores homogéneos).</p>
 
         <h3>CFDs (Contratos por Diferencia)</h3>
-        <p>Los CFDs tributan como ganancias y pérdidas patrimoniales, no como rendimientos del capital mobiliario. DeclaRenta detecta CFDs en eToro por el campo <code>leverage &gt; 1</code> o el tipo <code>"CFD"</code> en el informe.</p>
+        <p>Los CFDs tributan como ganancias y pérdidas patrimoniales, no como rendimientos del capital mobiliario. DeclaRenta detecta CFDs en eToro por el campo <code>leverage &gt; 1</code>, el tipo <code>"CFD"</code>, o el tipo <code>"Commodity"</code> (las materias primas en eToro son siempre CFDs). Se soportan acciones, índices y materias primas como CFDs.</p>
         <p>Las posiciones cortas en CFDs se soportan: si vendes primero sin lotes previos, DeclaRenta registra un coste base de 0 EUR y emite un aviso.</p>
         <p class="muted">La regla anti-churning no se aplica a CFDs. Los CFDs de criptomonedas no están soportados actualmente.</p>
       </section>

--- a/src/web/docs.html
+++ b/src/web/docs.html
@@ -348,9 +348,10 @@
         <li><a href="#modelo-d6">9. Modelo D-6</a></li>
         <li><a href="#modelo-721">10. Modelo 721</a></li>
         <li><a href="#acciones-corporativas">11. Acciones corporativas</a></li>
-        <li><a href="#faq">12. Preguntas frecuentes</a></li>
-        <li><a href="#privacidad">13. Privacidad y seguridad</a></li>
-        <li><a href="#referencia-legal">14. Referencia legal</a></li>
+        <li><a href="#otros-activos">12. Otros tipos de activo</a></li>
+        <li><a href="#faq">13. Preguntas frecuentes</a></li>
+        <li><a href="#privacidad">14. Privacidad y seguridad</a></li>
+        <li><a href="#referencia-legal">15. Referencia legal</a></li>
       </ol>
     </aside>
 
@@ -472,7 +473,7 @@ declarenta d6 --input informe.xml --year 2025 --nif 12345678A --name "Apellidos,
         </ol>
         <p><strong>Formato:</strong> XLSX (Excel) con pestaña "Closed Positions".</p>
         <p><strong>Datos extraídos:</strong> Posiciones cerradas con precios de apertura y cierre, dividendos.</p>
-        <p><strong>Limitaciones:</strong> eToro no proporciona ISINs directamente; DeclaRenta los mapea desde el nombre del activo. Las operaciones con CFDs no están soportadas.</p>
+        <p><strong>Limitaciones:</strong> eToro no proporciona ISINs directamente; DeclaRenta los mapea desde el nombre del activo. Los CFDs de acciones e índices se procesan; los CFDs de criptomonedas no están soportados.</p>
 
         <h3>Freedom24</h3>
         <h4>Cómo exportar el informe</h4>
@@ -850,9 +851,43 @@ declarenta d6 --input informe.xml --year 2025 --nif 12345678A --name "Apellidos,
         </ul>
       </section>
 
-      <!-- 12. FAQ -->
+      <!-- 12. Otros tipos de activo -->
+      <section id="otros-activos">
+        <h2>12. Otros tipos de activo</h2>
+        <p>Además de acciones (STK) y fondos (FUND), DeclaRenta procesa estos instrumentos financieros:</p>
+
+        <h3>Opciones (OPT)</h3>
+        <p>Las opciones se procesan con FIFO por símbolo (no tienen ISIN). El multiplicador del contrato (normalmente 100) se aplica automáticamente al calcular costes e importes de venta. DeclaRenta extrae los campos <code>putCall</code>, <code>strike</code>, <code>expiry</code> y <code>underlyingSymbol</code> del Flex Query XML de IBKR.</p>
+        <ul>
+          <li><strong>Compraventa de opciones</strong>: la prima pagada es el coste de adquisición; la prima recibida al vender es el valor de transmisión.</li>
+          <li><strong>Opciones ejercidas</strong>: el coste de la prima se integra en el coste de adquisición de las acciones subyacentes.</li>
+          <li><strong>Opciones que expiran sin valor</strong>: la prima pagada se declara como pérdida patrimonial total.</li>
+        </ul>
+        <p class="muted">La regla anti-churning (Art. 33.5.f) no se aplica a opciones.</p>
+
+        <h3>Futuros (FUT)</h3>
+        <p>Los contratos de futuros se procesan con FIFO por símbolo, aplicando el multiplicador del contrato. Las ganancias y pérdidas tributan como ganancias patrimoniales en la base del ahorro.</p>
+        <p class="muted">La regla anti-churning no se aplica a futuros.</p>
+
+        <h3>Forex (CASH)</h3>
+        <p>Las operaciones de compraventa de divisas (forex spot) tributan como ganancias y pérdidas patrimoniales. DeclaRenta las procesa con FIFO por par de divisas (símbolo). Los tipos de cambio ECB se aplican tanto a la compra como a la venta.</p>
+        <p>Las conversiones de divisa en IBKR (cambiar USD a EUR para depositar) se registran como operaciones CASH. Si generas ganancia o pérdida por la fluctuación del tipo de cambio entre la compra y la venta de la divisa, esta se declara como ganancia patrimonial.</p>
+        <p class="muted">La regla anti-churning no se aplica a operaciones forex.</p>
+
+        <h3>Bonos y renta fija (BOND)</h3>
+        <p>La compraventa de bonos tributa como ganancia o pérdida patrimonial, procesada con FIFO. Los cupones (intereses de bonos) se declaran como rendimiento del capital mobiliario en la Casilla 0033, al igual que los intereses de cuentas.</p>
+        <p>Las letras del Tesoro extranjeras reciben el mismo tratamiento fiscal que los bonos corporativos.</p>
+        <p class="muted">La regla anti-churning sí se aplica a bonos (son valores homogéneos).</p>
+
+        <h3>CFDs (Contratos por Diferencia)</h3>
+        <p>Los CFDs tributan como ganancias y pérdidas patrimoniales, no como rendimientos del capital mobiliario. DeclaRenta detecta CFDs en eToro por el campo <code>leverage &gt; 1</code> o el tipo <code>"CFD"</code> en el informe.</p>
+        <p>Las posiciones cortas en CFDs se soportan: si vendes primero sin lotes previos, DeclaRenta registra un coste base de 0 EUR y emite un aviso.</p>
+        <p class="muted">La regla anti-churning no se aplica a CFDs. Los CFDs de criptomonedas no están soportados actualmente.</p>
+      </section>
+
+      <!-- 13. FAQ -->
       <section id="faq">
-        <h2>12. Preguntas frecuentes</h2>
+        <h2>13. Preguntas frecuentes</h2>
 
         <dl>
           <div class="faq-item">
@@ -887,7 +922,7 @@ declarenta d6 --input informe.xml --year 2025 --nif 12345678A --name "Apellidos,
 
           <div class="faq-item">
             <dt>¿Se soportan los CFDs?</dt>
-            <dd>No. Los contratos por diferencia (CFDs) tienen un tratamiento fiscal distinto y no están soportados actualmente. Si tu broker ofrece operaciones en CFDs, estas serán ignoradas.</dd>
+            <dd>Sí, parcialmente. Los CFDs de acciones e índices en eToro se procesan como ganancias y pérdidas patrimoniales. Los CFDs de criptomonedas no están soportados. Otros brokers de CFDs (como XTB) están planificados para futuras versiones.</dd>
           </div>
 
           <div class="faq-item">
@@ -942,9 +977,9 @@ declarenta d6 --input informe.xml --year 2025 --nif 12345678A --name "Apellidos,
         </dl>
       </section>
 
-      <!-- 13. Privacidad y seguridad -->
+      <!-- 14. Privacidad y seguridad -->
       <section id="privacidad">
-        <h2>13. Privacidad y seguridad</h2>
+        <h2>14. Privacidad y seguridad</h2>
 
         <h3>Arquitectura sin servidor</h3>
         <p>DeclaRenta no tiene backend. No hay servidor que reciba tus datos. La aplicación web es un conjunto de ficheros estáticos (HTML, CSS, JavaScript) que se ejecutan íntegramente en tu navegador.</p>
@@ -962,9 +997,9 @@ declarenta d6 --input informe.xml --year 2025 --nif 12345678A --name "Apellidos,
         <p>El código fuente está disponible en <a href="https://github.com/GeiserX/DeclaRenta">GitHub</a> bajo licencia GPL-3.0. Cualquiera puede auditar el código, verificar que no hay transmisión de datos y contribuir mejoras.</p>
       </section>
 
-      <!-- 14. Referencia legal -->
+      <!-- 15. Referencia legal -->
       <section id="referencia-legal">
-        <h2>14. Referencia legal</h2>
+        <h2>15. Referencia legal</h2>
         <p>DeclaRenta implementa las siguientes normas de la legislación fiscal española:</p>
 
         <div class="table-wrapper">

--- a/src/web/docs.html
+++ b/src/web/docs.html
@@ -473,7 +473,7 @@ declarenta d6 --input informe.xml --year 2025 --nif 12345678A --name "Apellidos,
         </ol>
         <p><strong>Formato:</strong> XLSX (Excel) con pestaña "Closed Positions".</p>
         <p><strong>Datos extraídos:</strong> Posiciones cerradas con precios de apertura y cierre, dividendos.</p>
-        <p><strong>Limitaciones:</strong> eToro no proporciona ISINs directamente; DeclaRenta los mapea desde el nombre del activo. Los CFDs de acciones e índices se procesan; los CFDs de criptomonedas no están soportados.</p>
+        <p><strong>Limitaciones:</strong> eToro no proporciona ISINs directamente; DeclaRenta solo los utiliza si están presentes en el extracto exportado (no se infieren desde el nombre del activo). Los CFDs de acciones e índices se procesan; los CFDs de criptomonedas no están soportados.</p>
 
         <h3>Freedom24</h3>
         <h4>Cómo exportar el informe</h4>

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -8,7 +8,6 @@
   <meta name="theme-color" content="#3b82f6" />
   <link rel="manifest" href="./manifest.json" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://data-api.ecb.europa.eu; img-src 'self' data:; frame-ancestors 'none'" />
-  <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📊</text></svg>" />
   <link rel="stylesheet" href="./style.css" />
 </head>

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -7,6 +7,8 @@
   <meta name="description" content="Convierte reportes de IBKR, Degiro, Scalable Capital, eToro y Freedom24 en valores para tu declaración de la renta española. Self-hosted, privacidad total." />
   <meta name="theme-color" content="#3b82f6" />
   <link rel="manifest" href="./manifest.json" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://data-api.ecb.europa.eu; img-src 'self' data:; frame-ancestors 'none'" />
+  <meta http-equiv="X-Content-Type-Options" content="nosniff" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>📊</text></svg>" />
   <link rel="stylesheet" href="./style.css" />
 </head>

--- a/tests/engine/fifo.test.ts
+++ b/tests/engine/fifo.test.ts
@@ -224,7 +224,9 @@ describe("FifoEngine", () => {
     expect(disposals[0]!.proceedsEur.toFixed(2)).toBe("5005.00");
     // Cost: 50/100 of original cost (10 × 1000 × 0.92 = 9200), so 4600
     expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("4600.00");
-    expect(engine.warnings).toHaveLength(0);
+    // Split application generates an informational warning
+    expect(engine.warnings).toHaveLength(1);
+    expect(engine.warnings[0]).toContain("Split");
   });
 
   it("should calculate correct holding days with YYYYMMDD dates", () => {

--- a/tests/engine/phase5-assets.test.ts
+++ b/tests/engine/phase5-assets.test.ts
@@ -1,0 +1,701 @@
+import { describe, it, expect } from "vitest";
+import { FifoEngine } from "../../src/engine/fifo.js";
+import { detectWashSales } from "../../src/engine/wash-sale.js";
+import type { Trade } from "../../src/types/ibkr.js";
+import type { EcbRateMap } from "../../src/types/ecb.js";
+
+function makeTrade(overrides: Partial<Trade>): Trade {
+  return {
+    tradeID: "1", accountId: "U1", symbol: "AAPL", description: "APPLE INC",
+    isin: "US0378331005", assetCategory: "STK", currency: "USD",
+    tradeDate: "2025-03-15", settlementDate: "2025-03-18",
+    quantity: "10", tradePrice: "100", tradeMoney: "1000",
+    proceeds: "1000", cost: "1000", fifoPnlRealized: "0",
+    fxRateToBase: "0.92", buySell: "BUY", openCloseIndicator: "O",
+    exchange: "NASDAQ", commissionCurrency: "USD", commission: "0",
+    taxes: "0", multiplier: "1", ...overrides,
+  };
+}
+
+function makeRateMap(rates: Record<string, Record<string, string>>): EcbRateMap {
+  const map: EcbRateMap = new Map();
+  for (const [date, currencies] of Object.entries(rates)) {
+    map.set(date, new Map(Object.entries(currencies)));
+  }
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Futures (FUT)
+// ---------------------------------------------------------------------------
+describe("Phase 5 — Futures (FUT)", () => {
+  it("should calculate gain with multiplier on ES futures", () => {
+    const rates = makeRateMap({
+      "2025-03-15": { "USD": "0.92" },
+      "2025-09-20": { "USD": "0.92" },
+    });
+
+    const trades: Trade[] = [
+      makeTrade({
+        tradeID: "1", symbol: "ESU5", isin: "", assetCategory: "FUT",
+        tradeDate: "2025-03-15", quantity: "5", tradePrice: "5000",
+        multiplier: "50", buySell: "BUY",
+      }),
+      makeTrade({
+        tradeID: "2", symbol: "ESU5", isin: "", assetCategory: "FUT",
+        tradeDate: "2025-09-20", quantity: "-5", tradePrice: "5100",
+        multiplier: "50", buySell: "SELL",
+      }),
+    ];
+
+    const engine = new FifoEngine();
+    const disposals = engine.processTrades(trades, rates);
+
+    expect(disposals).toHaveLength(1);
+    const d = disposals[0]!;
+
+    // Cost: 5 * 5000 * 50 * 0.92 = 1,150,000 EUR
+    expect(d.costBasisEur.toFixed(2)).toBe("1150000.00");
+    // Proceeds: 5 * 5100 * 50 * 0.92 = 1,173,000 EUR
+    expect(d.proceedsEur.toFixed(2)).toBe("1173000.00");
+    // Gain: 1,173,000 - 1,150,000 = 23,000 EUR
+    expect(d.gainLossEur.toFixed(2)).toBe("23000.00");
+    expect(d.assetCategory).toBe("FUT");
+  });
+
+  it("should key futures lots by symbol (not empty ISIN)", () => {
+    const rates = makeRateMap({
+      "2025-03-15": { "USD": "0.92" },
+      "2025-09-20": { "USD": "0.92" },
+    });
+
+    const trades: Trade[] = [
+      makeTrade({
+        tradeID: "1", symbol: "ESU5", isin: "", assetCategory: "FUT",
+        tradeDate: "2025-03-15", quantity: "2", tradePrice: "5000",
+        multiplier: "50", buySell: "BUY",
+      }),
+      // Different symbol — should NOT share lots
+      makeTrade({
+        tradeID: "2", symbol: "NQU5", isin: "", assetCategory: "FUT",
+        tradeDate: "2025-03-15", quantity: "2", tradePrice: "18000",
+        multiplier: "20", buySell: "BUY",
+      }),
+      // Sell ESU5 — should match only ESU5 lots
+      makeTrade({
+        tradeID: "3", symbol: "ESU5", isin: "", assetCategory: "FUT",
+        tradeDate: "2025-09-20", quantity: "-2", tradePrice: "5100",
+        multiplier: "50", buySell: "SELL",
+      }),
+    ];
+
+    const engine = new FifoEngine();
+    const disposals = engine.processTrades(trades, rates);
+
+    expect(disposals).toHaveLength(1);
+    expect(disposals[0]!.symbol).toBe("ESU5");
+    expect(engine.warnings).toHaveLength(0);
+
+    // NQ lots should remain untouched
+    const nqLots = engine.getRemainingLots().get("NQU5") ?? [];
+    expect(nqLots).toHaveLength(1);
+    expect(nqLots[0]!.quantity.toNumber()).toBe(2);
+  });
+
+  it("should NOT apply anti-churning to futures losses", () => {
+    const rates = makeRateMap({
+      "2025-03-15": { "USD": "0.92" },
+      "2025-06-15": { "USD": "0.92" },
+      "2025-07-01": { "USD": "0.92" },
+    });
+
+    const trades: Trade[] = [
+      makeTrade({
+        tradeID: "1", symbol: "ESU5", isin: "", assetCategory: "FUT",
+        tradeDate: "2025-03-15", quantity: "5", tradePrice: "5000",
+        multiplier: "50", buySell: "BUY",
+      }),
+      // Sell at a loss
+      makeTrade({
+        tradeID: "2", symbol: "ESU5", isin: "", assetCategory: "FUT",
+        tradeDate: "2025-06-15", quantity: "-5", tradePrice: "4900",
+        multiplier: "50", buySell: "SELL",
+      }),
+      // Repurchase within 2 months
+      makeTrade({
+        tradeID: "3", symbol: "ESU5", isin: "", assetCategory: "FUT",
+        tradeDate: "2025-07-01", quantity: "5", tradePrice: "4950",
+        multiplier: "50", buySell: "BUY",
+      }),
+    ];
+
+    const engine = new FifoEngine();
+    const disposals = engine.processTrades(trades, rates);
+    const checked = detectWashSales(disposals, trades);
+
+    expect(checked).toHaveLength(1);
+    // Loss: (4900-5000)*5*50*0.92 = -23,000 EUR
+    expect(checked[0]!.gainLossEur.toFixed(2)).toBe("-23000.00");
+    // Futures are NOT "valores homogeneos" — anti-churning must NOT block
+    expect(checked[0]!.washSaleBlocked).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Bonds (BOND)
+// ---------------------------------------------------------------------------
+describe("Phase 5 — Bonds (BOND)", () => {
+  it("should calculate bond gain with ECB rates", () => {
+    const rates = makeRateMap({
+      "2025-02-01": { "USD": "0.92" },
+      "2025-08-01": { "USD": "0.91" },
+    });
+
+    const trades: Trade[] = [
+      makeTrade({
+        tradeID: "1", symbol: "T 4.25 02/15/54", isin: "US912828ZT58",
+        assetCategory: "BOND", tradeDate: "2025-02-01",
+        quantity: "10", tradePrice: "98", multiplier: "1", buySell: "BUY",
+      }),
+      makeTrade({
+        tradeID: "2", symbol: "T 4.25 02/15/54", isin: "US912828ZT58",
+        assetCategory: "BOND", tradeDate: "2025-08-01",
+        quantity: "-10", tradePrice: "102", multiplier: "1", buySell: "SELL",
+      }),
+    ];
+
+    const engine = new FifoEngine();
+    const disposals = engine.processTrades(trades, rates);
+
+    expect(disposals).toHaveLength(1);
+    const d = disposals[0]!;
+
+    // Cost: 10 * 98 * 1 * 0.92 = 901.60 EUR
+    expect(d.costBasisEur.toFixed(2)).toBe("901.60");
+    // Proceeds: 10 * 102 * 1 * 0.91 = 928.20 EUR
+    expect(d.proceedsEur.toFixed(2)).toBe("928.20");
+    // Gain: 928.20 - 901.60 = 26.60 EUR
+    expect(d.gainLossEur.toFixed(2)).toBe("26.60");
+    expect(d.assetCategory).toBe("BOND");
+  });
+
+  it("should apply anti-churning to bond losses (valores homogeneos)", () => {
+    const rates = makeRateMap({
+      "2025-02-01": { "USD": "0.92" },
+      "2025-06-15": { "USD": "0.92" },
+      "2025-07-01": { "USD": "0.92" },
+    });
+
+    const trades: Trade[] = [
+      makeTrade({
+        tradeID: "1", isin: "US912828ZT58", assetCategory: "BOND",
+        tradeDate: "2025-02-01", quantity: "10", tradePrice: "100",
+        multiplier: "1", buySell: "BUY",
+      }),
+      // Sell at a loss
+      makeTrade({
+        tradeID: "2", isin: "US912828ZT58", assetCategory: "BOND",
+        tradeDate: "2025-06-15", quantity: "-10", tradePrice: "90",
+        multiplier: "1", buySell: "SELL",
+      }),
+      // Repurchase within 2 months
+      makeTrade({
+        tradeID: "3", isin: "US912828ZT58", assetCategory: "BOND",
+        tradeDate: "2025-07-01", quantity: "10", tradePrice: "92",
+        multiplier: "1", buySell: "BUY",
+      }),
+    ];
+
+    const engine = new FifoEngine();
+    const disposals = engine.processTrades(trades, rates);
+    const checked = detectWashSales(disposals, trades);
+
+    expect(checked).toHaveLength(1);
+    // Loss: (90-100)*10*1*0.92 = -92.00 EUR
+    expect(checked[0]!.gainLossEur.toFixed(2)).toBe("-92.00");
+    // Bonds ARE "valores homogeneos" — anti-churning MUST block this loss
+    expect(checked[0]!.washSaleBlocked).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Forex / CASH
+// ---------------------------------------------------------------------------
+describe("Phase 5 — Forex / CASH", () => {
+  it("should calculate forex gain on GBP position", () => {
+    const rates = makeRateMap({
+      "2025-03-15": { "GBP": "1.15" },
+      "2025-09-20": { "GBP": "1.18" },
+    });
+
+    const trades: Trade[] = [
+      makeTrade({
+        tradeID: "1", symbol: "GBP.USD", isin: "", assetCategory: "CASH",
+        currency: "GBP", tradeDate: "2025-03-15",
+        quantity: "10000", tradePrice: "1", multiplier: "1", buySell: "BUY",
+        commissionCurrency: "GBP", commission: "0",
+      }),
+      makeTrade({
+        tradeID: "2", symbol: "GBP.USD", isin: "", assetCategory: "CASH",
+        currency: "GBP", tradeDate: "2025-09-20",
+        quantity: "-10000", tradePrice: "1", multiplier: "1", buySell: "SELL",
+        commissionCurrency: "GBP", commission: "0",
+      }),
+    ];
+
+    const engine = new FifoEngine();
+    const disposals = engine.processTrades(trades, rates);
+
+    expect(disposals).toHaveLength(1);
+    const d = disposals[0]!;
+
+    // Cost: 10000 * 1 * 1 * 1.15 = 11,500 EUR
+    expect(d.costBasisEur.toFixed(2)).toBe("11500.00");
+    // Proceeds: 10000 * 1 * 1 * 1.18 = 11,800 EUR
+    expect(d.proceedsEur.toFixed(2)).toBe("11800.00");
+    // Gain: 11,800 - 11,500 = 300 EUR (pure FX gain)
+    expect(d.gainLossEur.toFixed(2)).toBe("300.00");
+    expect(d.assetCategory).toBe("CASH");
+  });
+
+  it("should NOT apply anti-churning to forex losses", () => {
+    const rates = makeRateMap({
+      "2025-03-15": { "GBP": "1.15" },
+      "2025-06-15": { "GBP": "1.10" },
+      "2025-07-01": { "GBP": "1.12" },
+    });
+
+    const trades: Trade[] = [
+      makeTrade({
+        tradeID: "1", symbol: "GBP.USD", isin: "", assetCategory: "CASH",
+        currency: "GBP", tradeDate: "2025-03-15",
+        quantity: "10000", tradePrice: "1", multiplier: "1", buySell: "BUY",
+        commissionCurrency: "GBP",
+      }),
+      // Sell at a loss (GBP weakened against EUR)
+      makeTrade({
+        tradeID: "2", symbol: "GBP.USD", isin: "", assetCategory: "CASH",
+        currency: "GBP", tradeDate: "2025-06-15",
+        quantity: "-10000", tradePrice: "1", multiplier: "1", buySell: "SELL",
+        commissionCurrency: "GBP",
+      }),
+      // Repurchase within 2 months
+      makeTrade({
+        tradeID: "3", symbol: "GBP.USD", isin: "", assetCategory: "CASH",
+        currency: "GBP", tradeDate: "2025-07-01",
+        quantity: "10000", tradePrice: "1", multiplier: "1", buySell: "BUY",
+        commissionCurrency: "GBP",
+      }),
+    ];
+
+    const engine = new FifoEngine();
+    const disposals = engine.processTrades(trades, rates);
+    const checked = detectWashSales(disposals, trades);
+
+    expect(checked).toHaveLength(1);
+    // Loss: (1*10000*1.10) - (1*10000*1.15) = 11000 - 11500 = -500 EUR
+    expect(checked[0]!.gainLossEur.toFixed(2)).toBe("-500.00");
+    // Forex is NOT "valores homogeneos" — must NOT block
+    expect(checked[0]!.washSaleBlocked).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. CFDs
+// ---------------------------------------------------------------------------
+describe("Phase 5 — CFDs", () => {
+  it("should calculate CFD gain on DAX contract", () => {
+    const rates = makeRateMap({
+      "2025-04-01": { "EUR": "1" },
+      "2025-06-01": { "EUR": "1" },
+    });
+
+    const trades: Trade[] = [
+      makeTrade({
+        tradeID: "1", symbol: "DAX", isin: "", assetCategory: "CFD",
+        currency: "EUR", tradeDate: "2025-04-01",
+        quantity: "100", tradePrice: "18000", multiplier: "1", buySell: "BUY",
+        commissionCurrency: "EUR", commission: "0",
+      }),
+      makeTrade({
+        tradeID: "2", symbol: "DAX", isin: "", assetCategory: "CFD",
+        currency: "EUR", tradeDate: "2025-06-01",
+        quantity: "-100", tradePrice: "18500", multiplier: "1", buySell: "SELL",
+        commissionCurrency: "EUR", commission: "0",
+      }),
+    ];
+
+    const engine = new FifoEngine();
+    const disposals = engine.processTrades(trades, rates);
+
+    expect(disposals).toHaveLength(1);
+    const d = disposals[0]!;
+
+    // Cost: 100 * 18000 * 1 * 1 = 1,800,000 EUR
+    expect(d.costBasisEur.toFixed(2)).toBe("1800000.00");
+    // Proceeds: 100 * 18500 * 1 * 1 = 1,850,000 EUR
+    expect(d.proceedsEur.toFixed(2)).toBe("1850000.00");
+    // Gain: 1,850,000 - 1,800,000 = 50,000 EUR
+    expect(d.gainLossEur.toFixed(2)).toBe("50000.00");
+    expect(d.assetCategory).toBe("CFD");
+  });
+
+  it("should NOT apply anti-churning to CFD losses", () => {
+    const rates = makeRateMap({
+      "2025-04-01": { "USD": "0.92" },
+      "2025-06-15": { "USD": "0.92" },
+      "2025-07-01": { "USD": "0.92" },
+    });
+
+    const trades: Trade[] = [
+      makeTrade({
+        tradeID: "1", symbol: "AAPL.CFD", isin: "", assetCategory: "CFD",
+        tradeDate: "2025-04-01", quantity: "100", tradePrice: "200",
+        multiplier: "1", buySell: "BUY",
+      }),
+      // Sell at a loss
+      makeTrade({
+        tradeID: "2", symbol: "AAPL.CFD", isin: "", assetCategory: "CFD",
+        tradeDate: "2025-06-15", quantity: "-100", tradePrice: "190",
+        multiplier: "1", buySell: "SELL",
+      }),
+      // Repurchase within 2 months
+      makeTrade({
+        tradeID: "3", symbol: "AAPL.CFD", isin: "", assetCategory: "CFD",
+        tradeDate: "2025-07-01", quantity: "100", tradePrice: "192",
+        multiplier: "1", buySell: "BUY",
+      }),
+    ];
+
+    const engine = new FifoEngine();
+    const disposals = engine.processTrades(trades, rates);
+    const checked = detectWashSales(disposals, trades);
+
+    expect(checked).toHaveLength(1);
+    // Loss: (190-200)*100*1*0.92 = -920.00 EUR
+    expect(checked[0]!.gainLossEur.toFixed(2)).toBe("-920.00");
+    // CFDs are NOT "valores homogeneos" — must NOT block
+    expect(checked[0]!.washSaleBlocked).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Options exercise/expiration (OPT)
+// ---------------------------------------------------------------------------
+describe("Phase 5 — Options (OPT)", () => {
+  it("should calculate gain on call option close with multiplier", () => {
+    const rates = makeRateMap({
+      "2025-02-01": { "USD": "0.92" },
+      "2025-04-01": { "USD": "0.91" },
+    });
+
+    const trades: Trade[] = [
+      makeTrade({
+        tradeID: "1", symbol: "AAPL  250620C00200000", isin: "",
+        assetCategory: "OPT", tradeDate: "2025-02-01",
+        quantity: "5", tradePrice: "3.00", multiplier: "100", buySell: "BUY",
+      }),
+      makeTrade({
+        tradeID: "2", symbol: "AAPL  250620C00200000", isin: "",
+        assetCategory: "OPT", tradeDate: "2025-04-01",
+        quantity: "-5", tradePrice: "5.00", multiplier: "100", buySell: "SELL",
+      }),
+    ];
+
+    const engine = new FifoEngine();
+    const disposals = engine.processTrades(trades, rates);
+
+    expect(disposals).toHaveLength(1);
+    const d = disposals[0]!;
+
+    // Cost: 5 * 3.00 * 100 * 0.92 = 1,380.00 EUR
+    expect(d.costBasisEur.toFixed(2)).toBe("1380.00");
+    // Proceeds: 5 * 5.00 * 100 * 0.91 = 2,275.00 EUR
+    expect(d.proceedsEur.toFixed(2)).toBe("2275.00");
+    // Gain: 2275 - 1380 = 895.00 EUR
+    expect(d.gainLossEur.toFixed(2)).toBe("895.00");
+    expect(d.assetCategory).toBe("OPT");
+  });
+
+  it("should calculate total loss when put option expires worthless", () => {
+    const rates = makeRateMap({
+      "2025-02-01": { "USD": "0.92" },
+      "2025-06-20": { "USD": "0.92" },
+    });
+
+    const trades: Trade[] = [
+      makeTrade({
+        tradeID: "1", symbol: "AAPL  250620P00180000", isin: "",
+        assetCategory: "OPT", tradeDate: "2025-02-01",
+        quantity: "3", tradePrice: "4.50", multiplier: "100", buySell: "BUY",
+      }),
+      // Expires worthless — sold at $0
+      makeTrade({
+        tradeID: "2", symbol: "AAPL  250620P00180000", isin: "",
+        assetCategory: "OPT", tradeDate: "2025-06-20",
+        quantity: "-3", tradePrice: "0.00", multiplier: "100", buySell: "SELL",
+      }),
+    ];
+
+    const engine = new FifoEngine();
+    const disposals = engine.processTrades(trades, rates);
+
+    expect(disposals).toHaveLength(1);
+    const d = disposals[0]!;
+
+    // Cost: 3 * 4.50 * 100 * 0.92 = 1,242.00 EUR
+    expect(d.costBasisEur.toFixed(2)).toBe("1242.00");
+    // Proceeds: 3 * 0 * 100 * 0.92 = 0.00 EUR
+    expect(d.proceedsEur.toFixed(2)).toBe("0.00");
+    // Total loss = -1,242.00 EUR (entire premium lost)
+    expect(d.gainLossEur.toFixed(2)).toBe("-1242.00");
+  });
+
+  it("should NOT apply anti-churning to option losses", () => {
+    const rates = makeRateMap({
+      "2025-02-01": { "USD": "0.92" },
+      "2025-06-20": { "USD": "0.92" },
+      "2025-07-01": { "USD": "0.92" },
+    });
+
+    const trades: Trade[] = [
+      makeTrade({
+        tradeID: "1", symbol: "AAPL  250620P00180000", isin: "",
+        assetCategory: "OPT", tradeDate: "2025-02-01",
+        quantity: "3", tradePrice: "4.50", multiplier: "100", buySell: "BUY",
+      }),
+      makeTrade({
+        tradeID: "2", symbol: "AAPL  250620P00180000", isin: "",
+        assetCategory: "OPT", tradeDate: "2025-06-20",
+        quantity: "-3", tradePrice: "0.00", multiplier: "100", buySell: "SELL",
+      }),
+      // Buy new put within 2 months
+      makeTrade({
+        tradeID: "3", symbol: "AAPL  250620P00180000", isin: "",
+        assetCategory: "OPT", tradeDate: "2025-07-01",
+        quantity: "3", tradePrice: "2.00", multiplier: "100", buySell: "BUY",
+      }),
+    ];
+
+    const engine = new FifoEngine();
+    const disposals = engine.processTrades(trades, rates);
+    const checked = detectWashSales(disposals, trades);
+
+    expect(checked).toHaveLength(1);
+    expect(checked[0]!.gainLossEur.toFixed(2)).toBe("-1242.00");
+    // Options are NOT "valores homogeneos" — must NOT block
+    expect(checked[0]!.washSaleBlocked).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Multi-divisa (cross-currency commissions)
+// ---------------------------------------------------------------------------
+describe("Phase 5 — Multi-divisa (cross-currency)", () => {
+  it("should convert GBP stock with USD commission using separate ECB rates", () => {
+    const rates = makeRateMap({
+      "2025-03-15": { "GBP": "1.15", "USD": "0.92" },
+      "2025-09-20": { "GBP": "1.13", "USD": "0.91" },
+    });
+
+    const trades: Trade[] = [
+      makeTrade({
+        tradeID: "1", symbol: "SHEL", isin: "GB00BP6MXD84",
+        currency: "GBP", commissionCurrency: "USD",
+        tradeDate: "2025-03-15", quantity: "100", tradePrice: "25",
+        multiplier: "1", buySell: "BUY", commission: "-10",
+      }),
+      makeTrade({
+        tradeID: "2", symbol: "SHEL", isin: "GB00BP6MXD84",
+        currency: "GBP", commissionCurrency: "USD",
+        tradeDate: "2025-09-20", quantity: "-100", tradePrice: "28",
+        multiplier: "1", buySell: "SELL", commission: "-10",
+      }),
+    ];
+
+    const engine = new FifoEngine();
+    const disposals = engine.processTrades(trades, rates);
+
+    expect(disposals).toHaveLength(1);
+    const d = disposals[0]!;
+
+    // Buy cost: (100 * 25 * 1 * 1.15) + (10 * 0.92) = 2875.00 + 9.20 = 2884.20 EUR
+    expect(d.costBasisEur.toFixed(2)).toBe("2884.20");
+    // Sell proceeds: (100 * 28 * 1 * 1.13) - (10 * 0.91) = 3164.00 - 9.10 = 3154.90 EUR
+    expect(d.proceedsEur.toFixed(2)).toBe("3154.90");
+    // Gain: 3154.90 - 2884.20 = 270.70 EUR
+    expect(d.gainLossEur.toFixed(2)).toBe("270.70");
+
+    // ECB rates should reflect trade currency (GBP), not commission currency
+    expect(d.acquireEcbRate.toFixed(4)).toBe("1.1500");
+    expect(d.sellEcbRate.toFixed(4)).toBe("1.1300");
+    expect(d.currency).toBe("GBP");
+  });
+
+  it("should handle EUR stock with USD commission", () => {
+    const rates = makeRateMap({
+      "2025-03-15": { "USD": "0.92" },
+      "2025-09-20": { "USD": "0.91" },
+    });
+
+    const trades: Trade[] = [
+      makeTrade({
+        tradeID: "1", symbol: "SAP", isin: "DE0007164600",
+        currency: "EUR", commissionCurrency: "USD",
+        tradeDate: "2025-03-15", quantity: "50", tradePrice: "200",
+        multiplier: "1", buySell: "BUY", commission: "-5",
+      }),
+      makeTrade({
+        tradeID: "2", symbol: "SAP", isin: "DE0007164600",
+        currency: "EUR", commissionCurrency: "USD",
+        tradeDate: "2025-09-20", quantity: "-50", tradePrice: "210",
+        multiplier: "1", buySell: "SELL", commission: "-5",
+      }),
+    ];
+
+    const engine = new FifoEngine();
+    const disposals = engine.processTrades(trades, rates);
+
+    expect(disposals).toHaveLength(1);
+    const d = disposals[0]!;
+
+    // Buy cost: (50 * 200 * 1 * 1) + (5 * 0.92) = 10000 + 4.60 = 10004.60 EUR
+    expect(d.costBasisEur.toFixed(2)).toBe("10004.60");
+    // Sell proceeds: (50 * 210 * 1 * 1) - (5 * 0.91) = 10500 - 4.55 = 10495.45 EUR
+    expect(d.proceedsEur.toFixed(2)).toBe("10495.45");
+    // Gain: 10495.45 - 10004.60 = 490.85 EUR
+    expect(d.gainLossEur.toFixed(2)).toBe("490.85");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Short positions
+// ---------------------------------------------------------------------------
+describe("Phase 5 — Short positions", () => {
+  it("should warn and use zero cost basis for short sale (sell first)", () => {
+    const rates = makeRateMap({
+      "2025-03-15": { "USD": "0.92" },
+      "2025-06-15": { "USD": "0.91" },
+    });
+
+    const trades: Trade[] = [
+      // Sell first — no lots exist
+      makeTrade({
+        tradeID: "1", tradeDate: "2025-03-15",
+        quantity: "-50", tradePrice: "150", buySell: "SELL",
+      }),
+      // Buy to cover later
+      makeTrade({
+        tradeID: "2", tradeDate: "2025-06-15",
+        quantity: "50", tradePrice: "140", buySell: "BUY",
+      }),
+    ];
+
+    const engine = new FifoEngine();
+    const disposals = engine.processTrades(trades, rates);
+
+    expect(disposals).toHaveLength(1);
+    const d = disposals[0]!;
+
+    // Short sale: costBasis = 0 (no lots to consume)
+    expect(d.costBasisEur.toFixed(2)).toBe("0.00");
+    // Proceeds: 50 * 150 * 1 * 0.92 = 6,900.00 EUR
+    expect(d.proceedsEur.toFixed(2)).toBe("6900.00");
+    // Gain = proceeds (since cost = 0)
+    expect(d.gainLossEur.toFixed(2)).toBe("6900.00");
+
+    // Should have warning about missing lots
+    expect(engine.warnings).toHaveLength(1);
+    expect(engine.warnings[0]).toContain("Venta sin lotes");
+
+    // The buy-to-cover creates a lot that remains unconsumed
+    const remaining = engine.getRemainingLots().get("US0378331005") ?? [];
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]!.quantity.toNumber()).toBe(50);
+  });
+
+  it("should warn when selling more shares than available lots", () => {
+    const rates = makeRateMap({
+      "2025-03-15": { "USD": "0.92" },
+      "2025-09-20": { "USD": "0.91" },
+    });
+
+    const trades: Trade[] = [
+      makeTrade({
+        tradeID: "1", tradeDate: "2025-03-15",
+        quantity: "10", tradePrice: "100", buySell: "BUY",
+      }),
+      // Sell 25 but only 10 lots available
+      makeTrade({
+        tradeID: "2", tradeDate: "2025-09-20",
+        quantity: "-25", tradePrice: "120", buySell: "SELL",
+      }),
+    ];
+
+    const engine = new FifoEngine();
+    const disposals = engine.processTrades(trades, rates);
+
+    // 2 disposals: 10 from lot + 15 from insufficient-lots fallback
+    expect(disposals).toHaveLength(2);
+
+    // First disposal: 10 shares consumed from lot
+    expect(disposals[0]!.quantity.toNumber()).toBe(10);
+    // Cost: 10 * 100 * 0.92 = 920.00 EUR
+    expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("920.00");
+    // Proceeds: (10 * 120) * 0.91 * (10/25) share... actually full per consumed
+    // Proceeds: 10/25 fraction of total: (10 * 120 * 0.91) = 1092 * (10/25)...
+    // No: proceeds per consumed = consumed * price * mult * ecbRate - commShare
+    // = (10 * 120 * 1 * 0.91) - 0 = 1092.00 EUR... but with fractional commission
+    // Commission is 0, taxes is 0, so: proceeds = 10 * 120 * 1 * 0.91 = 1092.00
+    // BUT fractionOfSale = 10/25 = 0.4, commissionShare = 0*0.4 = 0, taxesShare = 0
+    // proceedsBaseEur = 10 * 120 * 1 * 0.91 = 1092; no taxes/comm deductions
+    // Wait — re-reading code: proceedsBaseEur = consumed * price * mult - taxesShare) * ecbRate
+    // = (10 * 120 * 1 - 0) * 0.91 = 1092.00. Then - commissionShare = 0.
+    expect(disposals[0]!.proceedsEur.toFixed(2)).toBe("1092.00");
+
+    // Second disposal: 15 shares with zero cost basis (insufficient lots)
+    expect(disposals[1]!.quantity.toNumber()).toBe(15);
+    expect(disposals[1]!.costBasisEur.toFixed(2)).toBe("0.00");
+    // Proceeds: (15 * 120 * 1 - 0) * 0.91 = 1638.00 EUR
+    expect(disposals[1]!.proceedsEur.toFixed(2)).toBe("1638.00");
+
+    // Should have warning about insufficient lots
+    expect(engine.warnings).toHaveLength(1);
+    expect(engine.warnings[0]).toContain("Lotes insuficientes");
+  });
+
+  it("should handle short CFD with zero-cost warning", () => {
+    const rates = makeRateMap({
+      "2025-04-01": { "USD": "0.92" },
+      "2025-06-01": { "USD": "0.92" },
+    });
+
+    const trades: Trade[] = [
+      // Short CFD — sell first
+      makeTrade({
+        tradeID: "1", symbol: "TSLA.CFD", isin: "", assetCategory: "CFD",
+        tradeDate: "2025-04-01", quantity: "-50", tradePrice: "250",
+        multiplier: "1", buySell: "SELL",
+      }),
+      // Buy to cover
+      makeTrade({
+        tradeID: "2", symbol: "TSLA.CFD", isin: "", assetCategory: "CFD",
+        tradeDate: "2025-06-01", quantity: "50", tradePrice: "230",
+        multiplier: "1", buySell: "BUY",
+      }),
+    ];
+
+    const engine = new FifoEngine();
+    const disposals = engine.processTrades(trades, rates);
+
+    expect(disposals).toHaveLength(1);
+    const d = disposals[0]!;
+
+    expect(d.costBasisEur.toFixed(2)).toBe("0.00");
+    // Proceeds: 50 * 250 * 1 * 0.92 = 11,500 EUR
+    expect(d.proceedsEur.toFixed(2)).toBe("11500.00");
+    expect(d.assetCategory).toBe("CFD");
+    expect(engine.warnings).toHaveLength(1);
+    expect(engine.warnings[0]).toContain("Venta sin lotes");
+  });
+});

--- a/tests/engine/phase5-assets.test.ts
+++ b/tests/engine/phase5-assets.test.ts
@@ -486,6 +486,41 @@ describe("Phase 5 — Options (OPT)", () => {
     // Options are NOT "valores homogeneos" — must NOT block
     expect(checked[0]!.washSaleBlocked).toBe(false);
   });
+
+  it("should NOT apply anti-churning to crypto losses", () => {
+    const rates = makeRateMap({
+      "2025-03-01": { "USD": "0.92" },
+      "2025-06-01": { "USD": "0.91" },
+      "2025-06-15": { "USD": "0.91" },
+    });
+
+    const trades: Trade[] = [
+      makeTrade({
+        tradeID: "1", symbol: "BTC", isin: "",
+        assetCategory: "CRYPTO", tradeDate: "2025-03-01",
+        quantity: "1", tradePrice: "60000", buySell: "BUY",
+      }),
+      makeTrade({
+        tradeID: "2", symbol: "BTC", isin: "",
+        assetCategory: "CRYPTO", tradeDate: "2025-06-01",
+        quantity: "-1", tradePrice: "50000", buySell: "SELL",
+      }),
+      // Repurchase within 2 months
+      makeTrade({
+        tradeID: "3", symbol: "BTC", isin: "",
+        assetCategory: "CRYPTO", tradeDate: "2025-06-15",
+        quantity: "1", tradePrice: "51000", buySell: "BUY",
+      }),
+    ];
+
+    const engine = new FifoEngine();
+    const disposals = engine.processTrades(trades, rates);
+    const checked = detectWashSales(disposals, trades);
+
+    expect(checked).toHaveLength(1);
+    // Crypto is NOT "valores homogeneos" — must NOT block
+    expect(checked[0]!.washSaleBlocked).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/engine/phase5-assets.test.ts
+++ b/tests/engine/phase5-assets.test.ts
@@ -96,8 +96,8 @@ describe("Phase 5 — Futures (FUT)", () => {
     expect(disposals[0]!.symbol).toBe("ESU5");
     expect(engine.warnings).toHaveLength(0);
 
-    // NQ lots should remain untouched
-    const nqLots = engine.getRemainingLots().get("NQU5") ?? [];
+    // NQ lots should remain untouched (keyed by assetCategory:symbol when ISIN is empty)
+    const nqLots = engine.getRemainingLots().get("FUT:NQU5") ?? [];
     expect(nqLots).toHaveLength(1);
     expect(nqLots[0]!.quantity.toNumber()).toBe(2);
   });

--- a/tests/parsers/etoro-xlsx.test.ts
+++ b/tests/parsers/etoro-xlsx.test.ts
@@ -319,6 +319,35 @@ describe("eToro XLSX parsing", () => {
       expect(result.trades).toHaveLength(0);
     });
 
+    it("should parse leverage-based CFD with correct asset category", async () => {
+      const data = buildEtoroWorkbook({
+        closedPositions: [
+          CLOSED_POSITIONS_HEADER,
+          ["Buy AAPL", "1000", "5", "180", "195", "82.50", "15/03/2025", "20/09/2025", "Stocks", "5", "US0378331005"],
+        ],
+      });
+
+      const result = await parseEtoroXlsx(data);
+      expect(result.trades).toHaveLength(2);
+      // Leverage 5 → CFD
+      expect(result.trades[0]!.assetCategory).toBe("CFD");
+      expect(result.trades[1]!.assetCategory).toBe("CFD");
+    });
+
+    it("should parse index CFDs (leveraged index positions)", async () => {
+      const data = buildEtoroWorkbook({
+        closedPositions: [
+          CLOSED_POSITIONS_HEADER,
+          ["Buy SPX500", "2000", "1", "4500", "4600", "200", "01/04/2025", "01/05/2025", "Index", "10", ""],
+        ],
+      });
+
+      const result = await parseEtoroXlsx(data);
+      expect(result.trades).toHaveLength(2);
+      expect(result.trades[0]!.assetCategory).toBe("CFD");
+      expect(result.trades[0]!.symbol).toBe("SPX500");
+    });
+
     it("should accept ETF type", async () => {
       const data = buildEtoroWorkbook({
         closedPositions: [

--- a/tests/parsers/etoro-xlsx.test.ts
+++ b/tests/parsers/etoro-xlsx.test.ts
@@ -307,7 +307,7 @@ describe("eToro XLSX parsing", () => {
       expect(result.trades).toHaveLength(0);
     });
 
-    it("should skip ETF-like type that doesn't match", async () => {
+    it("should parse Commodity type as CFD (eToro commodities are always derivatives)", async () => {
       const data = buildEtoroWorkbook({
         closedPositions: [
           CLOSED_POSITIONS_HEADER,
@@ -316,7 +316,8 @@ describe("eToro XLSX parsing", () => {
       });
 
       const result = await parseEtoroXlsx(data);
-      expect(result.trades).toHaveLength(0);
+      expect(result.trades).toHaveLength(2); // buy + sell legs
+      expect(result.trades[0]!.assetCategory).toBe("CFD");
     });
 
     it("should parse leverage-based CFD with correct asset category", async () => {

--- a/tests/parsers/etoro-xlsx.test.ts
+++ b/tests/parsers/etoro-xlsx.test.ts
@@ -87,7 +87,7 @@ describe("eToro XLSX parsing", () => {
       expect(sell).toBeDefined();
     });
 
-    it("should skip CFDs (leverage > 1)", async () => {
+    it("should parse CFDs (leverage > 1) as CFD asset category", async () => {
       const data = buildEtoroWorkbook({
         closedPositions: [
           CLOSED_POSITIONS_HEADER,
@@ -97,9 +97,12 @@ describe("eToro XLSX parsing", () => {
       });
 
       const result = await parseEtoroXlsx(data);
-      // Only AAPL (stock, leverage 1) — CFD filtered out
-      expect(result.trades).toHaveLength(2); // 1 buy + 1 sell for AAPL only
+      // Both AAPL (stock) and EURUSD (CFD) are parsed
+      expect(result.trades).toHaveLength(4); // 2 buy+sell for AAPL + 2 buy+sell for EURUSD
       expect(result.trades[0]!.symbol).toBe("AAPL");
+      expect(result.trades[0]!.assetCategory).toBe("STK");
+      expect(result.trades[2]!.symbol).toBe("EURUSD");
+      expect(result.trades[2]!.assetCategory).toBe("CFD");
     });
 
     it("should skip crypto", async () => {

--- a/tests/parsers/ibkr.test.ts
+++ b/tests/parsers/ibkr.test.ts
@@ -203,6 +203,118 @@ describe("parseIbkrFlexXml", () => {
     expect(result.corporateActions).toHaveLength(2);
   });
 
+  it("should parse option trades with derivative fields", () => {
+    const xml = `<?xml version="1.0"?>
+    <FlexQueryResponse queryName="Test" type="AF">
+      <FlexStatements count="1">
+        <FlexStatement accountId="U1234567" fromDate="20250101" toDate="20251231" period="LastYear">
+          <Trades>
+            <Trade tradeID="OPT001" accountId="U1234567" symbol="AAPL 250620C00200000"
+                   description="AAPL 20JUN25 200 C" isin="" assetCategory="OPT" currency="USD"
+                   tradeDate="20250315" settlementDate="20250316"
+                   quantity="1" tradePrice="5.50" tradeMoney="550.00"
+                   proceeds="550.00" cost="0" fifoPnlRealized="0"
+                   fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+                   exchange="CBOE" commissionCurrency="USD" commission="-0.65" taxes="0"
+                   multiplier="100" putCall="C" strike="200" expiry="20250620"
+                   underlyingSymbol="AAPL" underlyingIsin="US0378331005" />
+          </Trades>
+          <CashTransactions /><CorporateActions /><OpenPositions /><SecuritiesInfo />
+        </FlexStatement>
+      </FlexStatements>
+    </FlexQueryResponse>`;
+
+    const result = parseIbkrFlexXml(xml);
+    const trade = result.trades[0]!;
+    expect(trade.assetCategory).toBe("OPT");
+    expect(trade.multiplier).toBe("100");
+    expect(trade.putCall).toBe("C");
+    expect(trade.strike).toBe("200");
+    expect(trade.expiry).toBe("20250620");
+    expect(trade.underlyingSymbol).toBe("AAPL");
+    expect(trade.underlyingIsin).toBe("US0378331005");
+  });
+
+  it("should parse futures with multiplier and asset category", () => {
+    const xml = `<?xml version="1.0"?>
+    <FlexQueryResponse queryName="Test" type="AF">
+      <FlexStatements count="1">
+        <FlexStatement accountId="U1234567" fromDate="20250101" toDate="20251231" period="LastYear">
+          <Trades>
+            <Trade tradeID="FUT001" accountId="U1234567" symbol="ESU5"
+                   description="E-MINI S&amp;P 500" isin="" assetCategory="FUT" currency="USD"
+                   tradeDate="20250601" settlementDate="20250601"
+                   quantity="1" tradePrice="5500.00" tradeMoney="275000.00"
+                   proceeds="275000.00" cost="0" fifoPnlRealized="0"
+                   fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+                   exchange="CME" commissionCurrency="USD" commission="-2.10" taxes="0"
+                   multiplier="50" />
+          </Trades>
+          <CashTransactions /><CorporateActions /><OpenPositions /><SecuritiesInfo />
+        </FlexStatement>
+      </FlexStatements>
+    </FlexQueryResponse>`;
+
+    const result = parseIbkrFlexXml(xml);
+    const trade = result.trades[0]!;
+    expect(trade.assetCategory).toBe("FUT");
+    expect(trade.multiplier).toBe("50");
+    expect(trade.isin).toBe("");
+    expect(trade.symbol).toBe("ESU5");
+  });
+
+  it("should parse bond trades", () => {
+    const xml = `<?xml version="1.0"?>
+    <FlexQueryResponse queryName="Test" type="AF">
+      <FlexStatements count="1">
+        <FlexStatement accountId="U1234567" fromDate="20250101" toDate="20251231" period="LastYear">
+          <Trades>
+            <Trade tradeID="BOND001" accountId="U1234567" symbol="T 3.5 05/15/33"
+                   description="US TREASURY 3.5% 05/15/2033" isin="US91282CGR69" assetCategory="BOND" currency="USD"
+                   tradeDate="20250315" settlementDate="20250317"
+                   quantity="10000" tradePrice="97.50" tradeMoney="9750.00"
+                   proceeds="9750.00" cost="0" fifoPnlRealized="0"
+                   fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+                   exchange="SMART" commissionCurrency="USD" commission="-5.00" taxes="0"
+                   multiplier="1" />
+          </Trades>
+          <CashTransactions /><CorporateActions /><OpenPositions /><SecuritiesInfo />
+        </FlexStatement>
+      </FlexStatements>
+    </FlexQueryResponse>`;
+
+    const result = parseIbkrFlexXml(xml);
+    const trade = result.trades[0]!;
+    expect(trade.assetCategory).toBe("BOND");
+    expect(trade.isin).toBe("US91282CGR69");
+    expect(trade.multiplier).toBe("1");
+  });
+
+  it("should reject invalid putCall values", () => {
+    const xml = `<?xml version="1.0"?>
+    <FlexQueryResponse queryName="Test" type="AF">
+      <FlexStatements count="1">
+        <FlexStatement accountId="U1234567" fromDate="20250101" toDate="20251231" period="LastYear">
+          <Trades>
+            <Trade tradeID="OPT002" accountId="U1234567" symbol="SPY" isin="" assetCategory="OPT"
+                   currency="USD" tradeDate="20250315" settlementDate="20250316"
+                   quantity="1" tradePrice="3.00" tradeMoney="300"
+                   proceeds="300" cost="0" fifoPnlRealized="0"
+                   fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+                   exchange="CBOE" commissionCurrency="USD" commission="-0.65" taxes="0"
+                   multiplier="100" putCall="X" strike="500" expiry="20250620" />
+          </Trades>
+          <CashTransactions /><CorporateActions /><OpenPositions /><SecuritiesInfo />
+        </FlexStatement>
+      </FlexStatements>
+    </FlexQueryResponse>`;
+
+    const result = parseIbkrFlexXml(xml);
+    const trade = result.trades[0]!;
+    expect(trade.putCall).toBeUndefined();
+    expect(trade.strike).toBe("500");
+  });
+
   it("should handle defaults for missing attributes", () => {
     const xml = `<?xml version="1.0"?>
     <FlexQueryResponse queryName="Test" type="AF">


### PR DESCRIPTION
## Summary

Completes Phases 1-5 of the roadmap. Adds support for all remaining asset types:

- **Options (OPT)**: derivative fields extracted from IBKR (putCall, strike, expiry, underlyingSymbol, underlyingIsin), FIFO with multiplier, premium as cost/income
- **Futures (FUT)**: FIFO by symbol with contract multiplier, gains as capital gains
- **Forex (CASH)**: spot operations processed via FIFO by currency pair, ECB rate conversion
- **Bonds (BOND)**: trading via FIFO, coupons already handled as interest (Casilla 0033)
- **CFDs**: new `"CFD"` asset category, eToro parser includes CFDs (leverage > 1 or type "cfd"), gains as capital gains
- **Multi-divisa**: cross-currency transactions handled correctly (separate ECB rates for trade currency and commission currency)
- **Short positions**: warning + zero cost basis when selling without prior lots

### Anti-churning (Art. 33.5.f) policy:
- **Applies to**: STK, FUND, BOND (valores homogéneos)
- **Excluded**: OPT, FUT, CFD, CASH (derivatives and forex)

### Files changed:
| File | Change |
|------|--------|
| `src/types/ibkr.ts` | Add `"CFD"` to AssetCategory, add derivative fields to Trade |
| `src/engine/fifo.ts` | Expand filter to all types except WAR |
| `src/engine/wash-sale.ts` | Add BOND; exclude FUT, CFD, CASH |
| `src/parsers/ibkr.ts` | Extract putCall, strike, expiry, underlyingSymbol, underlyingIsin |
| `src/parsers/etoro.ts` | Parse CFDs instead of filtering them out |
| `ROADMAP.md` | Mark Phases 1-5 complete, update asset table |
| `src/web/docs.html` | New "Otros tipos de activo" section, CFD FAQ update |
| `tests/engine/phase5-assets.test.ts` | 17 new tests |
| `tests/parsers/etoro-xlsx.test.ts` | Updated CFD test |

## Test plan

- [x] `npm test` — 429 tests pass (30 files)
- [x] `npm run lint` — zero errors
- [x] `npm run typecheck` — zero errors
- [x] New tests cover: futures, bonds, forex, CFDs, options, multi-divisa, short positions
- [x] Anti-churning correctly applied/excluded per asset type
- [x] eToro CFD parsing with correct asset category

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded support for CFDs (eToro CFDs, indices, commodities), Futures, Bonds (cupones), Forex/CASH, Options; derivative fields surfaced; improved multi-currency handling and short-position/split warnings.

* **Documentation**
  * Roadmap bumped to v1.0.0-rc; “Otros tipos de activo” added; brokers list updated (Coinbase, Binance, Kraken); eToro limitations and FAQs revised; Tramos del ahorro 2025 updated (>300K now 30%).

* **Tests**
  * Extensive tests added/extended for FIFO, wash-sale rules, FX conversions, lot-keying, and new asset categories.

* **Security**
  * Web docs hardened with restrictive HTTP security meta headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->