### PR TITLE
feat(web): splash screen, visual overhaul, guided broker selection

### DIFF
--- a/src/i18n/locales/ca.ts
+++ b/src/i18n/locales/ca.ts
@@ -245,6 +245,14 @@ const ca: TranslationKeys = {
   // Trust signal
   "footer.open_source": "100% codi obert",
   "footer.verify_source": "Verificar codi font",
+
+  // Splash screen
+  "splash.tagline": "Converteix informes de brokers estrangers en la teva declaraci\u00f3 de la renda espanyola",
+  "splash.feature_free": "100% gratu\u00eft",
+  "splash.feature_selfhosted": "Self-hosted",
+  "splash.feature_privacy": "Privacitat total",
+  "splash.feature_opensource": "Codi obert",
+  "splash.cta": "Comen\u00e7ar",
 };
 
 export default ca;

--- a/src/i18n/locales/ca.ts
+++ b/src/i18n/locales/ca.ts
@@ -8,6 +8,8 @@ const ca: TranslationKeys = {
 
 
   "upload.title": "Puja el teu informe del broker",
+  "upload.broker_question": "Quin(s) broker(s) fas servir?",
+  "upload.broker_hint": "Selecciona un o diversos. Et guiarem pas a pas.",
   "upload.broker_label": "Broker:",
   "upload.auto_detect": "Auto-detectar",
   "upload.drop_text": "Arrossega el teu fitxer aquí o fes clic per seleccionar",
@@ -147,6 +149,7 @@ const ca: TranslationKeys = {
   "guide.title": "Com obtenir l'informe?",
   "guide.tip_fifo": "Inclou tot l'històric — DeclaRenta necessita operacions anteriors per al càlcul FIFO correcte.",
   "guide.select_broker_hint": "Selecciona el teu broker per veure les instruccions de descàrrega de l'informe.",
+  "guide.heading": "Com obtenir l'informe del teu broker?",
   "guide.ibkr.title": "Interactive Brokers (Flex Query XML)",
   "guide.ibkr.step1": "Inicia sessió al <strong>Portal del Client</strong> d'IBKR",
   "guide.ibkr.step2": "Ves a <strong>Rendiment i Informes → Flex Queries</strong>",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -249,6 +249,14 @@ const en: TranslationKeys = {
   // Trust signal
   "footer.open_source": "100% open source",
   "footer.verify_source": "Verify source code",
+
+  // Splash screen
+  "splash.tagline": "Convert foreign broker reports into your Spanish tax declaration",
+  "splash.feature_free": "100% free",
+  "splash.feature_selfhosted": "Self-hosted",
+  "splash.feature_privacy": "Total privacy",
+  "splash.feature_opensource": "Open source",
+  "splash.cta": "Get Started",
 };
 
 export default en;

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -7,6 +7,8 @@ const en: TranslationKeys = {
 
 
   "upload.title": "Upload your broker report",
+  "upload.broker_question": "Which broker(s) do you use?",
+  "upload.broker_hint": "Select one or more. We'll guide you step by step.",
   "upload.broker_label": "Broker:",
   "upload.auto_detect": "Auto-detect",
   "upload.drop_text": "Drag your file here or click to select",
@@ -149,6 +151,7 @@ const en: TranslationKeys = {
   "guide.title": "How to get the report?",
   "guide.tip_fifo": "Include the full history — DeclaRenta needs past trades for correct FIFO calculation.",
   "guide.select_broker_hint": "Select your broker to see report download instructions.",
+  "guide.heading": "How to get your broker report",
   "guide.ibkr.title": "Interactive Brokers (Flex Query XML)",
   "guide.ibkr.step1": "Log in to the IBKR <strong>Client Portal</strong>",
   "guide.ibkr.step2": "Go to <strong>Performance &amp; Reports → Flex Queries</strong>",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -278,6 +278,14 @@ const es = {
   // Trust signal
   "footer.open_source": "100% código abierto",
   "footer.verify_source": "Verificar código fuente",
+
+  // Splash screen
+  "splash.tagline": "Convierte reportes de brokers extranjeros en tu declaración de la renta española",
+  "splash.feature_free": "100% gratuito",
+  "splash.feature_selfhosted": "Self-hosted",
+  "splash.feature_privacy": "Privacidad total",
+  "splash.feature_opensource": "Open source",
+  "splash.cta": "Comenzar",
 } as const;
 
 export type TranslationKeys = Record<keyof typeof es, string>;

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -7,6 +7,8 @@ const es = {
 
   // Upload
   "upload.title": "Sube tu informe del broker",
+  "upload.broker_question": "¿Qué broker(s) utilizas?",
+  "upload.broker_hint": "Selecciona uno o varios. Te guiaremos paso a paso.",
   "upload.broker_label": "Broker:",
   "upload.auto_detect": "Auto-detectar",
   "upload.drop_text": "Arrastra tu fichero aquí o haz clic para seleccionar",
@@ -160,6 +162,7 @@ const es = {
   "guide.title": "¿Cómo obtener el informe?",
   "guide.tip_fifo": "Incluye todo el histórico — DeclaRenta necesita operaciones anteriores para el cálculo FIFO correcto.",
   "guide.select_broker_hint": "Selecciona tu broker para ver las instrucciones de descarga del informe.",
+  "guide.heading": "¿Cómo obtener el informe de tu broker?",
 
   // IBKR
   "guide.ibkr.title": "Interactive Brokers (Flex Query XML)",

--- a/src/i18n/locales/eu.ts
+++ b/src/i18n/locales/eu.ts
@@ -245,6 +245,14 @@ const eu: TranslationKeys = {
   // Trust signal
   "footer.open_source": "100% kode irekia",
   "footer.verify_source": "Iturburu-kodea egiaztatu",
+
+  // Splash screen
+  "splash.tagline": "Bihurtu atzerriko broker-en txostenak zure Espainiako errenta aitorpenera",
+  "splash.feature_free": "100% doakoa",
+  "splash.feature_selfhosted": "Self-hosted",
+  "splash.feature_privacy": "Pribatutasun osoa",
+  "splash.feature_opensource": "Kode irekia",
+  "splash.cta": "Hasi",
 };
 
 export default eu;

--- a/src/i18n/locales/eu.ts
+++ b/src/i18n/locales/eu.ts
@@ -8,6 +8,8 @@ const eu: TranslationKeys = {
 
 
   "upload.title": "Igo zure brokerraren txostena",
+  "upload.broker_question": "Zein broker(ak) erabiltzen d(it)uzu?",
+  "upload.broker_hint": "Hautatu bat edo gehiago. Pausoz pauso gidatuko zaitugu.",
   "upload.broker_label": "Brokerra:",
   "upload.auto_detect": "Auto-detektatu",
   "upload.drop_text": "Arrastatu zure fitxategia hona edo egin klik hautatzeko",
@@ -147,6 +149,7 @@ const eu: TranslationKeys = {
   "guide.title": "Nola lortu txostena?",
   "guide.tip_fifo": "Historial osoa sartu — DeclaRentak aurreko eragiketak behar ditu FIFO kalkulu zuzenera.",
   "guide.select_broker_hint": "Hautatu zure brokerra txostenaren deskarga-argibideak ikusteko.",
+  "guide.heading": "Nola lortu zure brokerraren txostena?",
   "guide.ibkr.title": "Interactive Brokers (Flex Query XML)",
   "guide.ibkr.step1": "Hasi saioa IBKRren <strong>Bezero Atarian</strong>",
   "guide.ibkr.step2": "Joan <strong>Errendimendua eta Txostenak → Flex Queries</strong> atalera",

--- a/src/i18n/locales/gl.ts
+++ b/src/i18n/locales/gl.ts
@@ -245,6 +245,14 @@ const gl: TranslationKeys = {
   // Trust signal
   "footer.open_source": "100% código aberto",
   "footer.verify_source": "Verificar código fonte",
+
+  // Splash screen
+  "splash.tagline": "Converte reportes de brokers estranxeiros na túa declaración da renda española",
+  "splash.feature_free": "100% gratuíto",
+  "splash.feature_selfhosted": "Self-hosted",
+  "splash.feature_privacy": "Privacidade total",
+  "splash.feature_opensource": "Código aberto",
+  "splash.cta": "Comezar",
 };
 
 export default gl;

--- a/src/i18n/locales/gl.ts
+++ b/src/i18n/locales/gl.ts
@@ -8,6 +8,8 @@ const gl: TranslationKeys = {
 
 
   "upload.title": "Sube o teu informe do broker",
+  "upload.broker_question": "Que broker(s) utilizas?",
+  "upload.broker_hint": "Selecciona un ou varios. Guiarémoste paso a paso.",
   "upload.broker_label": "Broker:",
   "upload.auto_detect": "Auto-detectar",
   "upload.drop_text": "Arrastra o teu ficheiro aquí ou fai clic para seleccionar",
@@ -147,6 +149,7 @@ const gl: TranslationKeys = {
   "guide.title": "Como obter o informe?",
   "guide.tip_fifo": "Inclúe todo o histórico — DeclaRenta necesita operacións anteriores para o cálculo FIFO correcto.",
   "guide.select_broker_hint": "Selecciona o teu broker para ver as instrucións de descarga do informe.",
+  "guide.heading": "Como obter o informe do teu broker?",
   "guide.ibkr.title": "Interactive Brokers (Flex Query XML)",
   "guide.ibkr.step1": "Inicia sesión no <strong>Portal do Cliente</strong> de IBKR",
   "guide.ibkr.step2": "Vai a <strong>Rendemento e Informes → Flex Queries</strong>",

--- a/src/web/broker-guides.ts
+++ b/src/web/broker-guides.ts
@@ -41,7 +41,7 @@ function renderCards(grid: HTMLElement): void {
     const title = t(`guide.${b.id}.title` as Parameters<typeof t>[0]);
     const isSelected = selected.has(b.id);
     return `
-      <button class="broker-card${isSelected ? " selected" : ""}" data-broker="${b.id}" type="button">
+      <button class="broker-card${isSelected ? " selected" : ""}" data-broker="${b.id}" type="button" aria-pressed="${isSelected}">
         <span class="broker-card-check">${isSelected ? "&#10003;" : ""}</span>
         <span class="broker-card-name">${title}</span>
         <span class="broker-card-format">${b.format}</span>

--- a/src/web/broker-guides.ts
+++ b/src/web/broker-guides.ts
@@ -1,69 +1,104 @@
 /**
- * Broker-specific document acquisition guides.
+ * Broker selection cards + step-by-step guides.
  *
- * Shows expandable panels with step-by-step instructions for
- * obtaining the correct report from each supported broker.
+ * Renders a visual grid of broker cards. Users click to select one or more.
+ * Selected brokers show their download guide inline below the grid.
  */
 
 import { t } from "../i18n/index.js";
+
+interface BrokerInfo {
+  id: string;
+  format: string;
+}
+
+const BROKERS: BrokerInfo[] = [
+  { id: "ibkr", format: "XML" },
+  { id: "degiro", format: "CSV" },
+  { id: "scalable", format: "CSV" },
+  { id: "etoro", format: "XLSX" },
+  { id: "freedom24", format: "JSON" },
+  { id: "coinbase", format: "CSV" },
+  { id: "binance", format: "CSV" },
+  { id: "kraken", format: "CSV" },
+];
+
+const selected = new Set<string>();
 
 function getGuideSteps(broker: string): string[] {
   const steps: string[] = [];
   for (let i = 1; i <= 10; i++) {
     const key = `guide.${broker}.step${i}`;
     const val = t(key as Parameters<typeof t>[0]);
-    if (val === key) break; // Key doesn't exist, stop
+    if (val === key) break;
     steps.push(val);
   }
   return steps;
 }
 
-/** Initialize broker guide display */
+function renderCards(grid: HTMLElement): void {
+  grid.innerHTML = BROKERS.map((b) => {
+    const title = t(`guide.${b.id}.title` as Parameters<typeof t>[0]);
+    const isSelected = selected.has(b.id);
+    return `
+      <button class="broker-card${isSelected ? " selected" : ""}" data-broker="${b.id}" type="button">
+        <span class="broker-card-check">${isSelected ? "&#10003;" : ""}</span>
+        <span class="broker-card-name">${title}</span>
+        <span class="broker-card-format">${b.format}</span>
+      </button>
+    `;
+  }).join("");
+}
+
+function renderGuides(container: HTMLElement): void {
+  if (selected.size === 0) {
+    container.innerHTML = "";
+    return;
+  }
+
+  const guides = Array.from(selected).map((brokerId) => {
+    const title = t(`guide.${brokerId}.title` as Parameters<typeof t>[0]);
+    const steps = getGuideSteps(brokerId);
+    if (steps.length === 0) return "";
+    return `
+      <div class="broker-guide open" data-broker="${brokerId}">
+        <div class="broker-guide-header">
+          <span class="broker-guide-name">${title}</span>
+        </div>
+        <div class="broker-guide-content">
+          <ol>${steps.map((s) => `<li>${s}</li>`).join("")}</ol>
+          <p class="guide-tip">${t("guide.tip_fifo")}</p>
+        </div>
+      </div>
+    `;
+  }).join("");
+
+  container.innerHTML = guides;
+}
+
+/** Initialize broker card grid + guides */
 export function initBrokerGuides(): void {
-  const brokerSelect = document.getElementById("broker-select") as HTMLSelectElement | null;
-  const container = document.getElementById("broker-guide-container");
-  if (!brokerSelect || !container) return;
+  const grid = document.getElementById("broker-card-grid");
+  const guideContainer = document.getElementById("broker-guide-container");
+  if (!grid || !guideContainer) return;
 
-  function renderGuide(): void {
-    if (!container) return;
-    const selected = brokerSelect!.value;
+  function update(): void {
+    renderCards(grid!);
+    renderGuides(guideContainer!);
 
-    if (selected === "auto") {
-      container.innerHTML = `<p class="muted">${t("guide.select_broker_hint")}</p>`;
-    } else {
-      const titleKey = `guide.${selected}.title`;
-      const title = t(titleKey as Parameters<typeof t>[0]);
-      const steps = getGuideSteps(selected);
-      if (steps.length > 0) {
-        container.innerHTML = renderPanel(title, steps);
-      } else {
-        container.innerHTML = "";
-      }
-    }
-
-    // Toggle behavior
-    container.querySelectorAll<HTMLElement>(".broker-guide").forEach((el) => {
-      el.querySelector(".broker-guide-header")?.addEventListener("click", () => {
-        el.classList.toggle("open");
+    // Bind card clicks
+    grid!.querySelectorAll<HTMLButtonElement>(".broker-card").forEach((card) => {
+      card.addEventListener("click", () => {
+        const id = card.dataset.broker!;
+        if (selected.has(id)) {
+          selected.delete(id);
+        } else {
+          selected.add(id);
+        }
+        update();
       });
     });
   }
 
-  brokerSelect.addEventListener("change", renderGuide);
-  renderGuide();
-}
-
-function renderPanel(title: string, steps: string[]): string {
-  return `
-    <div class="broker-guide">
-      <div class="broker-guide-header">
-        ${title}
-        <span class="broker-guide-toggle">&#9660;</span>
-      </div>
-      <div class="broker-guide-content">
-        <ol>${steps.map((s) => `<li>${s}</li>`).join("")}</ol>
-        <p class="guide-tip">${t("guide.tip_fifo")}</p>
-      </div>
-    </div>
-  `;
+  update();
 }

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -190,30 +190,30 @@
         <div id="d6-content"></div>
       </section>
 
+      <footer>
+        <p>
+          <a href="./docs.html" data-i18n="footer.docs">Documentación</a> ·
+          <a href="https://github.com/GeiserX/DeclaRenta">GitHub</a> ·
+          <strong data-i18n="footer.privacy">Self-hosted · Privacidad total</strong>
+        </p>
+        <p class="credits">
+          Made with <span class="heart">&#9829;</span> by <a href="https://geiser.cloud">Sergio Fernández</a>
+        </p>
+        <p class="footer-sponsor">
+          <a href="https://github.com/sponsors/GeiserX" class="sponsor-btn">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>
+            Sponsor
+          </a>
+        </p>
+        <p class="footer-trust">
+          <span data-i18n="footer.open_source">100% código abierto</span> ·
+          <a href="https://github.com/GeiserX/DeclaRenta" data-i18n="footer.verify_source">Verificar código fuente</a>
+          · <span class="footer-version" id="footer-version"></span>
+        </p>
+      </footer>
+
     </main>
   </div>
-
-  <footer>
-    <p>
-      <a href="./docs.html" data-i18n="footer.docs">Documentación</a> ·
-      <a href="https://github.com/GeiserX/DeclaRenta">GitHub</a> ·
-      <strong data-i18n="footer.privacy">Self-hosted · Privacidad total</strong>
-    </p>
-    <p class="credits">
-      Made with <span class="heart">&#9829;</span> by <a href="https://geiser.cloud">Sergio Fernández</a>
-    </p>
-    <p class="footer-sponsor">
-      <a href="https://github.com/sponsors/GeiserX" class="sponsor-btn">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>
-        Sponsor
-      </a>
-    </p>
-    <p class="footer-trust">
-      <span data-i18n="footer.open_source">100% código abierto</span> ·
-      <a href="https://github.com/GeiserX/DeclaRenta" data-i18n="footer.verify_source">Verificar código fuente</a>
-      · <span class="footer-version" id="footer-version"></span>
-    </p>
-  </footer>
 
   <script type="module" src="./main.ts"></script>
 </body>

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -136,27 +136,24 @@
             </button>
           </div>
 
-          <!-- Step 1: Upload -->
+          <!-- Step 1: Select brokers + Upload -->
           <section id="wizard-step-1" class="wizard-panel">
-            <h2 data-i18n="upload.title">Sube tu informe del broker</h2>
-            <div class="broker-selector">
-              <label>
-                <span data-i18n="upload.broker_label">Broker:</span>
-                <select id="broker-select">
-                  <option value="auto" selected data-i18n="upload.auto_detect">Auto-detectar</option>
-                  <option value="ibkr">Interactive Brokers (XML)</option>
-                  <option value="degiro">Degiro (CSV)</option>
-                  <option value="scalable">Scalable Capital (CSV)</option>
-                  <option value="etoro">eToro (XLSX)</option>
-                  <option value="freedom24">Freedom24 (JSON)</option>
-                  <option value="coinbase">Coinbase (CSV)</option>
-                  <option value="binance">Binance (CSV)</option>
-                  <option value="kraken">Kraken (CSV)</option>
-                </select>
-              </label>
-            </div>
-            <!-- Broker guide panel (inserted dynamically) -->
+            <!-- Hidden select for backwards compatibility -->
+            <select id="broker-select" hidden>
+              <option value="auto" selected>Auto-detectar</option>
+            </select>
+
+            <h2 data-i18n="upload.broker_question">¿Qué broker(s) utilizas?</h2>
+            <p class="section-description" data-i18n="upload.broker_hint">Selecciona uno o varios. Te guiaremos paso a paso.</p>
+
+            <!-- Broker card grid (rendered by broker-guides.ts) -->
+            <div id="broker-card-grid" class="broker-card-grid"></div>
+
+            <!-- Guides for selected brokers (rendered by broker-guides.ts) -->
             <div id="broker-guide-container" class="broker-guide-container"></div>
+
+            <!-- Upload zone -->
+            <h3 class="upload-heading" data-i18n="upload.title">Sube tu informe del broker</h3>
             <div id="drop-zone" role="button" tabindex="0" data-i18n-aria="a11y.drop_zone" aria-label="Zona de carga de ficheros">
               <div class="drop-icon" aria-hidden="true">&#8683;</div>
               <p data-i18n="upload.drop_text">Arrastra tu fichero aquí o haz clic para seleccionar</p>

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -7,14 +7,50 @@
   <meta name="description" content="Convierte reportes de IBKR, Degiro, Scalable Capital, eToro y Freedom24 en valores para tu declaración de la renta española. Self-hosted, privacidad total." />
   <meta name="theme-color" content="#3b82f6" />
   <link rel="manifest" href="./manifest.json" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://data-api.ecb.europa.eu; img-src 'self' data:; frame-ancestors 'none'" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src 'self' https://data-api.ecb.europa.eu; img-src 'self' data:; frame-ancestors 'none'" />
   <link rel="icon" type="image/png" sizes="32x32" href="./favicon-32.png" />
   <link rel="icon" type="image/png" sizes="16x16" href="./favicon-16.png" />
   <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;0,9..40,800;1,9..40,400&family=DM+Serif+Display&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="./style.css" />
 </head>
 <body>
   <a href="#app-content" class="skip-link" data-i18n="a11y.skip_link">Saltar al contenido</a>
+
+  <!-- Splash / Landing screen -->
+  <div id="splash" class="splash">
+    <div class="splash-bg-grid" aria-hidden="true"></div>
+    <div class="splash-content">
+      <div class="splash-logo-wrap">
+        <img src="./icon-192.png" alt="DeclaRenta" class="splash-logo" width="120" height="120" />
+        <div class="splash-logo-glow" aria-hidden="true"></div>
+      </div>
+      <h1 class="splash-title">Decla<span class="brand-accent">Renta</span></h1>
+      <p class="splash-tagline" data-i18n="splash.tagline">Convierte reportes de brokers extranjeros en tu declaraci&oacute;n de la renta espa&ntilde;ola</p>
+
+      <div class="splash-brokers">
+        <span class="splash-broker-tag">IBKR</span>
+        <span class="splash-broker-tag">Degiro</span>
+        <span class="splash-broker-tag">eToro</span>
+        <span class="splash-broker-tag">Scalable</span>
+        <span class="splash-broker-tag">Freedom24</span>
+        <span class="splash-broker-tag">Coinbase</span>
+        <span class="splash-broker-tag">Binance</span>
+        <span class="splash-broker-tag">Kraken</span>
+      </div>
+
+      <div class="splash-features">
+        <div class="splash-feature" data-i18n="splash.feature_free">100% gratuito</div>
+        <div class="splash-feature" data-i18n="splash.feature_selfhosted">Self-hosted</div>
+        <div class="splash-feature" data-i18n="splash.feature_privacy">Privacidad total</div>
+        <div class="splash-feature" data-i18n="splash.feature_opensource">Open source</div>
+      </div>
+
+      <button id="splash-cta" class="splash-cta" data-i18n="splash.cta">Comenzar</button>
+    </div>
+  </div>
 
   <!-- Top bar -->
   <nav class="top-bar" data-i18n-aria="a11y.nav_label" aria-label="Ajustes">

--- a/src/web/main.ts
+++ b/src/web/main.ts
@@ -79,6 +79,33 @@ document.addEventListener("localechange", () => {
 updateStaticText();
 
 // ---------------------------------------------------------------------------
+// Splash screen
+// ---------------------------------------------------------------------------
+
+const splash = document.getElementById("splash");
+const splashCta = document.getElementById("splash-cta");
+
+function dismissSplash() {
+  if (!splash) return;
+  splash.classList.add("splash-exit");
+  splash.addEventListener("animationend", () => {
+    splash.remove();
+    document.body.classList.remove("splash-visible");
+  }, { once: true });
+  try { localStorage.setItem("declarenta_splash_seen", "1"); } catch { /* noop */ }
+}
+
+if (splash) {
+  const seen = localStorage.getItem("declarenta_splash_seen");
+  if (seen) {
+    splash.remove();
+  } else {
+    document.body.classList.add("splash-visible");
+    splashCta?.addEventListener("click", dismissSplash);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Theme toggle (auto / light / dark)
 // ---------------------------------------------------------------------------
 

--- a/src/web/main.ts
+++ b/src/web/main.ts
@@ -89,21 +89,35 @@ function dismissSplash() {
   if (!splash) return;
   splash.classList.add("splash-exit");
   splash.addEventListener("animationend", () => {
-    splash.remove();
+    splash.hidden = true;
+    splash.classList.remove("splash-exit");
     document.body.classList.remove("splash-visible");
   }, { once: true });
   try { localStorage.setItem("declarenta_splash_seen", "1"); } catch { /* noop */ }
 }
 
+function showSplash() {
+  if (!splash) return;
+  splash.hidden = false;
+  splash.classList.remove("splash-exit");
+  document.body.classList.add("splash-visible");
+}
+
 if (splash) {
   const seen = localStorage.getItem("declarenta_splash_seen");
   if (seen) {
-    splash.remove();
+    splash.hidden = true;
   } else {
     document.body.classList.add("splash-visible");
     splashCta?.addEventListener("click", dismissSplash);
   }
 }
+
+// Logo click → show splash
+document.querySelector(".top-bar-brand")?.addEventListener("click", (e) => {
+  e.preventDefault();
+  showSplash();
+});
 
 // ---------------------------------------------------------------------------
 // Theme toggle (auto / light / dark)

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -235,13 +235,82 @@ h3 {
   color: var(--accent);
 }
 
-/* Broker selector */
-.broker-selector {
-  margin-bottom: 1rem;
+/* Broker card grid */
+.broker-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
 }
 
-.broker-selector select {
-  margin-left: 0.5rem;
+.broker-card {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: var(--surface);
+  border: 2px solid var(--border);
+  border-radius: 10px;
+  cursor: pointer;
+  transition: border-color 0.2s, background 0.2s, transform 0.15s, box-shadow 0.2s;
+  font-family: inherit;
+  font-size: 0.85rem;
+  color: var(--text);
+  text-align: left;
+}
+
+.broker-card:hover {
+  border-color: var(--accent);
+  background: var(--row-hover);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-sm, 0 2px 8px rgba(0,0,0,0.1));
+}
+
+.broker-card.selected {
+  border-color: var(--accent);
+  background: var(--accent-subtle, rgba(59, 130, 246, 0.08));
+  box-shadow: 0 0 0 1px var(--accent), var(--shadow-sm, 0 2px 8px rgba(0,0,0,0.1));
+}
+
+.broker-card-check {
+  width: 20px;
+  height: 20px;
+  border-radius: 5px;
+  border: 2px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  flex-shrink: 0;
+  transition: background 0.15s, border-color 0.15s;
+  color: white;
+}
+
+.broker-card.selected .broker-card-check {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.broker-card-name {
+  flex: 1;
+  font-weight: 600;
+}
+
+.broker-card-format {
+  font-size: 0.7rem;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  background: var(--tag-bg);
+  color: var(--accent);
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.upload-heading {
+  margin-top: 1.5rem;
+  margin-bottom: 0.75rem;
+  font-size: 1.1rem;
+  color: var(--text);
 }
 
 /* Drop zone */
@@ -500,6 +569,7 @@ details ul {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+  cursor: pointer;
 }
 
 .brand-logo {

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -735,6 +735,7 @@ footer a:hover {
 .disclaimer-content h3 {
   font-size: 1.2rem;
   margin-bottom: 1rem;
+  text-align: center;
   color: var(--text);
 }
 

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -1,88 +1,124 @@
 /* Dark theme (default) */
 :root {
   --topbar-h: 49px;
-  --bg: #0f1117;
-  --surface: #1a1d27;
-  --border: #2a2d3a;
-  --text: #e4e4e7;
-  --muted: #71717a;
+  --bg: #0b0e14;
+  --surface: #141820;
+  --surface-raised: #1a1f2b;
+  --border: #232a3a;
+  --text: #e8eaed;
+  --muted: #7a8194;
   --accent: #3b82f6;
   --accent-hover: #2563eb;
+  --accent-subtle: rgba(59, 130, 246, 0.08);
+  --accent-glow: rgba(59, 130, 246, 0.15);
+  --gold: #e5a63b;
+  --gold-subtle: rgba(229, 166, 59, 0.1);
   --success: #22c55e;
   --warning: #f59e0b;
   --danger: #ef4444;
   --row-alt: rgba(255, 255, 255, 0.02);
-  --row-hover: rgba(59, 130, 246, 0.05);
-  --drop-hover: rgba(59, 130, 246, 0.05);
+  --row-hover: rgba(59, 130, 246, 0.06);
+  --drop-hover: rgba(59, 130, 246, 0.06);
   --tag-bg: rgba(59, 130, 246, 0.1);
   --tag-border: rgba(59, 130, 246, 0.3);
   --warning-bg: rgba(245, 158, 11, 0.1);
   --warning-border: rgba(245, 158, 11, 0.3);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.3);
+  --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.4);
+  --topbar-bg: linear-gradient(180deg, #161b26 0%, #111620 100%);
 }
 
 /* Light theme */
 @media (prefers-color-scheme: light) {
   :root:not([data-theme="dark"]) {
-    --bg: #f8fafc;
+    --bg: #f5f7fa;
     --surface: #ffffff;
-    --border: #e2e8f0;
+    --surface-raised: #ffffff;
+    --border: #dfe3ea;
     --text: #1a202c;
-    --muted: #718096;
+    --muted: #5f6b7a;
     --accent: #2563eb;
     --accent-hover: #1d4ed8;
+    --accent-subtle: rgba(37, 99, 235, 0.06);
+    --accent-glow: rgba(37, 99, 235, 0.1);
+    --gold: #b8860b;
+    --gold-subtle: rgba(184, 134, 11, 0.08);
     --success: #16a34a;
     --warning: #d97706;
     --danger: #dc2626;
     --row-alt: rgba(0, 0, 0, 0.02);
-    --row-hover: rgba(59, 130, 246, 0.06);
-    --drop-hover: rgba(59, 130, 246, 0.04);
-    --tag-bg: rgba(59, 130, 246, 0.08);
-    --tag-border: rgba(59, 130, 246, 0.25);
+    --row-hover: rgba(37, 99, 235, 0.05);
+    --drop-hover: rgba(37, 99, 235, 0.04);
+    --tag-bg: rgba(37, 99, 235, 0.07);
+    --tag-border: rgba(37, 99, 235, 0.2);
     --warning-bg: rgba(245, 158, 11, 0.08);
     --warning-border: rgba(245, 158, 11, 0.25);
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+    --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.08);
+    --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.1);
+    --topbar-bg: linear-gradient(180deg, #ffffff 0%, #f8f9fb 100%);
   }
 }
 
 /* Explicit light override */
 [data-theme="light"] {
-  --bg: #f8fafc;
+  --bg: #f5f7fa;
   --surface: #ffffff;
-  --border: #e2e8f0;
+  --surface-raised: #ffffff;
+  --border: #dfe3ea;
   --text: #1a202c;
-  --muted: #718096;
+  --muted: #5f6b7a;
   --accent: #2563eb;
   --accent-hover: #1d4ed8;
+  --accent-subtle: rgba(37, 99, 235, 0.06);
+  --accent-glow: rgba(37, 99, 235, 0.1);
+  --gold: #b8860b;
+  --gold-subtle: rgba(184, 134, 11, 0.08);
   --success: #16a34a;
   --warning: #d97706;
   --danger: #dc2626;
   --row-alt: rgba(0, 0, 0, 0.02);
-  --row-hover: rgba(59, 130, 246, 0.06);
-  --drop-hover: rgba(59, 130, 246, 0.04);
-  --tag-bg: rgba(59, 130, 246, 0.08);
-  --tag-border: rgba(59, 130, 246, 0.25);
+  --row-hover: rgba(37, 99, 235, 0.05);
+  --drop-hover: rgba(37, 99, 235, 0.04);
+  --tag-bg: rgba(37, 99, 235, 0.07);
+  --tag-border: rgba(37, 99, 235, 0.2);
   --warning-bg: rgba(245, 158, 11, 0.08);
   --warning-border: rgba(245, 158, 11, 0.25);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.06);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.08);
+  --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.1);
+  --topbar-bg: linear-gradient(180deg, #ffffff 0%, #f8f9fb 100%);
 }
 
 /* Explicit dark override */
 [data-theme="dark"] {
-  --bg: #0f1117;
-  --surface: #1a1d27;
-  --border: #2a2d3a;
-  --text: #e4e4e7;
-  --muted: #71717a;
+  --bg: #0b0e14;
+  --surface: #141820;
+  --surface-raised: #1a1f2b;
+  --border: #232a3a;
+  --text: #e8eaed;
+  --muted: #7a8194;
   --accent: #3b82f6;
   --accent-hover: #2563eb;
+  --accent-subtle: rgba(59, 130, 246, 0.08);
+  --accent-glow: rgba(59, 130, 246, 0.15);
+  --gold: #e5a63b;
+  --gold-subtle: rgba(229, 166, 59, 0.1);
   --success: #22c55e;
   --warning: #f59e0b;
   --danger: #ef4444;
   --row-alt: rgba(255, 255, 255, 0.02);
-  --row-hover: rgba(59, 130, 246, 0.05);
-  --drop-hover: rgba(59, 130, 246, 0.05);
+  --row-hover: rgba(59, 130, 246, 0.06);
+  --drop-hover: rgba(59, 130, 246, 0.06);
   --tag-bg: rgba(59, 130, 246, 0.1);
   --tag-border: rgba(59, 130, 246, 0.3);
   --warning-bg: rgba(245, 158, 11, 0.1);
   --warning-border: rgba(245, 158, 11, 0.3);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.3);
+  --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.4);
+  --topbar-bg: linear-gradient(180deg, #161b26 0%, #111620 100%);
 }
 
 * {
@@ -130,11 +166,16 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-family: "DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   background: var(--bg);
   color: var(--text);
   line-height: 1.6;
   min-height: 100vh;
+}
+
+body.splash-visible .top-bar,
+body.splash-visible .app-layout {
+  display: none;
 }
 
 main {
@@ -174,15 +215,18 @@ header p {
 section {
   background: var(--surface);
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: 14px;
   padding: 2rem;
   margin-bottom: 1.5rem;
+  box-shadow: var(--shadow-sm);
 }
 
 h2 {
-  font-size: 1.4rem;
-  font-weight: 700;
+  font-family: "DM Serif Display", Georgia, serif;
+  font-size: 1.5rem;
+  font-weight: 400;
   margin-bottom: 1rem;
+  letter-spacing: -0.01em;
 }
 
 h3 {
@@ -203,17 +247,20 @@ h3 {
 /* Drop zone */
 #drop-zone {
   border: 2px dashed var(--border);
-  border-radius: 8px;
+  border-radius: 14px;
   padding: 3rem 2rem;
   text-align: center;
   cursor: pointer;
-  transition: border-color 0.2s, background 0.2s;
+  transition: border-color 0.25s, background 0.25s, box-shadow 0.25s, transform 0.2s;
+  background: var(--accent-subtle);
 }
 
 #drop-zone:hover,
 #drop-zone.dragover {
   border-color: var(--accent);
-  background: var(--drop-hover);
+  background: var(--accent-glow);
+  box-shadow: 0 0 0 4px var(--accent-subtle);
+  transform: scale(1.005);
 }
 
 .drop-icon {
@@ -221,11 +268,12 @@ h3 {
   line-height: 1;
   margin-bottom: 0.5rem;
   color: var(--muted);
-  transition: color 0.2s;
+  transition: color 0.25s, transform 0.25s;
 }
 
 #drop-zone:hover .drop-icon {
   color: var(--accent);
+  transform: translateY(-2px);
 }
 
 #file-input {
@@ -294,11 +342,12 @@ button {
   background: var(--accent);
   color: white;
   border: none;
-  border-radius: 8px;
+  border-radius: 10px;
   padding: 0.75rem 2rem;
   font-size: 1rem;
+  font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s;
+  transition: background 0.2s, transform 0.15s, box-shadow 0.2s;
 }
 
 .export-buttons button {
@@ -307,11 +356,19 @@ button {
 
 button:hover {
   background: var(--accent-hover);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.2);
+}
+
+button:active {
+  transform: translateY(0);
 }
 
 button[disabled] {
-  opacity: 0.5;
+  opacity: 0.4;
   cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
 }
 
 .export-buttons {
@@ -337,7 +394,8 @@ button[disabled] {
   max-height: 500px;
   overflow-y: auto;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 12px;
+  box-shadow: var(--shadow-sm);
 }
 
 table {
@@ -431,9 +489,11 @@ details ul {
   align-items: center;
   justify-content: space-between;
   padding: 0.5rem 1rem;
-  background: var(--surface);
+  background: var(--topbar-bg);
   border-bottom: 1px solid var(--border);
   z-index: 20;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
 }
 
 .top-bar-brand {
@@ -443,13 +503,20 @@ details ul {
 }
 
 .brand-logo {
-  border-radius: 6px;
+  border-radius: 8px;
+  transition: transform 0.2s;
+  box-shadow: var(--shadow-sm);
+}
+
+.brand-logo:hover {
+  transform: scale(1.05);
 }
 
 .top-bar-brand h1 {
+  font-family: "DM Serif Display", Georgia, serif;
   font-size: 1.4rem;
-  font-weight: 800;
-  letter-spacing: -0.03em;
+  font-weight: 400;
+  letter-spacing: -0.01em;
   line-height: 1;
   margin: 0;
 }
@@ -493,6 +560,7 @@ details ul {
   top: var(--topbar-h);
   height: calc(100vh - var(--topbar-h));
   overflow-y: auto;
+  box-shadow: 1px 0 0 var(--border);
 }
 
 .sidebar-nav {
@@ -511,17 +579,21 @@ details ul {
   color: var(--text);
   text-decoration: none;
   font-size: 0.9rem;
-  transition: background 0.15s, color 0.15s;
+  font-weight: 500;
+  transition: background 0.2s, color 0.2s, transform 0.15s, box-shadow 0.2s;
+  position: relative;
 }
 
 .sidebar-link:hover {
   background: var(--row-hover);
+  transform: translateX(2px);
 }
 
 .sidebar-link.active {
-  background: rgba(59, 130, 246, 0.1);
+  background: var(--accent-subtle);
   color: var(--accent);
   font-weight: 600;
+  box-shadow: inset 3px 0 0 var(--accent);
 }
 
 .sidebar-icon {
@@ -715,17 +787,18 @@ footer a:hover {
   background: var(--surface);
   color: var(--text);
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: 16px;
   padding: 0;
   max-width: 540px;
   width: 90vw;
   margin: auto;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--shadow-lg);
 }
 
 .disclaimer-dialog::backdrop {
   background: rgba(0, 0, 0, 0.5);
-  backdrop-filter: blur(4px);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
 }
 
 .disclaimer-content {
@@ -761,10 +834,15 @@ footer a:hover {
 }
 
 .chart-card {
-  background: var(--bg);
+  background: var(--surface-raised);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 1rem;
+  border-radius: 12px;
+  padding: 1.15rem;
+  transition: border-color 0.2s;
+}
+
+.chart-card:hover {
+  border-color: var(--accent);
 }
 
 .chart-title {
@@ -820,24 +898,27 @@ footer a:hover {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 2.25rem;
-  height: 2.25rem;
+  width: 2.5rem;
+  height: 2.5rem;
   border-radius: 50%;
   background: var(--border);
   color: var(--muted);
   font-weight: 700;
   font-size: 0.9rem;
-  transition: background 0.2s, color 0.2s;
+  transition: background 0.3s, color 0.3s, box-shadow 0.3s, transform 0.2s;
 }
 
 .wizard-indicator.active .wizard-step-num {
   background: var(--accent);
   color: #fff;
+  box-shadow: 0 0 0 4px var(--accent-subtle), 0 2px 8px rgba(59, 130, 246, 0.3);
+  transform: scale(1.05);
 }
 
 .wizard-indicator.completed .wizard-step-num {
   background: var(--success);
   color: #fff;
+  box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.1);
 }
 
 .wizard-step-label {
@@ -859,6 +940,13 @@ footer a:hover {
   max-width: 6rem;
   margin: 0 0.25rem;
   margin-bottom: 1.5rem;
+  border-radius: 1px;
+  position: relative;
+  overflow: hidden;
+}
+
+.wizard-indicator.completed + .wizard-connector {
+  background: var(--success);
 }
 
 /* Wizard panels */
@@ -896,11 +984,13 @@ footer a:hover {
   background: var(--surface);
   color: var(--text);
   border: 1px solid var(--border);
+  box-shadow: none;
 }
 
 .btn-secondary:hover {
   background: var(--row-hover);
   border-color: var(--accent);
+  box-shadow: none;
 }
 
 .btn-small {
@@ -936,10 +1026,16 @@ footer a:hover {
 }
 
 .review-card {
-  background: var(--bg);
+  background: var(--surface-raised);
   border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 1rem;
+  border-radius: 12px;
+  padding: 1.15rem;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.review-card:hover {
+  border-color: var(--accent);
+  box-shadow: 0 2px 8px var(--accent-subtle);
 }
 
 .review-card .review-label {
@@ -976,11 +1072,11 @@ footer a:hover {
 }
 
 .casilla-card {
-  background: var(--bg);
+  background: var(--surface-raised);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: 12px;
   overflow: hidden;
-  transition: border-color 0.2s;
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.15s;
 }
 
 .casilla-card.expandable {
@@ -989,10 +1085,13 @@ footer a:hover {
 
 .casilla-card.expandable:hover {
   border-color: var(--accent);
+  box-shadow: 0 2px 12px var(--accent-subtle);
+  transform: translateY(-1px);
 }
 
 .casilla-card.expanded {
   border-color: var(--accent);
+  box-shadow: 0 2px 12px var(--accent-subtle);
 }
 
 .casilla-header {
@@ -1319,12 +1418,13 @@ footer a:hover {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.75rem 1rem;
-  background: var(--accent);
+  padding: 0.85rem 1.25rem;
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-hover) 100%);
   color: #fff;
-  border-radius: 8px;
+  border-radius: 12px;
   margin-bottom: 1.5rem;
   font-weight: 600;
+  box-shadow: 0 4px 16px rgba(59, 130, 246, 0.2);
 }
 
 .section-header-bar .section-deadline {
@@ -1461,6 +1561,186 @@ footer a:hover {
   font-size: 0.7rem;
 }
 
+/* ==========================================================================
+   SPLASH SCREEN
+   ========================================================================== */
+
+.splash {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg);
+  overflow: hidden;
+}
+
+.splash-bg-grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(var(--border) 1px, transparent 1px),
+    linear-gradient(90deg, var(--border) 1px, transparent 1px);
+  background-size: 60px 60px;
+  opacity: 0.25;
+  mask-image: radial-gradient(ellipse 70% 60% at 50% 40%, black 30%, transparent 100%);
+  -webkit-mask-image: radial-gradient(ellipse 70% 60% at 50% 40%, black 30%, transparent 100%);
+}
+
+.splash-content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 2rem;
+  max-width: 640px;
+  animation: splashFadeIn 0.6s ease-out;
+}
+
+@keyframes splashFadeIn {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.splash-logo-wrap {
+  position: relative;
+  margin-bottom: 1.5rem;
+}
+
+.splash-logo {
+  width: 120px;
+  height: 120px;
+  border-radius: 24px;
+  box-shadow: var(--shadow-lg);
+  position: relative;
+  z-index: 1;
+  animation: splashLogoPulse 3s ease-in-out infinite;
+}
+
+@keyframes splashLogoPulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.03); }
+}
+
+.splash-logo-glow {
+  position: absolute;
+  inset: -20px;
+  border-radius: 50%;
+  background: radial-gradient(circle, var(--accent-glow) 0%, transparent 70%);
+  filter: blur(20px);
+  z-index: 0;
+}
+
+.splash-title {
+  font-family: "DM Serif Display", Georgia, serif;
+  font-size: 3.5rem;
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  margin-bottom: 0.75rem;
+  display: block;
+}
+
+.splash-tagline {
+  font-size: 1.1rem;
+  color: var(--muted);
+  line-height: 1.6;
+  max-width: 480px;
+  margin-bottom: 2rem;
+}
+
+.splash-brokers {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 2rem;
+}
+
+.splash-broker-tag {
+  padding: 0.3rem 0.75rem;
+  background: var(--accent-subtle);
+  border: 1px solid var(--tag-border);
+  border-radius: 20px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--accent);
+  letter-spacing: 0.02em;
+  transition: background 0.2s, transform 0.2s;
+}
+
+.splash-broker-tag:hover {
+  background: var(--accent-glow);
+  transform: translateY(-1px);
+}
+
+.splash-features {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem 1.5rem;
+  margin-bottom: 2.5rem;
+}
+
+.splash-feature {
+  font-size: 0.85rem;
+  color: var(--muted);
+  position: relative;
+  padding-left: 1.1rem;
+}
+
+.splash-feature::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--gold);
+}
+
+.splash-cta {
+  padding: 0.9rem 3rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+  border-radius: 12px;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s, background 0.2s;
+  box-shadow: 0 4px 20px rgba(59, 130, 246, 0.3);
+  letter-spacing: 0.01em;
+}
+
+.splash-cta:hover {
+  background: var(--accent-hover);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 28px rgba(59, 130, 246, 0.4);
+}
+
+.splash-cta:active {
+  transform: translateY(0);
+}
+
+/* Splash exit animation */
+.splash-exit {
+  animation: splashExit 0.45s ease-in forwards;
+  pointer-events: none;
+}
+
+@keyframes splashExit {
+  to {
+    opacity: 0;
+    transform: translateY(-30px) scale(0.97);
+  }
+}
+
 /* Responsive — tablet */
 @media (max-width: 1024px) {
   .app-content {
@@ -1474,6 +1754,27 @@ footer a:hover {
 
 /* Responsive — phone */
 @media (max-width: 768px) {
+  .splash-title {
+    font-size: 2.5rem;
+  }
+
+  .splash-logo {
+    width: 96px;
+    height: 96px;
+  }
+
+  .splash-tagline {
+    font-size: 1rem;
+  }
+
+  .splash-content {
+    padding: 1.5rem;
+  }
+
+  .splash-features {
+    gap: 0.5rem 1rem;
+  }
+
   .sidebar-toggle {
     display: block;
   }


### PR DESCRIPTION
## Summary
- Full-screen splash with bull logo, tagline, broker tags, and "Comenzar" CTA
- Complete visual overhaul: DM Serif Display + DM Sans typography, deeper dark theme, gold accents, layered surfaces
- Replace broker dropdown with visual card grid (multi-select with checkmarks)
- Selected brokers show step-by-step file acquisition guides inline
- Click top-bar logo to return to splash screen
- Footer moved inside content area (no longer under sidebar)
- Disclaimer modal title centered
- Polished sidebar, wizard steps, buttons, drop zone with micro-interactions
- i18n keys for splash + broker selection in all 5 locales

## Test plan
- [ ] Clear localStorage, verify splash screen appears with logo + CTA
- [ ] Click "Comenzar", verify app appears with smooth animation
- [ ] Click DeclaRenta logo in top bar, verify splash returns
- [ ] Select broker cards, verify guides appear inline
- [ ] Multi-select brokers, verify all guides shown
- [ ] Upload file via drop zone, verify auto-detect still works
- [ ] Verify footer is inside content area (not under sidebar)
- [ ] Verify disclaimer title is centered
- [ ] Test dark/light theme toggle
- [ ] Test mobile responsive layout
- [ ] `npm run build` succeeds
- [ ] `npm test` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a splash/landing screen displayed on first visit with feature highlights and a call-to-action
  * Enhanced broker selection with a multi-select card grid interface
  * Added new guide section for broker-specific instructions

* **Styling**
  * Refreshed typography with new fonts (DM Sans, DM Serif Display)
  * Updated color scheme and visual components across the interface
  * Enhanced broker card design with selection states and improved interactions

* **Internationalization**
  * Added new translation strings for splash screen, broker selection prompts, and guides across Catalan, English, Spanish, Euskara, and Galego

<!-- end of auto-generated comment: release notes by coderabbit.ai -->