### PR TITLE
fix(web): splash screen not dismissing on click

### DIFF
--- a/src/web/main.ts
+++ b/src/web/main.ts
@@ -89,8 +89,7 @@ function dismissSplash() {
   if (!splash) return;
   splash.classList.add("splash-exit");
   splash.addEventListener("animationend", () => {
-    splash.hidden = true;
-    splash.classList.remove("splash-exit");
+    splash.style.display = "none";
     document.body.classList.remove("splash-visible");
   }, { once: true });
   try { localStorage.setItem("declarenta_splash_seen", "1"); } catch { /* noop */ }
@@ -98,7 +97,7 @@ function dismissSplash() {
 
 function showSplash() {
   if (!splash) return;
-  splash.hidden = false;
+  splash.style.display = "";
   splash.classList.remove("splash-exit");
   document.body.classList.add("splash-visible");
 }
@@ -107,7 +106,7 @@ if (splash) {
   splashCta?.addEventListener("click", dismissSplash);
   const seen = localStorage.getItem("declarenta_splash_seen");
   if (seen) {
-    splash.hidden = true;
+    splash.style.display = "none";
   } else {
     document.body.classList.add("splash-visible");
   }


### PR DESCRIPTION
## Summary
- `.splash { display: flex }` in CSS overrides the `hidden` attribute's `display: none` (author CSS beats UA stylesheet)
- When `dismissSplash()` set `splash.hidden = true`, it had no effect — then removing `splash-exit` class snapped the splash back to full visibility
- Fix: use `splash.style.display = "none"` (inline style beats class selector) instead of the `hidden` attribute

## Test plan
- [ ] Click "Comenzar" — splash dismisses and stays dismissed
- [ ] Refresh page — splash stays hidden (localStorage)
- [ ] Click brand logo — splash returns
- [ ] Click "Comenzar" again — dismisses correctly