### PR TITLE
fix(i18n): re-render dynamic sections on locale change

### DIFF
--- a/src/web/broker-guides.ts
+++ b/src/web/broker-guides.ts
@@ -101,4 +101,7 @@ export function initBrokerGuides(): void {
   }
 
   update();
+
+  // Re-render when locale changes
+  document.addEventListener("localechange", () => update());
 }

--- a/src/web/main.ts
+++ b/src/web/main.ts
@@ -22,8 +22,8 @@ import { initWizard, goToStep, onStepChange, unlockStep, type WizardStep } from 
 import { initSidebar, updateBadge } from "./sidebar.js";
 import { initProfile, getProfile } from "./profile.js";
 import { initBrokerGuides } from "./broker-guides.js";
-import { initSection720, renderSection720 } from "./section-720.js";
-import { initSectionD6, renderSectionD6 } from "./section-d6.js";
+import { initSection720, renderSection720, rerenderSection720 } from "./section-720.js";
+import { initSectionD6, renderSectionD6, rerenderSectionD6 } from "./section-d6.js";
 import { t, initLocale, setLocale, getCurrentLocale, getLocaleNames, type Locale } from "../i18n/index.js";
 import Decimal from "decimal.js";
 
@@ -74,6 +74,9 @@ langSelect.addEventListener("change", () => {
 document.addEventListener("localechange", () => {
   updateStaticText();
   if (currentReport) renderResults(currentReport);
+  rerenderSection720();
+  rerenderSectionD6();
+  initProfile();
 });
 
 updateStaticText();


### PR DESCRIPTION
## Summary
- Broker guides, profile form, 720, and D-6 sections use `t()` for dynamic rendering but didn't re-render when the locale changed
- Wire up `localechange` event to re-render all dynamic sections

## Test plan
- [ ] Change language — broker guide text updates
- [ ] Change language — profile form labels update
- [ ] Change language with data loaded — 720 and D-6 sections update