### PR TITLE
Update D-6 to reflect 2021 reform (Orden ICT/1408/2021)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Si inviertes con un broker extranjero, hacer la renta es un infierno:
 - **Regla anti-churning** de 2 meses que nadie detecta automáticamente
 - **Doble imposición** internacional que hay que calcular a mano
 - **Modelo 720** obligatorio si tus activos en el extranjero superan 50.000 EUR
-- **Modelo D-6** para titulares de valores extranjeros a 31 de diciembre (verificar normativa vigente)
+- **Modelo D-6** solo obligatorio si tu participación es ≥10% del capital o derechos de voto (Orden ICT/1408/2021)
 
 DeclaRenta automatiza todo esto.
 

--- a/src/i18n/locales/ca.ts
+++ b/src/i18n/locales/ca.ts
@@ -212,7 +212,7 @@ const ca: TranslationKeys = {
 
   "d6.title": "Model D-6 — Inversions a l'exterior",
   "d6.description": "Declaració al Registre d'Inversions del Ministeri d'Economia.",
-  "d6.no_minimum": "El D-6 és obligatori per a QUALSEVOL import. No té llindar mínim.",
+  "d6.no_minimum": "Des de l'Orden ICT/1408/2021, el D-6 només és obligatori si la teva participació representa el <strong>10% o més</strong> del capital o drets de vot d'una empresa cotitzada estrangera. La majoria d'inversors minoristes estan exempts.",
   "d6.no_positions": "Puja un informe amb posicions obertes al Model 100 per analitzar el D-6.",
   "d6.positions_title": "Posicions a declarar",
   "d6.cancellations_title": "Cancel·lacions",
@@ -240,7 +240,7 @@ const ca: TranslationKeys = {
   "m720.empty_description": "El Model 720 és una declaració informativa obligatòria si posseeixes béns a l'estranger valorats en més de 50.000 €. Puja el teu informe del broker a la secció Model 100 perquè DeclaRenta calculi automàticament si superes el llindar i generi el fitxer. Termini: 1 de gener – 31 de març.",
   "m720.empty_cta": "Anar a Model 100",
   "d6.empty_title": "No hi ha posicions carregades",
-  "d6.empty_description": "El Model D-6 declara les teves inversions en valors estrangers davant el Ministeri d'Economia. És obligatori per a QUALSEVOL import (sense llindar mínim). Puja el teu informe del broker a la secció Model 100 i DeclaRenta generarà la guia pas a pas per emplenar el formulari AFORIX. Termini: 1 – 31 de gener.",
+  "d6.empty_description": "El Model D-6 declara les teves inversions en valors estrangers davant el Ministeri d'Economia. Des de la reforma de 2021 (Orden ICT/1408/2021), només és obligatori si la teva participació representa el 10% o més del capital o drets de vot d'una empresa cotitzada estrangera. Puja el teu informe del broker a la secció Model 100 i DeclaRenta generarà la guia pas a pas. Termini: 1 – 31 de gener.",
   "d6.empty_cta": "Anar a Model 100",
 
   // Profile required warnings

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -216,7 +216,7 @@ const en: TranslationKeys = {
   // Modelo D-6 section
   "d6.title": "Modelo D-6 — Foreign investments declaration",
   "d6.description": "Declaration to the Investment Registry of the Ministry of Economy.",
-  "d6.no_minimum": "D-6 is mandatory for ANY amount. There is no minimum threshold.",
+  "d6.no_minimum": "Since Orden ICT/1408/2021, the D-6 is only required if your stake represents <strong>10% or more</strong> of the capital or voting rights of a listed foreign company. Most retail investors are exempt.",
   "d6.no_positions": "Upload a report with open positions in Modelo 100 to analyze D-6.",
   "d6.positions_title": "Positions to declare",
   "d6.cancellations_title": "Cancellations",
@@ -244,7 +244,7 @@ const en: TranslationKeys = {
   "m720.empty_description": "Modelo 720 is a mandatory informative declaration if you hold foreign assets valued over 50,000 EUR. Upload your broker report in the Modelo 100 section so DeclaRenta can automatically check if you exceed the threshold and generate the file. Deadline: January 1 – March 31.",
   "m720.empty_cta": "Go to Modelo 100",
   "d6.empty_title": "No positions loaded",
-  "d6.empty_description": "Modelo D-6 declares your foreign securities investments to the Ministry of Economy. It is mandatory for ANY amount (no minimum threshold). Upload your broker report in the Modelo 100 section and DeclaRenta will generate a step-by-step guide to fill in the AFORIX form. Deadline: January 1–31.",
+  "d6.empty_description": "Modelo D-6 declares your foreign securities investments to the Ministry of Economy. Since the 2021 reform (Orden ICT/1408/2021), it is only required if your stake represents 10% or more of the capital or voting rights of a listed foreign company. Upload your broker report in the Modelo 100 section and DeclaRenta will generate a step-by-step guide. Deadline: January 1–31.",
   "d6.empty_cta": "Go to Modelo 100",
 
   // Profile required warnings

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -243,7 +243,7 @@ const es = {
   // Modelo D-6 section
   "d6.title": "Modelo D-6 — Inversiones en el exterior",
   "d6.description": "Declaración al Registro de Inversiones del Ministerio de Economía.",
-  "d6.no_minimum": "El D-6 es obligatorio para CUALQUIER importe. No tiene umbral mínimo.",
+  "d6.no_minimum": "Desde la Orden ICT/1408/2021, el D-6 solo es obligatorio si tu participación representa el <strong>10% o más</strong> del capital o derechos de voto de una empresa cotizada extranjera. La mayoría de inversores minoristas están exentos.",
   "d6.no_positions": "Sube un informe con posiciones abiertas en Modelo 100 para analizar el D-6.",
   "d6.positions_title": "Posiciones a declarar",
   "d6.cancellations_title": "Cancelaciones",
@@ -273,7 +273,7 @@ const es = {
   "m720.empty_description": "El Modelo 720 es una declaración informativa obligatoria si posees bienes en el extranjero valorados en más de 50.000 €. Sube tu informe del broker en la sección Modelo 100 para que DeclaRenta calcule automáticamente si superas el umbral y genere el fichero. Plazo: 1 de enero – 31 de marzo.",
   "m720.empty_cta": "Ir a Modelo 100",
   "d6.empty_title": "No hay posiciones cargadas",
-  "d6.empty_description": "El Modelo D-6 declara tus inversiones en valores extranjeros ante el Ministerio de Economía. Es obligatorio para CUALQUIER importe (sin umbral mínimo). Sube tu informe del broker en la sección Modelo 100 y DeclaRenta generará la guía paso a paso para rellenar el formulario AFORIX. Plazo: 1 – 31 de enero.",
+  "d6.empty_description": "El Modelo D-6 declara inversiones en valores extranjeros ante el Ministerio de Economía. Desde la reforma de 2021 (Orden ICT/1408/2021), solo es obligatorio si tu participación representa el 10% o más del capital o derechos de voto de una empresa cotizada extranjera. Sube tu informe del broker en la sección Modelo 100 y DeclaRenta generará la guía paso a paso. Plazo: 1 – 31 de enero.",
   "d6.empty_cta": "Ir a Modelo 100",
 
   // Profile required warnings

--- a/src/i18n/locales/eu.ts
+++ b/src/i18n/locales/eu.ts
@@ -212,7 +212,7 @@ const eu: TranslationKeys = {
 
   "d6.title": "D-6 Eredua — Atzerriko inbertsioak",
   "d6.description": "Ekonomia Ministerioko Inbertsio Erregistroko aitorpena.",
-  "d6.no_minimum": "D-6 EDOZEIN zenbatekorako da nahitaezkoa. Ez du gutxieneko atalaserik.",
+  "d6.no_minimum": "ICT/1408/2021 Aginduaz geroztik, D-6 soilik nahitaezkoa da zure partaidetza atzerriko enpresa kotizatu baten kapitalaren edo boto-eskubideen <strong>%10 edo gehiago</strong> bada. Txikizkako inbertitzaile gehienak salbuetsita daude.",
   "d6.no_positions": "Igo posizio irekiak dituen txostena 100 Ereduan D-6 aztertzeko.",
   "d6.positions_title": "Aitortu beharreko posizioak",
   "d6.cancellations_title": "Baliogabetzeak",
@@ -240,7 +240,7 @@ const eu: TranslationKeys = {
   "m720.empty_description": "720 Eredua aitorpen informatibo nahitaezkoa da atzerrian 50.000 € baino gehiagoko ondasunak badituzu. Igo zure brokerraren txostena 100 Ereduaren atalean, DeclaRentak automatikoki kalkulatu dezan atalasea gainditzen duzun eta fitxategia sortzeko. Epea: urtarrilaren 1etik martxoaren 31ra.",
   "m720.empty_cta": "100 Eredura joan",
   "d6.empty_title": "Ez dago posiziorik kargatuta",
-  "d6.empty_description": "D-6 Ereduak atzerriko baloreetan dituzun inbertsioak aitortzen ditu Ekonomia Ministerioan. EDOZEIN zenbatekorako da nahitaezkoa (gutxieneko atalaserik gabe). Igo zure brokerraren txostena 100 Ereduaren atalean eta DeclaRentak AFORIX formularioa betetzeko pausoz pausoko gida sortuko du. Epea: urtarrilaren 1etik 31ra.",
+  "d6.empty_description": "D-6 Ereduak atzerriko baloreetan dituzun inbertsioak aitortzen ditu Ekonomia Ministerioan. 2021eko erreformatik (ICT/1408/2021 Agindua), soilik nahitaezkoa da zure partaidetza atzerriko enpresa kotizatu baten kapitalaren edo boto-eskubideen %10 edo gehiago bada. Igo zure brokerraren txostena 100 Ereduaren atalean eta DeclaRentak pausoz pausoko gida sortuko du. Epea: urtarrilaren 1etik 31ra.",
   "d6.empty_cta": "100 Eredura joan",
 
   // Profile required warnings

--- a/src/i18n/locales/gl.ts
+++ b/src/i18n/locales/gl.ts
@@ -212,7 +212,7 @@ const gl: TranslationKeys = {
 
   "d6.title": "Modelo D-6 — Investimentos no exterior",
   "d6.description": "Declaración ao Rexistro de Investimentos do Ministerio de Economía.",
-  "d6.no_minimum": "O D-6 é obrigatorio para CALQUERA importe. Non ten limiar mínimo.",
+  "d6.no_minimum": "Desde a Orde ICT/1408/2021, o D-6 só é obrigatorio se a túa participación representa o <strong>10% ou máis</strong> do capital ou dereitos de voto dunha empresa cotizada estranxeira. A maioría dos investidores minoristas están exentos.",
   "d6.no_positions": "Sube un informe con posicións abertas no Modelo 100 para analizar o D-6.",
   "d6.positions_title": "Posicións a declarar",
   "d6.cancellations_title": "Cancelacións",
@@ -240,7 +240,7 @@ const gl: TranslationKeys = {
   "m720.empty_description": "O Modelo 720 é unha declaración informativa obrigatoria se posúes bens no estranxeiro valorados en máis de 50.000 €. Sube o teu informe do broker na sección Modelo 100 para que DeclaRenta calcule automaticamente se superas o limiar e xere o ficheiro. Prazo: 1 de xaneiro – 31 de marzo.",
   "m720.empty_cta": "Ir a Modelo 100",
   "d6.empty_title": "Non hai posicións cargadas",
-  "d6.empty_description": "O Modelo D-6 declara os teus investimentos en valores estranxeiros ante o Ministerio de Economía. É obrigatorio para CALQUERA importe (sen limiar mínimo). Sube o teu informe do broker na sección Modelo 100 e DeclaRenta xerará a guía paso a paso para encher o formulario AFORIX. Prazo: 1 – 31 de xaneiro.",
+  "d6.empty_description": "O Modelo D-6 declara investimentos en valores estranxeiros ante o Ministerio de Economía. Desde a reforma de 2021 (Orde ICT/1408/2021), só é obrigatorio se a túa participación representa o 10% ou máis do capital ou dereitos de voto dunha empresa cotizada estranxeira. Sube o teu informe do broker na sección Modelo 100 e DeclaRenta xerará a guía paso a paso. Prazo: 1 – 31 de xaneiro.",
   "d6.empty_cta": "Ir a Modelo 100",
 
   // Profile required warnings

--- a/src/web/section-d6.ts
+++ b/src/web/section-d6.ts
@@ -93,8 +93,8 @@ export function renderSectionD6(statement: Statement, rateMap: EcbRateMap): void
     </div>`;
   }
 
-  // No minimum threshold reminder
-  html += `<div class="banner banner-info">${t("d6.no_minimum")}</div>`;
+  // 10% threshold reminder (Orden ICT/1408/2021)
+  html += `<div class="banner banner-warning">${t("d6.no_minimum")}</div>`;
 
   // Total value
   const totalValue = positions.reduce((sum, p) => {


### PR DESCRIPTION
## Summary
- D-6 is no longer mandatory for all foreign securities holders
- Since Orden ICT/1408/2021, only investors with ≥10% stake in capital or voting rights of a listed foreign company must file
- Updated all 5 locales, README, and section banner
- Reference: https://comercio.gob.es/es-es/NotasPrensa/2021/Paginas/211222_DeclaracionInversiones.aspx

## Test plan
- [x] All 492 tests pass
- [x] TypeScript compiles cleanly
- [ ] Manual: verify D-6 section shows 10% threshold warning instead of "ANY amount"