### PR TITLE
fix: handle IBKR semicolon dateTime format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,14 @@ tests/           Vitest tests mirroring src/ structure
 3. Add tests in `tests/parsers/<broker>.test.ts` with anonymized fixture data
 4. Export from `src/index.ts`
 
+### IBKR DateTime Format (Hard Trace)
+- IBKR Flex Query dateTime fields use `YYYYMMDD;HHMMSS` format (e.g. `"20190916;130630"`), NOT `YYYY-MM-DD` or plain `YYYYMMDD`
+- **Symptom**: `Error: Invalid time value` when processing dividends/interest, or silently wrong ECB rate lookups
+- **Root cause**: Code using `dateTime.slice(0, 10)` gets `"20190916;1"` instead of a valid date — the semicolon is at position 8, not position 10
+- **Fix**: Always use `normalizeDate()` from `dates.ts` which strips the `;HHMMSS` time component. Never use raw `slice()` on dateTime fields.
+- **Safe pattern**: `slice(0, 8)` also works (extracts `"20190916"`) but `normalizeDate()` is preferred as it handles all formats
+- **Files affected**: `dividends.ts`, `report.ts` used `slice(0, 10)` — `fifo.ts` was safe because it used `slice(0, 8)` + `normalizeDate()`
+
 ### IBKR Multi-Account Flex Queries
 - When users export a Flex Query covering multiple IBKR accounts, the XML contains multiple `<FlexStatement>` elements inside `<FlexStatements count="N">`
 - The parser merges all accounts' trades, cashTransactions, corporateActions, openPositions, and securitiesInfo into a single combined FlexStatement

--- a/src/engine/dates.ts
+++ b/src/engine/dates.ts
@@ -6,11 +6,14 @@
  * provides safe parsing for both formats.
  */
 
-/** Normalize a date string to YYYY-MM-DD format */
+/** Normalize a date string to YYYY-MM-DD format.
+ *  Handles YYYYMMDD, YYYY-MM-DD, and IBKR's YYYYMMDD;HHMMSS datetime format. */
 export function normalizeDate(date: string): string {
-  return date.length === 8 && !date.includes("-")
-    ? `${date.slice(0, 4)}-${date.slice(4, 6)}-${date.slice(6, 8)}`
-    : date;
+  // Strip IBKR time component (e.g. "20190916;130630" → "20190916")
+  const dateOnly = date.includes(";") ? date.split(";")[0]! : date;
+  return dateOnly.length === 8 && !dateOnly.includes("-")
+    ? `${dateOnly.slice(0, 4)}-${dateOnly.slice(4, 6)}-${dateOnly.slice(6, 8)}`
+    : dateOnly;
 }
 
 /** Parse a date string in YYYYMMDD or YYYY-MM-DD format */

--- a/src/engine/dividends.ts
+++ b/src/engine/dividends.ts
@@ -10,7 +10,7 @@ import type { CashTransaction } from "../types/ibkr.js";
 import type { DividendEntry } from "../types/tax.js";
 import type { EcbRateMap } from "../types/ecb.js";
 import { getEcbRate } from "./ecb.js";
-import { parseDate } from "./dates.js";
+import { normalizeDate, parseDate } from "./dates.js";
 
 /**
  * Process IBKR cash transactions to extract dividends with withholdings.
@@ -29,7 +29,7 @@ export function calculateDividends(
   const withholdings = cashTransactions.filter((t) => t.type === "Withholding Tax");
 
   return dividends.map((div) => {
-    const ecbRate = getEcbRate(rateMap, div.dateTime.slice(0, 10), div.currency);
+    const ecbRate = getEcbRate(rateMap, normalizeDate(div.dateTime), div.currency);
     const grossAmount = new Decimal(div.amount);
 
     // Find matching withholding (same ISIN, same or close date)
@@ -38,7 +38,7 @@ export function calculateDividends(
         w.isin === div.isin &&
         w.currency === div.currency &&
         Math.abs(
-          parseDate(w.dateTime.slice(0, 10)).getTime() - parseDate(div.dateTime.slice(0, 10)).getTime(),
+          parseDate(normalizeDate(w.dateTime)).getTime() - parseDate(normalizeDate(div.dateTime)).getTime(),
         ) <= 7 * 24 * 60 * 60 * 1000, // Within 7 days
     );
 
@@ -53,7 +53,7 @@ export function calculateDividends(
       isin: div.isin,
       symbol: div.symbol,
       description: div.description,
-      payDate: div.dateTime.slice(0, 10),
+      payDate: normalizeDate(div.dateTime),
       grossAmountEur: grossAmount.mul(ecbRate),
       withholdingTaxEur: withholdingAmount.mul(ecbRate),
       withholdingCountry: country,

--- a/src/generators/report.ts
+++ b/src/generators/report.ts
@@ -15,6 +15,7 @@ import { detectWashSales } from "../engine/wash-sale.js";
 import { calculateDividends } from "../engine/dividends.js";
 import { calculateDoubleTaxation } from "../engine/double-taxation.js";
 import { getEcbRate } from "../engine/ecb.js";
+import { normalizeDate } from "../engine/dates.js";
 
 /**
  * Generate a complete tax report from an IBKR Flex Statement.
@@ -68,7 +69,7 @@ export function generateTaxReport(
   let interestEarned = new Decimal(0);
   let interestPaid = new Decimal(0);
   const interestEntries = interestTransactions.map((t) => {
-    const ecbRate = getEcbRate(rateMap, t.dateTime.slice(0, 10), t.currency);
+    const ecbRate = getEcbRate(rateMap, normalizeDate(t.dateTime), t.currency);
     const amountEur = new Decimal(t.amount).mul(ecbRate);
     const isEarned = t.type.includes("Received");
 
@@ -81,7 +82,7 @@ export function generateTaxReport(
     return {
       type: isEarned ? "earned" as const : "paid" as const,
       description: t.description,
-      date: t.dateTime.slice(0, 10),
+      date: normalizeDate(t.dateTime),
       amountEur: amountEur.abs(),
       currency: t.currency,
       ecbRate,

--- a/tests/engine/dates.test.ts
+++ b/tests/engine/dates.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseDate, daysBetween } from "../../src/engine/dates.js";
+import { normalizeDate, parseDate, daysBetween } from "../../src/engine/dates.js";
 
 describe("parseDate", () => {
   it("should parse YYYYMMDD format", () => {
@@ -14,6 +14,33 @@ describe("parseDate", () => {
     expect(d.getUTCFullYear()).toBe(2025);
     expect(d.getUTCMonth()).toBe(8); // September
     expect(d.getUTCDate()).toBe(20);
+  });
+});
+
+describe("normalizeDate", () => {
+  it("should normalize YYYYMMDD to YYYY-MM-DD", () => {
+    expect(normalizeDate("20190916")).toBe("2019-09-16");
+  });
+
+  it("should pass through YYYY-MM-DD unchanged", () => {
+    expect(normalizeDate("2019-09-16")).toBe("2019-09-16");
+  });
+
+  it("should strip IBKR semicolon time component", () => {
+    expect(normalizeDate("20190916;130630")).toBe("2019-09-16");
+  });
+
+  it("should handle IBKR datetime with midnight time", () => {
+    expect(normalizeDate("20200101;000000")).toBe("2020-01-01");
+  });
+});
+
+describe("parseDate with IBKR datetime", () => {
+  it("should parse YYYYMMDD;HHMMSS format", () => {
+    const d = parseDate("20190916;130630");
+    expect(d.getUTCFullYear()).toBe(2019);
+    expect(d.getUTCMonth()).toBe(8); // September
+    expect(d.getUTCDate()).toBe(16);
   });
 });
 


### PR DESCRIPTION
## Summary
- IBKR Flex Query `dateTime` fields use `YYYYMMDD;HHMMSS` format (e.g. `"20190916;130630"`), not plain `YYYYMMDD` or `YYYY-MM-DD`
- `dividends.ts` and `report.ts` used `dateTime.slice(0, 10)` which produced `"20190916;1"` → `Error: Invalid time value`
- Replaced all raw `slice(0, 10)` on dateTime with `normalizeDate()` which strips the `;HHMMSS` component
- Added 5 new tests for the semicolon datetime format
- Documented the hard trace in AGENTS.md

## Root cause
The semicolon in IBKR's datetime sits at position 8, so `slice(0, 10)` crosses the boundary and includes `";1"` from the time part. `fifo.ts` was unaffected because it used `slice(0, 8)` + `normalizeDate()`.

## Test plan
- [x] 500/500 tests pass (5 new date tests added)
- [x] TypeScript strict check passes
- [x] Verified with real multi-currency IBKR XML (650 trades, 129 cash transactions, USD/CAD/GBP)