### PR TITLE
fix: add profile save button, skip empty year reports, normalize warning dates

### DIFF
--- a/src/engine/fifo.ts
+++ b/src/engine/fifo.ts
@@ -361,7 +361,7 @@ export class FifoEngine {
     const lots = this.lots.get(key);
     if (!lots || lots.length === 0) {
       // Short sale or missing prior data — warn and record with zero cost basis
-      this.warnings.push(`⚠ Venta sin lotes: ${trade.symbol} (${trade.isin}) × ${remaining} el ${trade.tradeDate}. Coste base = 0 (posible posición corta o datos previos incompletos).`);
+      this.warnings.push(`⚠ Venta sin lotes: ${trade.symbol} (${trade.isin}) × ${remaining} el ${normalizeDate(trade.tradeDate)}. Coste base = 0 (posible posición corta o datos previos incompletos).`);
       const proceedsBaseEur = remaining.mul(pricePerShare).mul(multiplier).minus(taxes).mul(ecbRate);
       const proceedsEur = proceedsBaseEur.minus(commission.mul(commissionEcbRate));
       this.disposals.push({
@@ -438,7 +438,7 @@ export class FifoEngine {
 
     if (remaining.greaterThan(0)) {
       // Remaining shares with no lots — short sale or data gap
-      this.warnings.push(`⚠ Lotes insuficientes: ${trade.symbol} (${trade.isin}) × ${remaining} el ${trade.tradeDate}. Coste base = 0.`);
+      this.warnings.push(`⚠ Lotes insuficientes: ${trade.symbol} (${trade.isin}) × ${remaining} el ${normalizeDate(trade.tradeDate)}. Coste base = 0.`);
       const fractionOfSale = remaining.dividedBy(totalSellQuantity);
       const commissionShare = commission.mul(fractionOfSale);
       const taxesShare = taxes.mul(fractionOfSale);

--- a/src/i18n/locales/ca.ts
+++ b/src/i18n/locales/ca.ts
@@ -145,6 +145,7 @@ const ca: TranslationKeys = {
   "profile.phone_label": "Telèfon:",
   "profile.phone_placeholder": "600123456",
   "profile.saved": "Perfil desat",
+  "profile.save_btn": "Desar perfil",
   "profile.incomplete_banner": "Completa el teu perfil fiscal per generar els models 720 i D-6.",
   "profile.go_to_profile": "Anar al perfil",
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -146,6 +146,7 @@ const en: TranslationKeys = {
   "profile.phone_label": "Phone:",
   "profile.phone_placeholder": "600123456",
   "profile.saved": "Profile saved",
+  "profile.save_btn": "Save profile",
   "profile.incomplete_banner": "Complete your tax profile to generate Modelo 720 and D-6 files.",
   "profile.go_to_profile": "Go to profile",
 

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -157,6 +157,7 @@ const es = {
   "profile.phone_label": "Teléfono:",
   "profile.phone_placeholder": "600123456",
   "profile.saved": "Perfil guardado",
+  "profile.save_btn": "Guardar perfil",
   "profile.incomplete_banner": "Completa tu perfil fiscal para generar los modelos 720 y D-6.",
   "profile.go_to_profile": "Ir al perfil",
 

--- a/src/i18n/locales/eu.ts
+++ b/src/i18n/locales/eu.ts
@@ -145,6 +145,7 @@ const eu: TranslationKeys = {
   "profile.phone_label": "Telefonoa:",
   "profile.phone_placeholder": "600123456",
   "profile.saved": "Profila gordeta",
+  "profile.save_btn": "Profila gorde",
   "profile.incomplete_banner": "Osatu zure profil fiskala 720 eta D-6 ereduak sortzeko.",
   "profile.go_to_profile": "Profilara joan",
 

--- a/src/i18n/locales/gl.ts
+++ b/src/i18n/locales/gl.ts
@@ -145,6 +145,7 @@ const gl: TranslationKeys = {
   "profile.phone_label": "Teléfono:",
   "profile.phone_placeholder": "600123456",
   "profile.saved": "Perfil gardado",
+  "profile.save_btn": "Gardar perfil",
   "profile.incomplete_banner": "Completa o teu perfil fiscal para xerar os modelos 720 e D-6.",
   "profile.go_to_profile": "Ir ao perfil",
 

--- a/src/web/profile.ts
+++ b/src/web/profile.ts
@@ -125,13 +125,13 @@ export function initProfile(): void {
           ${yearOptions}
         </select>
       </label>
+      <button type="submit" class="btn-primary" id="profile-save-btn">${t("profile.save_btn")}</button>
     </form>
     <p class="profile-saved-msg" id="profile-saved-msg">${t("profile.saved")}</p>
   `;
 
-  // Auto-save on any input change
-  document.getElementById("profile-form")!.addEventListener("input", () => {
-    const updated: FiscalProfile = {
+  function collectProfile(): FiscalProfile {
+    return {
       nif: (document.getElementById("profile-nif") as HTMLInputElement).value.trim().toUpperCase(),
       apellidos: (document.getElementById("profile-surname") as HTMLInputElement).value.trim(),
       nombre: (document.getElementById("profile-name") as HTMLInputElement).value.trim(),
@@ -139,7 +139,17 @@ export function initProfile(): void {
       telefono: (document.getElementById("profile-phone") as HTMLInputElement).value.trim(),
       year: parseInt((document.getElementById("profile-year") as HTMLSelectElement).value, 10),
     };
-    saveProfile(updated);
+  }
+
+  // Auto-save on any input change
+  document.getElementById("profile-form")!.addEventListener("input", () => {
+    saveProfile(collectProfile());
+  });
+
+  // Explicit save button
+  document.getElementById("profile-form")!.addEventListener("submit", (e) => {
+    e.preventDefault();
+    saveProfile(collectProfile());
     showSavedMessage();
   });
 }

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -1289,6 +1289,12 @@ footer a:hover {
   grid-column: 1 / -1;
 }
 
+.profile-form button[type="submit"] {
+  grid-column: 1 / -1;
+  justify-self: start;
+  margin-top: 0.5rem;
+}
+
 .profile-saved-msg {
   color: var(--success);
   font-size: 0.85rem;

--- a/src/web/year-compare.ts
+++ b/src/web/year-compare.ts
@@ -18,6 +18,9 @@ function esc(s: string): string {
  * Convert a TaxSummary into a StoredReport and save to localStorage.
  */
 export function persistReport(report: TaxSummary, brokers: string[]): void {
+  // Don't persist empty reports (e.g. wrong year selected with no matching data)
+  if (report.capitalGains.disposals.length === 0 && report.dividends.entries.length === 0) return;
+
   const currencies = new Set<string>();
   for (const d of report.capitalGains.disposals) currencies.add(d.currency);
   for (const d of report.dividends.entries) currencies.add(d.currency);


### PR DESCRIPTION
## Summary
- Add explicit "Guardar perfil" button to fiscal profile form (was auto-saving silently with no visible confirmation)
- Don't persist reports with 0 disposals AND 0 dividends in year comparison table — prevents ghost years (e.g. 2025) showing with all zeros
- Normalize IBKR date format in FIFO warning messages (`20190918` → `2019-09-18`)

## Test plan
- [x] All 499 tests pass
- [x] Lint + typecheck clean
- [ ] Verify profile form shows save button
- [ ] Verify year comparison no longer shows empty years after clearing history
- [ ] Verify warning dates display in ISO format