### PR TITLE
fix: per-file broker names in review, year-filtered warnings, updated mismatch text

### DIFF
--- a/src/generators/report.ts
+++ b/src/generators/report.ts
@@ -92,9 +92,16 @@ export function generateTaxReport(
   // 4. Double taxation
   const doubleTaxation = calculateDoubleTaxation(dividendEntries);
 
+  // Filter warnings to those relevant to the selected year
+  const yearWarnings = fifoEngine.warnings.filter((w) => {
+    const dateMatch = w.match(/\b(\d{4})-\d{2}-\d{2}\b/);
+    if (!dateMatch) return true; // No date in warning → always show
+    return dateMatch[1] === yearStr;
+  });
+
   return {
     year,
-    warnings: fifoEngine.warnings,
+    warnings: yearWarnings,
     capitalGains: {
       transmissionValue,
       acquisitionValue,

--- a/src/i18n/locales/ca.ts
+++ b/src/i18n/locales/ca.ts
@@ -32,7 +32,7 @@ const ca: TranslationKeys = {
   "results.export_csv": "Exportar CSV",
   "results.operations_count": "{{count}} operació(ns)",
   "results.dividends_count": "{{count}} dividend(s)",
-  "results.year_mismatch": "El fitxer conté dades dels exercicis {{available}}, però l'exercici seleccionat és {{year}}. Canvia'l al teu Perfil fiscal.",
+  "results.year_mismatch": "El fitxer conté dades dels exercicis {{available}}, però l'exercici seleccionat és {{year}}. Selecciona un altre any al desplegable superior.",
 
   "table.isin": "ISIN",
   "table.symbol": "Símbol",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -31,7 +31,7 @@ const en: TranslationKeys = {
   "results.export_csv": "Export CSV",
   "results.operations_count": "{{count}} transaction(s)",
   "results.dividends_count": "{{count}} dividend(s)",
-  "results.year_mismatch": "The file contains data for tax years {{available}}, but the selected year is {{year}}. Change it in your Fiscal Profile.",
+  "results.year_mismatch": "The file contains data for tax years {{available}}, but the selected year is {{year}}. Select another year from the dropdown above.",
 
   "table.isin": "ISIN",
   "table.symbol": "Symbol",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -33,7 +33,7 @@ const es = {
   "results.export_csv": "Exportar CSV",
   "results.operations_count": "{{count}} operación(es)",
   "results.dividends_count": "{{count}} dividendo(s)",
-  "results.year_mismatch": "El fichero contiene datos de los ejercicios {{available}}, pero el ejercicio seleccionado es {{year}}. Cambia el ejercicio en tu Perfil fiscal.",
+  "results.year_mismatch": "El fichero contiene datos de los ejercicios {{available}}, pero el ejercicio seleccionado es {{year}}. Selecciona otro año en el desplegable superior.",
 
   // Table headers
   "table.isin": "ISIN",

--- a/src/i18n/locales/eu.ts
+++ b/src/i18n/locales/eu.ts
@@ -32,7 +32,7 @@ const eu: TranslationKeys = {
   "results.export_csv": "Esportatu CSV",
   "results.operations_count": "{{count}} eragiketa",
   "results.dividends_count": "{{count}} dibidendu",
-  "results.year_mismatch": "Fitxategiak {{available}} ekitaldietako datuak ditu, baina hautatutako ekitaldia {{year}} da. Aldatu zure Zerga Profilean.",
+  "results.year_mismatch": "Fitxategiak {{available}} ekitaldietako datuak ditu, baina hautatutako ekitaldia {{year}} da. Hautatu beste urte bat goiko zerrendan.",
 
   "table.isin": "ISIN",
   "table.symbol": "Sinboloa",

--- a/src/i18n/locales/gl.ts
+++ b/src/i18n/locales/gl.ts
@@ -32,7 +32,7 @@ const gl: TranslationKeys = {
   "results.export_csv": "Exportar CSV",
   "results.operations_count": "{{count}} operación(s)",
   "results.dividends_count": "{{count}} dividendo(s)",
-  "results.year_mismatch": "O ficheiro contén datos dos exercicios {{available}}, pero o exercicio seleccionado é {{year}}. Cámbiao no teu Perfil fiscal.",
+  "results.year_mismatch": "O ficheiro contén datos dos exercicios {{available}}, pero o exercicio seleccionado é {{year}}. Selecciona outro ano no despregable superior.",
 
   "table.isin": "ISIN",
   "table.symbol": "Símbolo",

--- a/src/web/main.ts
+++ b/src/web/main.ts
@@ -368,7 +368,7 @@ async function parseFiles(): Promise<void> {
       saveProfile(profile);
     }
 
-    renderReview(merged, detectedBrokers);
+    renderReview(merged, detectedBrokers, brokerNames);
     unlockStep(3);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
@@ -376,7 +376,7 @@ async function parseFiles(): Promise<void> {
   }
 }
 
-function renderReview(merged: Statement, brokers: string[]): void {
+function renderReview(merged: Statement, brokers: string[], perFileBrokers: string[]): void {
   const tradeCount = merged.trades.length;
   const divCount = merged.cashTransactions.filter((c) =>
     c.type === "Dividends" || c.type === "Payment In Lieu Of Dividends",
@@ -418,7 +418,7 @@ function renderReview(merged: Statement, brokers: string[]): void {
       <table>
         <thead><tr><th>${t("review.file")}</th><th>${t("review.broker")}</th></tr></thead>
         <tbody>${pendingFiles.map((f, i) => `
-          <tr><td>${esc(f.name)}</td><td>${esc(brokers[i] ?? "—")}</td></tr>
+          <tr><td>${esc(f.name)}</td><td>${esc(perFileBrokers[i] ?? "—")}</td></tr>
         `).join("")}</tbody>
       </table>
     </div>


### PR DESCRIPTION
## Summary
- **Review table**: Show correct broker name per file (was showing "—" for 2nd+ files when all are IBKR because the deduplicated array had only 1 entry)
- **Warnings**: Filter FIFO warnings by selected year — splits/sales from other years no longer pollute the current year's view (e.g. viewing 2023 won't show 2024-2025 warnings)
- **Year mismatch banner**: Updated text to reference the dropdown selector instead of "Cambia en Perfil fiscal" (since the year selector is right there in results)

## Test plan
- [x] All 499 tests pass
- [x] Lint + typecheck clean
- [ ] Upload multi-year IBKR file, verify all files show "Interactive Brokers" in review table
- [ ] Select year with no sales, verify 0 warnings (not warnings from other years)
- [ ] Year mismatch banner references dropdown, not profile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Tax report warnings now display only for the selected year
  * Each uploaded file's broker information is correctly shown in the review table

* **Improvements**
  * Updated user guidance messages to direct year selection via dropdown instead of profile settings (now in Catalan, English, Spanish, Euskara, and Galego)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->