### PR TITLE
fix: broker-aware validation warnings and year mismatch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,11 @@ name: Docker Build & Push
 on:
   push:
     tags: ["v*"]
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
   workflow_dispatch:
 
 jobs:
@@ -20,10 +25,15 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract version from tag
+      - name: Extract version
         id: meta
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          if [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+            VERSION="${VERSION#v}"
+          else
+            VERSION="${GITHUB_REF_NAME#v}"
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Build and push

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,11 @@ on:
       version:
         required: true
         type: string
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     name: Bump version and release
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    outputs:
+      new_tag: ${{ steps.version.outputs.new_tag }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -122,3 +124,12 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker:
+    name: Build and push Docker image
+    needs: release
+    if: needs.release.outputs.new_tag != ''
+    uses: ./.github/workflows/docker.yml
+    with:
+      version: ${{ needs.release.outputs.new_tag }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,4 +132,6 @@ jobs:
     uses: ./.github/workflows/docker.yml
     with:
       version: ${{ needs.release.outputs.new_tag }}
-    secrets: inherit
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <h1 align="center">DeclaRenta</h1>
 
 <p align="center">
-  <strong>Convierte reportes de brokers extranjeros en tu declaración de la renta española.</strong>
+  <strong>Herramienta fiscal gratuita para inversores con brokers internacionales.</strong>
 </p>
 
 <p align="center">

--- a/src/i18n/locales/ca.ts
+++ b/src/i18n/locales/ca.ts
@@ -334,6 +334,8 @@ const ca: TranslationKeys = {
   // Validation
   "validation.future_date": "L'operaci\u00f3 de {{symbol}} t\u00e9 data futura ({{date}}). Verifica les dades.",
   "validation.no_cash_transactions": "No s'han trobat transaccions d'efectiu (dividends/retencions). Si fas servir IBKR, activa la secci\u00f3 Cash Transactions a la teva Flex Query.",
+  "validation.no_cash_degiro": "No s'han trobat dividends ni retencions. Degiro els inclou en un fitxer separat: descarrega tamb\u00e9 el CSV de Compte (Account) des de la B\u00fastia.",
+  "validation.no_cash_generic": "No s'han trobat transaccions d'efectiu (dividends/retencions). Si el teu broker les exporta per separat, puja-les com a fitxer addicional.",
   "validation.no_trades_in_year": "No hi ha operacions a l'exercici {{year}}. Les operacions anteriors s'utilitzen per al c\u00e0lcul FIFO.",
   "validation.very_old_data": "Les dades inclouen operacions des de {{year}} (m\u00e9s de 10 anys). Verifica que el fitxer \u00e9s correcte.",
   "validation.duplicate_trades": "S'han detectat {{count}} operaci\u00f3(ns) duplicada(es). Revisa si has pujat el mateix fitxer dues vegades.",

--- a/src/i18n/locales/ca.ts
+++ b/src/i18n/locales/ca.ts
@@ -324,7 +324,7 @@ const ca: TranslationKeys = {
   "footer.verify_source": "Verificar codi font",
 
   // Splash screen
-  "splash.tagline": "Converteix informes de brokers estrangers en la teva declaraci\u00f3 de la renda espanyola",
+  "splash.tagline": "Eina fiscal gratu\u00efta per a inversors amb brokers internacionals",
   "splash.feature_free": "100% gratu\u00eft",
   "splash.feature_selfhosted": "Self-hosted",
   "splash.feature_privacy": "Privacitat total",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -338,6 +338,8 @@ const en: TranslationKeys = {
   // Validation
   "validation.future_date": "Trade for {{symbol}} has a future date ({{date}}). Please verify your data.",
   "validation.no_cash_transactions": "No cash transactions (dividends/withholdings) found. If using IBKR, enable the Cash Transactions section in your Flex Query.",
+  "validation.no_cash_degiro": "No dividends or withholdings found. Degiro includes them in a separate file: also download the Account CSV from the Inbox.",
+  "validation.no_cash_generic": "No cash transactions (dividends/withholdings) found. If your broker exports them separately, upload them as an additional file.",
   "validation.no_trades_in_year": "No trades found for tax year {{year}}. Prior trades are used for FIFO calculation.",
   "validation.very_old_data": "Data includes trades from {{year}} (over 10 years ago). Verify the file is correct.",
   "validation.duplicate_trades": "{{count}} duplicate trade(s) detected. Check if you uploaded the same file twice.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -328,7 +328,7 @@ const en: TranslationKeys = {
   "footer.verify_source": "Verify source code",
 
   // Splash screen
-  "splash.tagline": "Convert foreign broker reports into your Spanish tax declaration",
+  "splash.tagline": "Free tax tool for investors with international brokers",
   "splash.feature_free": "100% free",
   "splash.feature_selfhosted": "Self-hosted",
   "splash.feature_privacy": "Total privacy",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -357,7 +357,7 @@ const es = {
   "footer.verify_source": "Verificar código fuente",
 
   // Splash screen
-  "splash.tagline": "Convierte reportes de brokers extranjeros en tu declaración de la renta española",
+  "splash.tagline": "Herramienta fiscal gratuita para inversores con brokers internacionales",
   "splash.feature_free": "100% gratuito",
   "splash.feature_selfhosted": "Self-hosted",
   "splash.feature_privacy": "Privacidad total",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -367,6 +367,8 @@ const es = {
   // Validation
   "validation.future_date": "La operación de {{symbol}} tiene fecha futura ({{date}}). Verifica los datos.",
   "validation.no_cash_transactions": "No se han encontrado transacciones de efectivo (dividendos/retenciones). Si usas IBKR, activa la sección Cash Transactions en tu Flex Query.",
+  "validation.no_cash_degiro": "No se han encontrado dividendos ni retenciones. Degiro los incluye en un fichero separado: descarga también el CSV de Cuenta (Account) desde el Buzón.",
+  "validation.no_cash_generic": "No se han encontrado transacciones de efectivo (dividendos/retenciones). Si tu broker las exporta por separado, súbelas como fichero adicional.",
   "validation.no_trades_in_year": "No hay operaciones en el ejercicio {{year}}. Las operaciones anteriores se usan para el cálculo FIFO.",
   "validation.very_old_data": "Los datos incluyen operaciones desde {{year}} (más de 10 años). Verifica que el fichero es correcto.",
   "validation.duplicate_trades": "Se han detectado {{count}} operación(es) duplicada(s). Revisa si has subido el mismo fichero dos veces.",

--- a/src/i18n/locales/eu.ts
+++ b/src/i18n/locales/eu.ts
@@ -334,6 +334,8 @@ const eu: TranslationKeys = {
   // Validation
   "validation.future_date": "{{symbol}} eragiketak etorkizuneko data du ({{date}}). Egiaztatu datuak.",
   "validation.no_cash_transactions": "Ez da eskudiru-transakziorik aurkitu (dibidenduak/atxikipenak). IBKR erabiltzen baduzu, gaitu Cash Transactions atala zure Flex Query-n.",
+  "validation.no_cash_degiro": "Ez da dibidendurik edo atxikipenik aurkitu. Degirok fitxategi bereizi batean sartzen ditu: deskargatu Kontuaren CSV-a (Account) ere Sarrera-ontzitik.",
+  "validation.no_cash_generic": "Ez da eskudiru-transakziorik aurkitu (dibidenduak/atxikipenak). Zure brokerrak bereizita esportatzen baditu, igo fitxategi gehigarri gisa.",
   "validation.no_trades_in_year": "Ez dago eragiketarik {{year}} ekitaldian. Aurreko eragiketak FIFO kalkulurako erabiltzen dira.",
   "validation.very_old_data": "Datuek {{year}}(e)tik aurrerako eragiketak dituzte (10 urte baino gehiago). Egiaztatu fitxategia zuzena dela.",
   "validation.duplicate_trades": "{{count}} eragiketa bikoiztu detektatu d(ir)a. Egiaztatu fitxategi bera bi aldiz igo duzun.",

--- a/src/i18n/locales/eu.ts
+++ b/src/i18n/locales/eu.ts
@@ -324,7 +324,7 @@ const eu: TranslationKeys = {
   "footer.verify_source": "Iturburu-kodea egiaztatu",
 
   // Splash screen
-  "splash.tagline": "Bihurtu atzerriko broker-en txostenak zure Espainiako errenta aitorpenera",
+  "splash.tagline": "Doako zerga-tresna nazioarteko broker-ekin inbertitzaileentzat",
   "splash.feature_free": "100% doakoa",
   "splash.feature_selfhosted": "Self-hosted",
   "splash.feature_privacy": "Pribatutasun osoa",

--- a/src/i18n/locales/gl.ts
+++ b/src/i18n/locales/gl.ts
@@ -334,6 +334,8 @@ const gl: TranslationKeys = {
   // Validation
   "validation.future_date": "A operaci\u00f3n de {{symbol}} ten data futura ({{date}}). Verifica os datos.",
   "validation.no_cash_transactions": "Non se atoparon transacci\u00f3ns de efectivo (dividendos/retenci\u00f3ns). Se usas IBKR, activa a secci\u00f3n Cash Transactions na t\u00faa Flex Query.",
+  "validation.no_cash_degiro": "Non se atoparon dividendos nin retenci\u00f3ns. Degiro incl\u00faeos nun ficheiro separado: descarga tam\u00e9n o CSV de Conta (Account) desde o Buz\u00f3n.",
+  "validation.no_cash_generic": "Non se atoparon transacci\u00f3ns de efectivo (dividendos/retenci\u00f3ns). Se o teu broker as exporta por separado, s\u00fabeas como ficheiro adicional.",
   "validation.no_trades_in_year": "Non hai operaci\u00f3ns no exercicio {{year}}. As operaci\u00f3ns anteriores \u00fasanse para o c\u00e1lculo FIFO.",
   "validation.very_old_data": "Os datos incl\u00faen operaci\u00f3ns desde {{year}} (m\u00e1is de 10 anos). Verifica que o ficheiro \u00e9 correcto.",
   "validation.duplicate_trades": "Detect\u00e1ronse {{count}} operaci\u00f3n(s) duplicada(s). Revisa se subiches o mesmo ficheiro d\u00faas veces.",

--- a/src/i18n/locales/gl.ts
+++ b/src/i18n/locales/gl.ts
@@ -324,7 +324,7 @@ const gl: TranslationKeys = {
   "footer.verify_source": "Verificar código fonte",
 
   // Splash screen
-  "splash.tagline": "Converte reportes de brokers estranxeiros na túa declaración da renda española",
+  "splash.tagline": "Ferramenta fiscal gratu\u00edta para investidores con brokers internacionais",
   "splash.feature_free": "100% gratuíto",
   "splash.feature_selfhosted": "Self-hosted",
   "splash.feature_privacy": "Privacidade total",

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>DeclaRenta - Broker extranjero → Renta española</title>
-  <meta name="description" content="Convierte reportes de IBKR, Degiro, Scalable Capital, eToro y Freedom24 en valores para tu declaración de la renta española. Self-hosted, privacidad total." />
+  <meta name="description" content="Herramienta fiscal gratuita para inversores con brokers internacionales. IBKR, Degiro, Scalable Capital, eToro, Freedom24, Coinbase, Binance, Kraken. Self-hosted, privacidad total." />
   <meta name="theme-color" content="#3b82f6" />
   <link rel="manifest" href="./manifest.json" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src 'self' https://data-api.ecb.europa.eu; img-src 'self' data:; frame-ancestors 'none'" />
@@ -29,7 +29,7 @@
         <div class="splash-logo-glow" aria-hidden="true"></div>
       </div>
       <h1 class="splash-title">Decla<span class="brand-accent">Renta</span></h1>
-      <p class="splash-tagline" data-i18n="splash.tagline">Convierte reportes de brokers extranjeros en tu declaraci&oacute;n de la renta espa&ntilde;ola</p>
+      <p class="splash-tagline" data-i18n="splash.tagline">Herramienta fiscal gratuita para inversores con brokers internacionales</p>
 
       <div class="splash-brokers">
         <span class="splash-broker-tag">IBKR</span>

--- a/src/web/main.ts
+++ b/src/web/main.ts
@@ -431,7 +431,7 @@ function renderReview(merged: Statement, brokers: string[], perFileBrokers: stri
   }
 
   // Validation warnings
-  const validationIssues = validateStatement(merged, activeYear);
+  const validationIssues = validateStatement(merged, activeYear, brokers);
   if (validationIssues.length > 0) {
     reviewContent.insertAdjacentHTML("beforeend", renderValidationIssues(validationIssues));
   }
@@ -582,7 +582,7 @@ function renderResults(report: TaxSummary) {
       </span>
     </div>`;
 
-    if (!hasData && detectedYears.length > 0) {
+    if (!hasData && detectedYears.length > 0 && !detectedYears.includes(year)) {
       hdrHtml += `<div class="banner banner-warning">
         <span>${t("results.year_mismatch", { year: String(year), available: detectedYears.join(", ") })}</span>
       </div>`;

--- a/src/web/validation.ts
+++ b/src/web/validation.ts
@@ -39,12 +39,9 @@ export function validateStatement(statement: Statement, selectedYear: number | n
     const brokerLower = (brokers ?? []).map((b) => b.toLowerCase());
     const isDegiro = brokerLower.some((b) => b.includes("degiro"));
     const isIbkr = brokerLower.some((b) => b.includes("ibkr") || b.includes("interactive") || b.includes("mexem"));
-    const key = isDegiro
-      ? "validation.no_cash_degiro"
-      : isIbkr
-        ? "validation.no_cash_transactions"
-        : "validation.no_cash_generic";
-    issues.push({ level: "warning", message: t(key) });
+    if (isDegiro) issues.push({ level: "warning", message: t("validation.no_cash_degiro") });
+    if (isIbkr) issues.push({ level: "warning", message: t("validation.no_cash_transactions") });
+    if (!isDegiro && !isIbkr) issues.push({ level: "warning", message: t("validation.no_cash_generic") });
   }
 
   // 3. No trades for selected year

--- a/src/web/validation.ts
+++ b/src/web/validation.ts
@@ -14,7 +14,7 @@ export interface ValidationIssue {
  * Run sanity checks on parsed statement data.
  * Called after all files are parsed and merged, before processing.
  */
-export function validateStatement(statement: Statement, selectedYear: number | null): ValidationIssue[] {
+export function validateStatement(statement: Statement, selectedYear: number | null, brokers?: string[]): ValidationIssue[] {
   const issues: ValidationIssue[] = [];
   const trades = statement.trades;
 
@@ -32,14 +32,19 @@ export function validateStatement(statement: Statement, selectedYear: number | n
     }
   }
 
-  // 2. Missing IBKR Cash Transactions (dividends)
+  // 2. Missing cash transactions (dividends/withholdings)
   const hasTrades = trades.length > 0;
   const hasCash = statement.cashTransactions.length > 0;
   if (hasTrades && !hasCash) {
-    issues.push({
-      level: "warning",
-      message: t("validation.no_cash_transactions"),
-    });
+    const brokerLower = (brokers ?? []).map((b) => b.toLowerCase());
+    const isDegiro = brokerLower.some((b) => b.includes("degiro"));
+    const isIbkr = brokerLower.some((b) => b.includes("ibkr") || b.includes("interactive") || b.includes("mexem"));
+    const key = isDegiro
+      ? "validation.no_cash_degiro"
+      : isIbkr
+        ? "validation.no_cash_transactions"
+        : "validation.no_cash_generic";
+    issues.push({ level: "warning", message: t(key) });
   }
 
   // 3. No trades for selected year


### PR DESCRIPTION
## Summary
- Cash transaction warning now shows broker-specific guidance: Degiro users see "download Account CSV", IBKR users see "enable Cash Transactions", others get generic message
- Year mismatch banner no longer fires when selected year IS in the detected years (e.g. 2021 with buys but no sells showed contradictory message)

## Test plan
- [ ] Upload Degiro Transactions CSV — warning should mention Account CSV, not IBKR Flex Query
- [ ] Upload IBKR XML without Cash Transactions — warning should mention Flex Query
- [ ] Select a year with only buys (no sells) — should show empty results without the year mismatch banner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Broker-specific validation guidance for missing cash transactions, including detailed Degiro instructions
  * Expanded broker support messaging highlighting additional international brokers

* **Bug Fixes**
  * Corrected year-mismatch warning to display only when applicable to the data

* **Improvements**
  * Updated app messaging across all supported languages to reflect broader broker compatibility
  * Enhanced validation error messages with clearer guidance on required file uploads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->