### PR TITLE
docs: add Degiro Account CSV step to broker guide

### DIFF
--- a/src/i18n/locales/ca.ts
+++ b/src/i18n/locales/ca.ts
@@ -167,6 +167,7 @@ const ca: TranslationKeys = {
   "guide.degiro.step3": "Fes clic a <strong>Transaccions</strong> (historial de transaccions dels teus productes)",
   "guide.degiro.step4": "Selecciona el rang de dates desitjat (inclou <strong>tot l'històric</strong> per al FIFO)",
   "guide.degiro.step5": "Fes clic a <strong>Exportar</strong> i descarrega el fitxer CSV",
+  "guide.degiro.step6": "Per a dividends: torna a la <strong>B\u00fastia</strong> \u2192 <strong>Compte</strong> (historial de moviments del teu compte) \u2192 mateix rang de dates \u2192 <strong>Exportar</strong> CSV",
   "guide.etoro.title": "eToro (XLSX)",
   "guide.etoro.step1": "Inicia sessió a <strong>eToro</strong>",
   "guide.etoro.step2": "Ves a <strong>Configuració → Extracte de compte</strong>",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -169,6 +169,7 @@ const en: TranslationKeys = {
   "guide.degiro.step3": "Click <strong>Transactions</strong> (transaction history for your products)",
   "guide.degiro.step4": "Select the desired date range (include <strong>all history</strong> for FIFO)",
   "guide.degiro.step5": "Click <strong>Export</strong> and download the CSV file",
+  "guide.degiro.step6": "For dividends: go back to <strong>Inbox</strong> → <strong>Account</strong> (account movement history) → same date range → <strong>Export</strong> CSV",
   "guide.etoro.title": "eToro (XLSX)",
   "guide.etoro.step1": "Log in to <strong>eToro</strong>",
   "guide.etoro.step2": "Go to <strong>Settings → Account Statement</strong>",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -184,6 +184,7 @@ const es = {
   "guide.degiro.step3": "Haz clic en <strong>Transacciones</strong> (historial de transacciones de tus productos)",
   "guide.degiro.step4": "Selecciona el rango de fechas deseado (incluye <strong>todo el histórico</strong> para FIFO)",
   "guide.degiro.step5": "Haz clic en <strong>Exportar</strong> y descarga el fichero CSV",
+  "guide.degiro.step6": "Para dividendos: vuelve al <strong>Buzón</strong> → <strong>Cuenta</strong> (historial de movimientos de tu cuenta) → misma fecha → <strong>Exportar</strong> CSV",
 
   // eToro
   "guide.etoro.title": "eToro (XLSX)",

--- a/src/i18n/locales/eu.ts
+++ b/src/i18n/locales/eu.ts
@@ -167,6 +167,7 @@ const eu: TranslationKeys = {
   "guide.degiro.step3": "Egin klik <strong>Transakzioak</strong> (zure produktuen transakzio-historia)",
   "guide.degiro.step4": "Hautatu nahi duzun data-tartea (<strong>historia osoa</strong> sartu FIFO-rako)",
   "guide.degiro.step5": "Egin klik <strong>Esportatu</strong> botoian eta deskargatu CSV fitxategia",
+  "guide.degiro.step6": "Dibidenduetarako: itzuli <strong>Sarrera-ontzira</strong> \u2192 <strong>Kontua</strong> (kontuaren mugimendu-historia) \u2192 data-tarte bera \u2192 <strong>Esportatu</strong> CSV",
   "guide.etoro.title": "eToro (XLSX)",
   "guide.etoro.step1": "Hasi saioa <strong>eToro</strong>-n",
   "guide.etoro.step2": "Joan <strong>Ezarpenak → Kontu-laburpena</strong> atalera",

--- a/src/i18n/locales/gl.ts
+++ b/src/i18n/locales/gl.ts
@@ -167,6 +167,7 @@ const gl: TranslationKeys = {
   "guide.degiro.step3": "Fai clic en <strong>Transaccións</strong> (historial de transaccións dos teus produtos)",
   "guide.degiro.step4": "Selecciona o rango de datas desexado (inclúe <strong>todo o histórico</strong> para FIFO)",
   "guide.degiro.step5": "Fai clic en <strong>Exportar</strong> e descarga o ficheiro CSV",
+  "guide.degiro.step6": "Para dividendos: volve ao <strong>Buz\u00f3n</strong> \u2192 <strong>Conta</strong> (historial de movementos da t\u00faa conta) \u2192 mesmo rango de datas \u2192 <strong>Exportar</strong> CSV",
   "guide.etoro.title": "eToro (XLSX)",
   "guide.etoro.step1": "Inicia sesión en <strong>eToro</strong>",
   "guide.etoro.step2": "Vai a <strong>Axustes → Extracto de conta</strong>",


### PR DESCRIPTION
## Summary
- Adds step 6 to the Degiro broker guide across all 5 locales (es, en, ca, gl, eu)
- Instructs users to also download the **Account** (Cuenta) CSV for dividends and withholdings, not just the Transactions CSV

## Context
The Degiro guide only mentioned the Transactions CSV export. Users uploading only that file get a warning about missing cash transactions (dividends/withholdings), which live in a separate Account CSV export.

## Test plan
- [ ] `npm run typecheck` passes
- [ ] Broker guide renders step 6 for Degiro (auto-discovered by `broker-guides.ts`)