### PR TITLE
fix: use IBKR conid for FIFO lot matching on ISIN-less instruments

### DIFF
--- a/src/engine/fifo.ts
+++ b/src/engine/fifo.ts
@@ -16,9 +16,11 @@ import { daysBetween, normalizeDate } from "./dates.js";
 /** Known asset categories — warn on unknown values to catch future IBKR additions */
 const KNOWN_CATEGORIES: ReadonlySet<string> = new Set(["STK", "OPT", "FUT", "CASH", "BOND", "FUND", "WAR", "CRYPTO", "CFD"]);
 
-/** Lot grouping key: ISIN when available; otherwise asset category + symbol to prevent cross-type collisions */
-function lotKey(trade: { isin: string; symbol: string; assetCategory: string }): string {
-  return trade.isin || `${trade.assetCategory}:${trade.symbol}`;
+/** Lot grouping key: ISIN when available; conid for IBKR instruments without ISIN (survives ticker renames); otherwise asset category + symbol */
+function lotKey(trade: { isin: string; symbol: string; assetCategory: string; conid?: string }): string {
+  if (trade.isin) return trade.isin;
+  if (trade.conid) return `${trade.assetCategory}:conid:${trade.conid}`;
+  return `${trade.assetCategory}:${trade.symbol}`;
 }
 
 export class FifoEngine {

--- a/src/parsers/ibkr.ts
+++ b/src/parsers/ibkr.ts
@@ -96,6 +96,7 @@ function mapTrade(raw: Record<string, string>): Trade {
   return {
     tradeID: raw.tradeID ?? "",
     accountId: raw.accountId ?? "",
+    conid: raw.conid ?? "",
     symbol: raw.symbol ?? "",
     description: raw.description ?? "",
     isin: raw.isin ?? "",

--- a/src/parsers/ibkr.ts
+++ b/src/parsers/ibkr.ts
@@ -96,7 +96,7 @@ function mapTrade(raw: Record<string, string>): Trade {
   return {
     tradeID: raw.tradeID ?? "",
     accountId: raw.accountId ?? "",
-    conid: raw.conid ?? "",
+    ...(raw.conid?.trim() ? { conid: raw.conid.trim() } : {}),
     symbol: raw.symbol ?? "",
     description: raw.description ?? "",
     isin: raw.isin ?? "",

--- a/src/types/ibkr.ts
+++ b/src/types/ibkr.ts
@@ -18,6 +18,8 @@ export interface FlexStatement {
 export interface Trade {
   tradeID: string;
   accountId: string;
+  /** IBKR contract ID — stable across ticker renames */
+  conid?: string;
   symbol: string;
   description: string;
   isin: string;


### PR DESCRIPTION
## Summary

- Parse `conid` (contract ID) from IBKR Flex Query XML and add it to the Trade interface
- Use `conid` as the FIFO lot grouping key for instruments without ISINs (options, futures)
- Falls back to symbol-based key for non-IBKR brokers that don't provide conid

## Problem

When IBKR renames a ticker mid-position (e.g. `DFDV → DFDV1` after a corporate action), options under the old and new symbol got different lot keys because they have no ISIN. This caused:
- False "Venta sin lotes" warning on the sell under the renamed ticker
- Zero cost basis assigned to the disposal, overstating capital gains

The `conid` is stable across ticker renames — both DFDV and DFDV1 trades share `conid=788726909`.

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npm run lint` — zero errors  
- [x] `npm test` — all 499 tests pass
- [x] `npm run build` — builds successfully
- [ ] Manual: upload IBKR file with DFDV/DFDV1 ticker rename, verify no warning and correct cost basis

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of IBKR instruments without ISIN identifiers by using contract IDs for more accurate lot tracking and aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->