### PR TITLE
fix: allow Cloudflare beacon in CSP, remove ignored frame-ancestors

### DIFF
--- a/src/web/docs.html
+++ b/src/web/docs.html
@@ -6,7 +6,7 @@
   <title>DeclaRenta - Documentación</title>
   <meta name="description" content="Documentación completa de DeclaRenta: brokers soportados, casillas del Modelo 100, FIFO, doble imposición, Modelo 720, D-6 y más." />
   <meta name="theme-color" content="#3b82f6" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://data-api.ecb.europa.eu; img-src 'self' data:; frame-ancestors 'none'" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; connect-src 'self' https://data-api.ecb.europa.eu; img-src 'self' data:" />
   <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
   <link rel="icon" type="image/png" sizes="32x32" href="./favicon-32.png" />
   <link rel="stylesheet" href="./style.css" />

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Herramienta fiscal gratuita para inversores con brokers internacionales. IBKR, Degiro, Scalable Capital, eToro, Freedom24, Coinbase, Binance, Kraken. Self-hosted, privacidad total." />
   <meta name="theme-color" content="#3b82f6" />
   <link rel="manifest" href="./manifest.json" />
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src 'self' https://data-api.ecb.europa.eu; img-src 'self' data:; frame-ancestors 'none'" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src 'self' https://data-api.ecb.europa.eu; img-src 'self' data:" />
   <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
   <link rel="icon" type="image/png" sizes="32x32" href="./favicon-32.png" />
   <link rel="icon" type="image/png" sizes="16x16" href="./favicon-16.png" />


### PR DESCRIPTION
## Summary
- Add `https://static.cloudflareinsights.com` to `script-src` in CSP meta tags on both `index.html` and `docs.html`, so Cloudflare Web Analytics beacon loads without being blocked
- Remove `frame-ancestors 'none'` from `<meta>` CSP tags — browsers ignore this directive when delivered via meta element (only works in HTTP headers)

## Context
With `declarenta.com` served through Cloudflare, the proxy injects a Web Analytics beacon script. The existing `script-src 'self'` policy blocked it, causing console errors. The `frame-ancestors` directive in `<meta>` was silently ignored by all browsers.

## Test plan
- [ ] Verify no CSP errors in browser console on `declarenta.com`
- [ ] Verify Cloudflare Web Analytics beacon loads successfully
- [ ] Verify `docs.html` also loads without CSP errors