### PR TITLE
fix: deploy after auto-release so version matches the tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,9 @@
 name: Deploy to GitHub Pages
 
 on:
-  push:
-    branches: [main]
-    paths-ignore: ['**.md', 'docs/**', 'LICENSE', '.gitignore']
+  workflow_run:
+    workflows: ["Auto Release"]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   build:
     runs-on: [self-hosted, linux, x64]
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Change Deploy workflow from `push` trigger to `workflow_run` (after Auto Release completes)
- Add condition to only deploy if Auto Release succeeded (skip on failure or manual dispatch)

## Problem
Deploy and Auto Release both triggered on `push` to main concurrently. Deploy built before the version bump commit existed, so the live site always showed the previous version (e.g. v0.22.8 when the release was v0.22.9).

## Fix
Deploy now triggers via `workflow_run` after Auto Release completes, so `git describe --tags` picks up the correct tag and the site shows the right version.

## Test plan
- [ ] Merge this PR and verify Auto Release runs first
- [ ] Verify Deploy triggers after Auto Release completes
- [ ] Verify live site version matches the latest release tag