### PR TITLE
fix: fetch previous year ECB rates for early-January lookback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,7 @@ When adding a new section (like 721), follow this checklist:
 - We store the inverse: "1 FCY = X EUR" for direct multiplication with broker amounts
 - Weekends/holidays: walk backward up to 10 business days
 - Rate source: `https://data-api.ecb.europa.eu/service/data/EXR`
+- **Early-January lookback (Hard Trace)**: `fetchEcbRates(year)` only fetches rates for that calendar year. Trades on Jan 1-2 trigger a 10-day lookback into late December of the *previous* year, but those rates won't exist in the map unless `year - 1` is also fetched. **Both `main.ts` and `cli/index.ts` must add `minYear - 1` to the years set** before the fetch loop. This bug surfaces every time a new parser is added with sample data containing early-January trades.
 
 ## Development
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -158,6 +158,10 @@ program
 
       const years = new Set(merged.trades.map((t) => parseInt(t.tradeDate.slice(0, 4))));
       years.add(opts.year);
+      // Fetch previous year for the earliest trade year so the 10-day lookback
+      // can find late-December rates for early-January trades (e.g. Jan 1-2).
+      const minYear = Math.min(...years);
+      years.add(minYear - 1);
       const allRates: EcbRateMap = new Map();
       for (const yr of years) {
         const rates = await fetchEcbRates(yr, [...currencies]);

--- a/src/web/main.ts
+++ b/src/web/main.ts
@@ -478,6 +478,10 @@ async function processFiles(): Promise<void> {
 
     const years = new Set(merged.trades.map((tr) => parseInt(tr.tradeDate.slice(0, 4))));
     years.add(year);
+    // Fetch previous year for the earliest trade year so the 10-day lookback
+    // can find late-December rates for early-January trades (e.g. Jan 1-2).
+    const minYear = Math.min(...years);
+    years.add(minYear - 1);
     const allRates: EcbRateMap = new Map();
     for (const yr of years) {
       const rates = await fetchEcbRates(yr, [...currencies]);


### PR DESCRIPTION
## Summary
- Trades on Jan 1-2 trigger a 10-day ECB rate lookback into late December, but only the trade's calendar year was being fetched — causing `No ECB rate found for USD near 2020-01-01`
- Fixed in both web UI (`main.ts`) and CLI (`cli/index.ts`) by adding `minYear - 1` to the years fetch set
- Added hard trace to AGENTS.md documenting this pattern for future parser work

## Test plan
- [x] `tsc --noEmit` passes
- [x] Full suite (571 tests) passes
- [ ] Manual test: upload Revolut sample XLSX (with Jan 1 2020 trade) in browser — should no longer error