### PR TITLE
Add sitemap.xml and robots.txt

### DIFF
--- a/src/web/public/robots.txt
+++ b/src/web/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://declarenta.com/sitemap.xml

--- a/src/web/public/sitemap.xml
+++ b/src/web/public/sitemap.xml
@@ -2,12 +2,10 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://declarenta.com/</loc>
-    <changefreq>monthly</changefreq>
-    <priority>1.0</priority>
+    <lastmod>2026-04-23</lastmod>
   </url>
   <url>
     <loc>https://declarenta.com/docs.html</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
+    <lastmod>2026-04-23</lastmod>
   </url>
 </urlset>

--- a/src/web/public/sitemap.xml
+++ b/src/web/public/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://declarenta.com/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://declarenta.com/docs.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- Adds `sitemap.xml` with entries for `/` and `/docs.html`
- Adds `robots.txt` pointing to the sitemap
- Both placed in `src/web/public/` so Vite copies them to `dist/web/`

Enables Google Search Console sitemap submission for declarenta.com.