### PR TITLE
fix: short positions (SELL+O/BUY+C) and 720 cash balances

### DIFF
--- a/src/engine/fifo.ts
+++ b/src/engine/fifo.ts
@@ -573,7 +573,7 @@ export class FifoEngine {
     }
 
     if (remaining.greaterThan(0)) {
-      this.addLot({ ...trade, quantity: remaining.toString(), openCloseIndicator: "O" }, rateMap);
+      this.addLot({ ...trade, quantity: remaining.toString(), openCloseIndicator: "O", commission: "0", taxes: "0" }, rateMap);
     }
   }
 

--- a/src/engine/fifo.ts
+++ b/src/engine/fifo.ts
@@ -24,8 +24,10 @@ function lotKey(trade: { isin: string; symbol: string; assetCategory: string; co
 }
 
 export class FifoEngine {
-  /** FIFO queue per security (ISIN or symbol) */
+  /** FIFO queue per security (ISIN or symbol) — long positions */
   private lots: Map<string, Lot[]> = new Map();
+  /** FIFO queue per security — short positions (opened via SELL+O) */
+  private shortLots: Map<string, Lot[]> = new Map();
   private disposals: FifoDisposal[] = [];
   private nextLotId = 1;
   /** Warnings for issues that don't block execution */
@@ -170,7 +172,12 @@ export class FifoEngine {
         spinOffIdx++;
       }
 
-      if (trade.buySell === "BUY") {
+      const oci = trade.openCloseIndicator;
+      if (trade.buySell === "SELL" && oci === "O") {
+        this.addShortLot(trade, rateMap);
+      } else if (trade.buySell === "BUY" && oci === "C") {
+        this.consumeShortLots(trade, rateMap);
+      } else if (trade.buySell === "BUY") {
         this.addLot(trade, rateMap);
       } else {
         this.consumeLots(trade, rateMap);
@@ -463,6 +470,110 @@ export class FifoEngine {
         assetCategory: trade.assetCategory,
         washSaleBlocked: false,
       });
+    }
+  }
+
+  private addShortLot(trade: Trade, rateMap: EcbRateMap): void {
+    const ecbRate = getEcbRate(rateMap, trade.tradeDate, trade.currency);
+    const quantity = new Decimal(trade.quantity).abs();
+    const pricePerShare = new Decimal(trade.tradePrice);
+    const multiplier = new Decimal(trade.multiplier || "1");
+    const commission = new Decimal(trade.commission).abs();
+    const taxes = new Decimal(trade.taxes || "0").abs();
+    const baseAmount = quantity.mul(pricePerShare).mul(multiplier).minus(taxes);
+    const commissionEcbRate = !commission.isZero() && trade.commissionCurrency && trade.commissionCurrency !== trade.currency
+      ? getEcbRate(rateMap, trade.tradeDate, trade.commissionCurrency)
+      : ecbRate;
+    const proceedsInEur = baseAmount.mul(ecbRate).minus(commission.mul(commissionEcbRate));
+
+    const lot: Lot = {
+      id: `LOT-${this.nextLotId++}`,
+      isin: trade.isin,
+      symbol: trade.symbol,
+      description: trade.description,
+      acquireDate: trade.tradeDate,
+      quantity,
+      pricePerShare,
+      costInEur: proceedsInEur,
+      currency: trade.currency,
+      ecbRate,
+      isShort: true,
+    };
+
+    const key = lotKey(trade);
+    if (!this.shortLots.has(key)) {
+      this.shortLots.set(key, []);
+    }
+    this.shortLots.get(key)!.push(lot);
+  }
+
+  private consumeShortLots(trade: Trade, rateMap: EcbRateMap): void {
+    const ecbRate = getEcbRate(rateMap, trade.tradeDate, trade.currency);
+    let remaining = new Decimal(trade.quantity).abs();
+    const commission = new Decimal(trade.commission).abs();
+    const taxes = new Decimal(trade.taxes || "0").abs();
+    const pricePerShare = new Decimal(trade.tradePrice);
+    const multiplier = new Decimal(trade.multiplier || "1");
+    const commissionEcbRate = !commission.isZero() && trade.commissionCurrency && trade.commissionCurrency !== trade.currency
+      ? getEcbRate(rateMap, trade.tradeDate, trade.commissionCurrency)
+      : ecbRate;
+
+    const key = lotKey(trade);
+    const lots = this.shortLots.get(key);
+    if (!lots || lots.length === 0) {
+      this.addLot(trade, rateMap);
+      return;
+    }
+
+    const totalBuyQuantity = remaining;
+
+    while (remaining.greaterThan(0) && lots.length > 0) {
+      const lot = lots[0]!;
+      const consumed = Decimal.min(remaining, lot.quantity);
+      const fractionOfBuy = consumed.dividedBy(totalBuyQuantity);
+      const commissionShare = commission.mul(fractionOfBuy);
+      const taxesShare = taxes.mul(fractionOfBuy);
+
+      const closeCostBaseEur = consumed.mul(pricePerShare).mul(multiplier).plus(taxesShare).mul(ecbRate);
+      const closeCostEur = closeCostBaseEur.plus(commissionShare.mul(commissionEcbRate));
+
+      const lotProceedsPerUnit = lot.costInEur.dividedBy(lot.quantity);
+      const openProceedsEur = lotProceedsPerUnit.mul(consumed);
+
+      const acquireDate = lot.acquireDate;
+      const holdingDays = daysBetween(acquireDate, trade.tradeDate);
+
+      this.disposals.push({
+        isin: trade.isin,
+        symbol: trade.symbol,
+        description: trade.description,
+        sellDate: trade.tradeDate,
+        acquireDate,
+        quantity: consumed,
+        proceedsEur: openProceedsEur,
+        costBasisEur: closeCostEur,
+        gainLossEur: openProceedsEur.minus(closeCostEur),
+        holdingPeriodDays: holdingDays,
+        currency: trade.currency,
+        sellEcbRate: ecbRate,
+        acquireEcbRate: lot.ecbRate,
+        assetCategory: trade.assetCategory,
+        washSaleBlocked: false,
+        isShort: true,
+      });
+
+      lot.quantity = lot.quantity.minus(consumed);
+      lot.costInEur = lot.costInEur.minus(openProceedsEur);
+
+      if (lot.quantity.isZero()) {
+        lots.shift();
+      }
+
+      remaining = remaining.minus(consumed);
+    }
+
+    if (remaining.greaterThan(0)) {
+      this.addLot({ ...trade, quantity: remaining.toString(), openCloseIndicator: "O" }, rateMap);
     }
   }
 

--- a/src/generators/modelo720.ts
+++ b/src/generators/modelo720.ts
@@ -6,7 +6,7 @@
  */
 
 import Decimal from "decimal.js";
-import type { OpenPosition } from "../types/ibkr.js";
+import type { OpenPosition, CashBalance } from "../types/ibkr.js";
 import type { Lot } from "../types/tax.js";
 import type { EcbRateMap } from "../types/ecb.js";
 import { getEcbRate, getQ4AverageRate } from "../engine/ecb.js";
@@ -54,6 +54,7 @@ export function checkModelo720Thresholds(
   positions: OpenPosition[],
   rateMap: EcbRateMap,
   year: number,
+  cashBalances?: CashBalance[],
 ): Modelo720ThresholdResult {
   const THRESHOLD = new Decimal(50000);
 
@@ -65,9 +66,18 @@ export function checkModelo720Thresholds(
       return sum.plus(new Decimal(p.positionValue).abs().mul(ecbRate));
     }, new Decimal(0));
 
-  // Accounts and real estate are not derived from broker positions —
-  // they would come from separate data sources. Return zero for now.
-  const accountsTotal = new Decimal(0);
+  // Category C: cash balances at foreign brokers
+  const yearEnd = `${year}-12-31`;
+  const accountsTotal = (cashBalances ?? [])
+    .filter((cb) => {
+      const cash = new Decimal(cb.endingCash);
+      return !cash.isZero();
+    })
+    .reduce((sum, cb) => {
+      const ecbRate = cb.currency === "EUR" ? new Decimal(1) : getEcbRate(rateMap, yearEnd, cb.currency);
+      return sum.plus(new Decimal(cb.endingCash).abs().mul(ecbRate));
+    }, new Decimal(0));
+
   const realEstateTotal = new Decimal(0);
 
   return {

--- a/src/generators/modelo720.ts
+++ b/src/generators/modelo720.ts
@@ -69,13 +69,10 @@ export function checkModelo720Thresholds(
   // Category C: cash balances at foreign brokers
   const yearEnd = `${year}-12-31`;
   const accountsTotal = (cashBalances ?? [])
-    .filter((cb) => {
-      const cash = new Decimal(cb.endingCash);
-      return !cash.isZero();
-    })
+    .filter((cb) => new Decimal(cb.endingCash).greaterThan(0))
     .reduce((sum, cb) => {
       const ecbRate = cb.currency === "EUR" ? new Decimal(1) : getEcbRate(rateMap, yearEnd, cb.currency);
-      return sum.plus(new Decimal(cb.endingCash).abs().mul(ecbRate));
+      return sum.plus(new Decimal(cb.endingCash).mul(ecbRate));
     }, new Decimal(0));
 
   const realEstateTotal = new Decimal(0);

--- a/src/i18n/locales/ca.ts
+++ b/src/i18n/locales/ca.ts
@@ -50,6 +50,7 @@ const ca: TranslationKeys = {
   "table.casilla": "Casella",
   "table.concept": "Concepte",
   "table.amount_eur": "Import (EUR)",
+  "table.currency": "Divisa",
 
   "casilla.transmission_value": "Valor de transmissió",
   "casilla.acquisition_value": "Valor d'adquisició",
@@ -248,6 +249,7 @@ const ca: TranslationKeys = {
   "m720.threshold_not_exceeded": "No superes el llindar de 50.000 € (total: {{amount}} €). No estàs obligat a presentar.",
   "m720.no_positions": "Puja un informe amb posicions obertes al Model 100 per analitzar el Model 720.",
   "m720.positions_title": "Posicions declarables",
+  "m720.cash_title": "Saldos en efectiu (Comptes)",
   "m720.generate_btn": "Generar fitxer Model 720",
   "m720.deadline": "Termini: 1 gener – 31 març de l'any següent",
   "m720.total_value": "Valor total: {{amount}} €",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -49,6 +49,7 @@ const en: TranslationKeys = {
   "table.casilla": "Box",
   "table.concept": "Concept",
   "table.amount_eur": "Amount (EUR)",
+  "table.currency": "Currency",
 
   "casilla.transmission_value": "Transmission value",
   "casilla.acquisition_value": "Acquisition value",
@@ -251,6 +252,7 @@ const en: TranslationKeys = {
   "m720.threshold_not_exceeded": "You are below the 50,000 EUR threshold (total: {{amount}} EUR). Filing is not required.",
   "m720.no_positions": "Upload a report with open positions in Modelo 100 to analyze Modelo 720.",
   "m720.positions_title": "Declarable positions",
+  "m720.cash_title": "Cash balances (Accounts)",
   "m720.generate_btn": "Generate Modelo 720 file",
   "m720.deadline": "Deadline: January 1 – March 31 of the following year",
   "m720.total_value": "Total value: {{amount}} EUR",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -52,6 +52,7 @@ const es = {
   "table.casilla": "Casilla",
   "table.concept": "Concepto",
   "table.amount_eur": "Importe (EUR)",
+  "table.currency": "Divisa",
 
   // Casillas
   "casilla.transmission_value": "Valor de transmisión",
@@ -278,6 +279,7 @@ const es = {
   "m720.threshold_not_exceeded": "No superas el umbral de 50.000 € (total: {{amount}} €). No estás obligado a presentar.",
   "m720.no_positions": "Sube un informe con posiciones abiertas en Modelo 100 para analizar el Modelo 720.",
   "m720.positions_title": "Posiciones declarables",
+  "m720.cash_title": "Saldos en efectivo (Cuentas)",
   "m720.generate_btn": "Generar fichero Modelo 720",
   "m720.deadline": "Plazo: 1 enero – 31 marzo del año siguiente",
   "m720.total_value": "Valor total: {{amount}} €",

--- a/src/i18n/locales/eu.ts
+++ b/src/i18n/locales/eu.ts
@@ -50,6 +50,7 @@ const eu: TranslationKeys = {
   "table.casilla": "Laukia",
   "table.concept": "Kontzeptua",
   "table.amount_eur": "Zenbatekoa (EUR)",
+  "table.currency": "Moneta",
 
   "casilla.transmission_value": "Transmisio-balioa",
   "casilla.acquisition_value": "Eskuratze-balioa",
@@ -248,6 +249,7 @@ const eu: TranslationKeys = {
   "m720.threshold_not_exceeded": "Ez duzu 50.000 €-ko atalasea gainditzen (guztira: {{amount}} €). Ez zaude aurkeztera behartuta.",
   "m720.no_positions": "Igo posizio irekiak dituen txostena 100 Ereduan 720 Eredua aztertzeko.",
   "m720.positions_title": "Aitortu beharreko posizioak",
+  "m720.cash_title": "Eskudiruzko saldoak (Kontuak)",
   "m720.generate_btn": "720 Ereduaren fitxategia sortu",
   "m720.deadline": "Epea: urtarrilaren 1etik martxoaren 31ra hurrengo urtean",
   "m720.total_value": "Balio osoa: {{amount}} €",

--- a/src/i18n/locales/gl.ts
+++ b/src/i18n/locales/gl.ts
@@ -50,6 +50,7 @@ const gl: TranslationKeys = {
   "table.casilla": "Casilla",
   "table.concept": "Concepto",
   "table.amount_eur": "Importe (EUR)",
+  "table.currency": "Divisa",
 
   "casilla.transmission_value": "Valor de transmisión",
   "casilla.acquisition_value": "Valor de adquisición",
@@ -248,6 +249,7 @@ const gl: TranslationKeys = {
   "m720.threshold_not_exceeded": "Non superas o limiar de 50.000 € (total: {{amount}} €). Non estás obrigado a presentar.",
   "m720.no_positions": "Sube un informe con posicións abertas no Modelo 100 para analizar o Modelo 720.",
   "m720.positions_title": "Posicións declarables",
+  "m720.cash_title": "Saldos en efectivo (Contas)",
   "m720.generate_btn": "Xerar ficheiro Modelo 720",
   "m720.deadline": "Prazo: 1 xaneiro – 31 marzo do ano seguinte",
   "m720.total_value": "Valor total: {{amount}} €",

--- a/src/parsers/ibkr.ts
+++ b/src/parsers/ibkr.ts
@@ -13,6 +13,7 @@ import type {
   CorporateAction,
   OpenPosition,
   SecurityInfo,
+  CashBalance,
 } from "../types/ibkr.js";
 import type { BrokerParser, Statement } from "../types/broker.js";
 
@@ -28,6 +29,7 @@ const parser = new XMLParser({
       "FlexQueryResponse.FlexStatements.FlexStatement.CorporateActions.CorporateAction",
       "FlexQueryResponse.FlexStatements.FlexStatement.OpenPositions.OpenPosition",
       "FlexQueryResponse.FlexStatements.FlexStatement.SecuritiesInfo.SecurityInfo",
+      "FlexQueryResponse.FlexStatements.FlexStatement.CashReport.CashReportCurrency",
     ];
     return arrayPaths.some((p) => jpath === p);
   },
@@ -64,6 +66,7 @@ export function parseIbkrFlexXml(xml: string): FlexStatement {
   const corporateActions: ReturnType<typeof mapCorporateAction>[] = [];
   const openPositions: ReturnType<typeof mapOpenPosition>[] = [];
   const securitiesInfo: ReturnType<typeof mapSecurityInfo>[] = [];
+  const cashBalances: ReturnType<typeof mapCashBalance>[] = [];
 
   for (const stmt of statements) {
     trades.push(...ensureArray(stmt.Trades?.Trade).map(mapTrade));
@@ -71,6 +74,7 @@ export function parseIbkrFlexXml(xml: string): FlexStatement {
     corporateActions.push(...ensureArray(stmt.CorporateActions?.CorporateAction).map(mapCorporateAction));
     openPositions.push(...ensureArray(stmt.OpenPositions?.OpenPosition).map(mapOpenPosition));
     securitiesInfo.push(...ensureArray(stmt.SecuritiesInfo?.SecurityInfo).map(mapSecurityInfo));
+    cashBalances.push(...ensureArray(stmt.CashReport?.CashReportCurrency).map(mapCashBalance));
   }
 
   // Use first statement's metadata, combine accountIds for multi-account
@@ -89,6 +93,7 @@ export function parseIbkrFlexXml(xml: string): FlexStatement {
     corporateActions,
     openPositions,
     securitiesInfo,
+    cashBalances: cashBalances.length > 0 ? cashBalances : undefined,
   };
 }
 
@@ -187,6 +192,15 @@ function mapSecurityInfo(raw: Record<string, string>): SecurityInfo {
     assetCategory: (raw.assetCategory ?? "STK") as SecurityInfo["assetCategory"],
     multiplier: raw.multiplier ?? "1",
     subCategory: raw.subCategory ?? "",
+  };
+}
+
+function mapCashBalance(raw: Record<string, string>): CashBalance {
+  return {
+    accountId: raw.accountId ?? "",
+    currency: raw.currency ?? "",
+    endingCash: raw.endingCash ?? "0",
+    endingSettledCash: raw.endingSettledCash ?? "0",
   };
 }
 

--- a/src/types/ibkr.ts
+++ b/src/types/ibkr.ts
@@ -13,6 +13,7 @@ export interface FlexStatement {
   corporateActions: CorporateAction[];
   openPositions: OpenPosition[];
   securitiesInfo: SecurityInfo[];
+  cashBalances?: CashBalance[];
 }
 
 export interface Trade {
@@ -121,6 +122,14 @@ export interface SecurityInfo {
   assetCategory: AssetCategory;
   multiplier: string;
   subCategory: string;
+}
+
+/** Cash balance at a foreign broker (for Modelo 720, category C — Cuentas) */
+export interface CashBalance {
+  accountId: string;
+  currency: string;
+  endingCash: string;
+  endingSettledCash: string;
 }
 
 export type AssetCategory = "STK" | "OPT" | "FUT" | "CASH" | "BOND" | "FUND" | "WAR" | "CRYPTO" | "CFD";

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -16,6 +16,8 @@ export interface Lot {
   costInEur: Decimal;
   currency: string;
   ecbRate: Decimal;
+  /** True for short lots (opened via SELL+O) */
+  isShort?: boolean;
 }
 
 /** Result of consuming lots via FIFO for a sale */
@@ -40,6 +42,8 @@ export interface FifoDisposal {
   assetCategory: string;
   /** True if loss is blocked by the anti-churning rule (Art. 33.5.f LIRPF) */
   washSaleBlocked: boolean;
+  /** True for short position disposals (SELL+O → BUY+C) */
+  isShort?: boolean;
 }
 
 /** Dividend received from a foreign security */

--- a/src/web/section-720.ts
+++ b/src/web/section-720.ts
@@ -53,7 +53,7 @@ export function renderSection720(statement: Statement, rateMap: EcbRateMap): voi
   const profile = getProfile();
   const year = profile.year;
 
-  const hasCashBalances = (statement.cashBalances ?? []).some((cb) => parseFloat(cb.endingCash) !== 0);
+  const hasCashBalances = (statement.cashBalances ?? []).some((cb) => new Decimal(cb.endingCash).greaterThan(0));
   if (statement.openPositions.length === 0 && !hasCashBalances) {
     container.innerHTML = `<p class="muted">${t("m720.no_positions")}</p>`;
     return;
@@ -146,7 +146,7 @@ export function renderSection720(statement: Statement, rateMap: EcbRateMap): voi
   }
 
   // Cash balances table (Category C — Cuentas)
-  const cashBalances = (statement.cashBalances ?? []).filter((cb) => parseFloat(cb.endingCash) !== 0);
+  const cashBalances = (statement.cashBalances ?? []).filter((cb) => new Decimal(cb.endingCash).greaterThan(0));
   if (cashBalances.length > 0) {
     html += `<h3>${t("m720.cash_title")}</h3>
     <div class="table-wrapper"><table>
@@ -162,7 +162,7 @@ export function renderSection720(statement: Statement, rateMap: EcbRateMap): voi
   }
 
   // Generate button
-  if (exceeds || positions.length > 0 || cashBalances.length > 0) {
+  if (exceeds || positions.length > 0) {
     html += `<button id="m720-generate-btn">${t("m720.generate_btn")}</button>`;
   }
 

--- a/src/web/section-720.ts
+++ b/src/web/section-720.ts
@@ -53,7 +53,8 @@ export function renderSection720(statement: Statement, rateMap: EcbRateMap): voi
   const profile = getProfile();
   const year = profile.year;
 
-  if (statement.openPositions.length === 0) {
+  const hasCashBalances = (statement.cashBalances ?? []).some((cb) => parseFloat(cb.endingCash) !== 0);
+  if (statement.openPositions.length === 0 && !hasCashBalances) {
     container.innerHTML = `<p class="muted">${t("m720.no_positions")}</p>`;
     return;
   }
@@ -86,9 +87,9 @@ export function renderSection720(statement: Statement, rateMap: EcbRateMap): voi
   }
 
   // Threshold check
-  const thresholds = checkModelo720Thresholds(statement.openPositions, rateMap, year);
-  const totalValue = thresholds.values.total;
-  const exceeds = thresholds.values.exceeds;
+  const thresholds = checkModelo720Thresholds(statement.openPositions, rateMap, year, statement.cashBalances);
+  const totalValue = thresholds.values.total.plus(thresholds.accounts.total);
+  const exceeds = thresholds.values.exceeds || thresholds.accounts.exceeds;
   const pct = Math.min(totalValue.div(50000).mul(100).toNumber(), 100);
 
   html += `<div class="threshold-bar">
@@ -144,8 +145,24 @@ export function renderSection720(statement: Statement, rateMap: EcbRateMap): voi
     }
   }
 
+  // Cash balances table (Category C — Cuentas)
+  const cashBalances = (statement.cashBalances ?? []).filter((cb) => parseFloat(cb.endingCash) !== 0);
+  if (cashBalances.length > 0) {
+    html += `<h3>${t("m720.cash_title")}</h3>
+    <div class="table-wrapper"><table>
+      <thead><tr>
+        <th>${t("table.currency")}</th><th>${t("table.amount_eur")}</th>
+      </tr></thead>
+      <tbody>${cashBalances.map((cb) => {
+        const ecbRate = cb.currency === "EUR" ? new Decimal(1) : getEcbRate(rateMap, dateForRates, cb.currency);
+        const val = new Decimal(cb.endingCash).mul(ecbRate).toFixed(2);
+        return `<tr><td>${esc(cb.currency)}</td><td>${val}</td></tr>`;
+      }).join("")}</tbody>
+    </table></div>`;
+  }
+
   // Generate button
-  if (exceeds || positions.length > 0) {
+  if (exceeds || positions.length > 0 || cashBalances.length > 0) {
     html += `<button id="m720-generate-btn">${t("m720.generate_btn")}</button>`;
   }
 

--- a/tests/engine/corporate-actions.test.ts
+++ b/tests/engine/corporate-actions.test.ts
@@ -32,7 +32,7 @@ function makeTrade(overrides: Partial<Trade> = {}): Trade {
     fifoPnlRealized: "0",
     fxRateToBase: "1",
     buySell: "BUY",
-    openCloseIndicator: "O",
+    openCloseIndicator: overrides.buySell === "SELL" ? "C" : "O",
     exchange: "NYSE",
     commissionCurrency: "USD",
     commission: "-1",

--- a/tests/engine/fifo-branches.test.ts
+++ b/tests/engine/fifo-branches.test.ts
@@ -30,7 +30,7 @@ function makeTrade(overrides: Partial<Trade>): Trade {
     fifoPnlRealized: "0",
     fxRateToBase: "1",
     buySell: "BUY",
-    openCloseIndicator: "O",
+    openCloseIndicator: overrides.buySell === "SELL" ? "C" : "O",
     exchange: "XETR",
     commissionCurrency: "EUR",
     commission: "-1",

--- a/tests/engine/fifo.test.ts
+++ b/tests/engine/fifo.test.ts
@@ -31,7 +31,7 @@ function makeTrade(overrides: Partial<Trade>): Trade {
     fifoPnlRealized: "0",
     fxRateToBase: "0.92",
     buySell: "BUY",
-    openCloseIndicator: "O",
+    openCloseIndicator: overrides.buySell === "SELL" ? "C" : "O",
     exchange: "NASDAQ",
     commissionCurrency: "USD",
     commission: "0",
@@ -882,6 +882,162 @@ describe("FifoEngine", () => {
       expect(disposals[0]!.costBasisEur.greaterThan(0)).toBe(true);
       // Check spin-off warning
       expect(engine.warnings.some((w) => w.includes("Spin-off"))).toBe(true);
+    });
+  });
+
+  describe("Short positions (SELL+O → BUY+C)", () => {
+    it("should handle basic short sale lifecycle", () => {
+      const rates = makeRateMap({ "2025-03-15": "0.9200", "2025-06-15": "0.9100" });
+      const trades: Trade[] = [
+        makeTrade({
+          tradeID: "1", tradeDate: "2025-03-15", quantity: "-10", tradePrice: "150",
+          buySell: "SELL", openCloseIndicator: "O",
+        }),
+        makeTrade({
+          tradeID: "2", tradeDate: "2025-06-15", quantity: "10", tradePrice: "140",
+          buySell: "BUY", openCloseIndicator: "C",
+        }),
+      ];
+
+      const engine = new FifoEngine();
+      const disposals = engine.processTrades(trades, rates);
+
+      expect(disposals).toHaveLength(1);
+      const d = disposals[0]!;
+      expect(d.isShort).toBe(true);
+      // proceeds = premium received = 10 * 150 * 0.92 = 1380
+      expect(d.proceedsEur.toFixed(2)).toBe("1380.00");
+      // cost = buy-to-close = 10 * 140 * 0.91 = 1274
+      expect(d.costBasisEur.toFixed(2)).toBe("1274.00");
+      // gain = 1380 - 1274 = 106
+      expect(d.gainLossEur.toFixed(2)).toBe("106.00");
+    });
+
+    it("should handle short sale at a loss", () => {
+      const rates = makeRateMap({ "2025-03-15": "0.9200", "2025-06-15": "0.9100" });
+      const trades: Trade[] = [
+        makeTrade({
+          tradeID: "1", tradeDate: "2025-03-15", quantity: "-10", tradePrice: "100",
+          buySell: "SELL", openCloseIndicator: "O",
+        }),
+        makeTrade({
+          tradeID: "2", tradeDate: "2025-06-15", quantity: "10", tradePrice: "130",
+          buySell: "BUY", openCloseIndicator: "C",
+        }),
+      ];
+
+      const engine = new FifoEngine();
+      const disposals = engine.processTrades(trades, rates);
+
+      expect(disposals).toHaveLength(1);
+      const d = disposals[0]!;
+      expect(d.isShort).toBe(true);
+      // proceeds = 10 * 100 * 0.92 = 920
+      expect(d.proceedsEur.toFixed(2)).toBe("920.00");
+      // cost = 10 * 130 * 0.91 = 1183
+      expect(d.costBasisEur.toFixed(2)).toBe("1183.00");
+      // loss = 920 - 1183 = -263
+      expect(d.gainLossEur.toFixed(2)).toBe("-263.00");
+    });
+
+    it("should consume short lots in FIFO order", () => {
+      const rates = makeRateMap({
+        "2025-01-10": "0.9000", "2025-03-15": "0.9200", "2025-06-15": "0.9100",
+      });
+      const trades: Trade[] = [
+        makeTrade({
+          tradeID: "1", tradeDate: "2025-01-10", quantity: "-5", tradePrice: "100",
+          buySell: "SELL", openCloseIndicator: "O",
+        }),
+        makeTrade({
+          tradeID: "2", tradeDate: "2025-03-15", quantity: "-5", tradePrice: "110",
+          buySell: "SELL", openCloseIndicator: "O",
+        }),
+        makeTrade({
+          tradeID: "3", tradeDate: "2025-06-15", quantity: "10", tradePrice: "90",
+          buySell: "BUY", openCloseIndicator: "C",
+        }),
+      ];
+
+      const engine = new FifoEngine();
+      const disposals = engine.processTrades(trades, rates);
+
+      expect(disposals).toHaveLength(2);
+      // First disposal consumes the Jan short lot
+      expect(disposals[0]!.acquireDate).toBe("2025-01-10");
+      expect(disposals[0]!.proceedsEur.toFixed(2)).toBe("450.00"); // 5*100*0.90
+      // Second disposal consumes the Mar short lot
+      expect(disposals[1]!.acquireDate).toBe("2025-03-15");
+      expect(disposals[1]!.proceedsEur.toFixed(2)).toBe("506.00"); // 5*110*0.92
+    });
+
+    it("should fall back to addLot when BUY+C has no short lots", () => {
+      const rates = makeRateMap({ "2025-03-15": "0.9200", "2025-06-15": "0.9100" });
+      const trades: Trade[] = [
+        makeTrade({
+          tradeID: "1", tradeDate: "2025-03-15", quantity: "10", tradePrice: "100",
+          buySell: "BUY", openCloseIndicator: "C",
+        }),
+        makeTrade({
+          tradeID: "2", tradeDate: "2025-06-15", quantity: "-10", tradePrice: "120",
+          buySell: "SELL", openCloseIndicator: "C",
+        }),
+      ];
+
+      const engine = new FifoEngine();
+      const disposals = engine.processTrades(trades, rates);
+
+      expect(disposals).toHaveLength(1);
+      expect(disposals[0]!.isShort).toBeUndefined();
+    });
+
+    it("should handle partial close of short position", () => {
+      const rates = makeRateMap({ "2025-03-15": "0.9200", "2025-06-15": "0.9100" });
+      const trades: Trade[] = [
+        makeTrade({
+          tradeID: "1", tradeDate: "2025-03-15", quantity: "-10", tradePrice: "100",
+          buySell: "SELL", openCloseIndicator: "O",
+        }),
+        makeTrade({
+          tradeID: "2", tradeDate: "2025-06-15", quantity: "4", tradePrice: "90",
+          buySell: "BUY", openCloseIndicator: "C",
+        }),
+      ];
+
+      const engine = new FifoEngine();
+      const disposals = engine.processTrades(trades, rates);
+
+      expect(disposals).toHaveLength(1);
+      expect(disposals[0]!.quantity.toNumber()).toBe(4);
+      expect(disposals[0]!.isShort).toBe(true);
+    });
+
+    it("should handle short option with multiplier", () => {
+      const rates = makeRateMap({ "2025-03-15": "0.9200", "2025-06-15": "0.9100" });
+      const trades: Trade[] = [
+        makeTrade({
+          tradeID: "1", tradeDate: "2025-03-15", assetCategory: "OPT",
+          quantity: "-1", tradePrice: "5", multiplier: "100",
+          buySell: "SELL", openCloseIndicator: "O",
+        }),
+        makeTrade({
+          tradeID: "2", tradeDate: "2025-06-15", assetCategory: "OPT",
+          quantity: "1", tradePrice: "2", multiplier: "100",
+          buySell: "BUY", openCloseIndicator: "C",
+        }),
+      ];
+
+      const engine = new FifoEngine();
+      const disposals = engine.processTrades(trades, rates);
+
+      expect(disposals).toHaveLength(1);
+      const d = disposals[0]!;
+      expect(d.isShort).toBe(true);
+      // proceeds = 1 * 5 * 100 * 0.92 = 460
+      expect(d.proceedsEur.toFixed(2)).toBe("460.00");
+      // cost = 1 * 2 * 100 * 0.91 = 182
+      expect(d.costBasisEur.toFixed(2)).toBe("182.00");
+      expect(d.gainLossEur.toFixed(2)).toBe("278.00");
     });
   });
 });

--- a/tests/engine/multi-currency.test.ts
+++ b/tests/engine/multi-currency.test.ts
@@ -22,7 +22,7 @@ function makeTrade(overrides: Partial<Trade>): Trade {
     fifoPnlRealized: "0",
     fxRateToBase: "0.92",
     buySell: "BUY",
-    openCloseIndicator: "O",
+    openCloseIndicator: overrides.buySell === "SELL" ? "C" : "O",
     exchange: "NASDAQ",
     commissionCurrency: "USD",
     commission: "0",

--- a/tests/engine/phase5-assets.test.ts
+++ b/tests/engine/phase5-assets.test.ts
@@ -11,7 +11,7 @@ function makeTrade(overrides: Partial<Trade>): Trade {
     tradeDate: "2025-03-15", settlementDate: "2025-03-18",
     quantity: "10", tradePrice: "100", tradeMoney: "1000",
     proceeds: "1000", cost: "1000", fifoPnlRealized: "0",
-    fxRateToBase: "0.92", buySell: "BUY", openCloseIndicator: "O",
+    fxRateToBase: "0.92", buySell: "BUY", openCloseIndicator: overrides.buySell === "SELL" ? "C" : "O",
     exchange: "NASDAQ", commissionCurrency: "USD", commission: "0",
     taxes: "0", multiplier: "1", ...overrides,
   };

--- a/tests/generators/report.test.ts
+++ b/tests/generators/report.test.ts
@@ -30,7 +30,7 @@ function makeTrade(overrides: Partial<Trade>): Trade {
     fifoPnlRealized: "0",
     fxRateToBase: "0.92",
     buySell: "BUY",
-    openCloseIndicator: "O",
+    openCloseIndicator: overrides.buySell === "SELL" ? "C" : "O",
     exchange: "NASDAQ",
     commissionCurrency: "USD",
     commission: "0",

--- a/tests/parsers/ibkr.test.ts
+++ b/tests/parsers/ibkr.test.ts
@@ -469,6 +469,36 @@ describe("parseIbkrFlexXml", () => {
     expect(result.cashTransactions).toHaveLength(2);
   });
 
+  it("should parse CashReport cash balances", () => {
+    const xml = `<?xml version="1.0"?>
+    <FlexQueryResponse queryName="Test" type="AF">
+      <FlexStatements count="1">
+        <FlexStatement accountId="U1234567" fromDate="20250101" toDate="20251231" period="LastYear">
+          <Trades /><CashTransactions /><CorporateActions /><OpenPositions /><SecuritiesInfo />
+          <CashReport>
+            <CashReportCurrency accountId="U1234567" currency="USD"
+                                endingCash="14523.45" endingSettledCash="14523.45" />
+            <CashReportCurrency accountId="U1234567" currency="EUR"
+                                endingCash="1200.00" endingSettledCash="1200.00" />
+          </CashReport>
+        </FlexStatement>
+      </FlexStatements>
+    </FlexQueryResponse>`;
+
+    const result = parseIbkrFlexXml(xml);
+    expect(result.cashBalances).toHaveLength(2);
+    expect(result.cashBalances![0]!.currency).toBe("USD");
+    expect(result.cashBalances![0]!.endingCash).toBe("14523.45");
+    expect(result.cashBalances![0]!.accountId).toBe("U1234567");
+    expect(result.cashBalances![1]!.currency).toBe("EUR");
+    expect(result.cashBalances![1]!.endingCash).toBe("1200.00");
+  });
+
+  it("should return undefined cashBalances when no CashReport section", () => {
+    const result = parseIbkrFlexXml(MINIMAL_FLEX_XML);
+    expect(result.cashBalances).toBeUndefined();
+  });
+
   it("should handle multi-account with empty sections in some accounts", () => {
     const xml = `<?xml version="1.0"?>
     <FlexQueryResponse queryName="Multi" type="AF">


### PR DESCRIPTION
## Summary
- **Short positions**: FIFO engine now routes trades by `openCloseIndicator` — `SELL+O` opens a short lot (premium received as cost basis), `BUY+C` closes it (buy-to-close as proceeds). Fixes inflated capital gains for IBKR users trading options/short sales where all premium was treated as pure profit.
- **Modelo 720 cash balances**: Parse `CashReport.CashReportCurrency` from IBKR Flex XML and include foreign broker cash deposits in Category C (Cuentas) threshold calculation with ECB year-end rate conversion.
- **i18n**: Added `table.currency` and `m720.cash_title` keys across all 5 locales (es, en, ca, gl, eu).

## Test plan
- [x] 808 tests passing (was 800 — added 8 new tests)
- [x] 6 new short position tests: basic lifecycle, loss, FIFO order, fallback to addLot, partial close, options with multiplier
- [x] 2 new IBKR parser tests: CashReport parsing, undefined when absent
- [x] ESLint clean
- [x] TypeScript strict compilation passes

Reported by @MikheCtB via Telegram.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added short trading support with open/close position mechanics
  * Added cash balance tracking and reporting from broker statements
  * Added currency column to position tables
  * Extended Model 720 tax form to include cash balances with EUR conversion

* **Localization**
  * Added translations for new features across multiple languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->