### PR TITLE
feat: FX FIFO engine for foreign currency gains

### DIFF
--- a/docs/casillas.md
+++ b/docs/casillas.md
@@ -15,6 +15,20 @@
 - Las pérdidas bloqueadas por la regla anti-churning (Art. 33.5.f LIRPF) se reportan por separado y no se incluyen en 0358 hasta que se vendan los valores recomprados.
 - Los impuestos de transacción (STT, FTT, SEC fees) se incluyen en el coste de adquisición (compras) y se deducen del valor de transmisión (ventas).
 
+## Base del ahorro — Ganancias por transmisión de moneda extranjera
+
+| Casilla | Concepto | Cómo calcula DeclaRenta | Referencia legal |
+|---------|----------|------------------------|------------------|
+| **1626** | Valor de transmisión (FX) | Σ cantidad_divisa_vendida × tipo_ECB_fecha_venta | Art. 37.1.l LIRPF |
+| **1631** | Valor de adquisición (FX) | Σ cantidad_divisa × tipo_ECB_fecha_adquisición, consumiendo lotes FIFO | Art. 37.1.l LIRPF |
+
+**Notas:**
+- Cada conversión EUR→FCY crea un lote en la cola FIFO de esa divisa (DGT V2324-10).
+- Cada disposición de divisa (FCY→EUR, o compra de valores en FCY) consume lotes por FIFO.
+- Las conversiones automáticas del broker (FXCONV) se excluyen: solo las operaciones deliberadas generan eventos fiscales.
+- No existe umbral mínimo (de minimis) — toda conversión es declarable.
+- La regla anti-churning (Art. 33.5.f) NO se aplica a divisas.
+
 ## Base del ahorro — Rendimientos del capital mobiliario
 
 | Casilla | Concepto | Cómo calcula DeclaRenta | Referencia legal |
@@ -26,7 +40,7 @@
 **Notas:**
 - Los dividendos incluyen tanto dividendos ordinarios como "Payment In Lieu of Dividends" (dividendos sustitutivos en operaciones de préstamo de valores).
 - Las retenciones extranjeras NO se deducen aquí — se declaran en la casilla 0588.
-- La conversión a EUR usa el tipo de cambio ECB oficial del día de pago (Art. 47 LGT).
+- La conversión a EUR usa el tipo de cambio ECB oficial del día de pago (DGT V0583-16, PGC NRV 11a).
 
 ## Deducciones
 
@@ -58,7 +72,7 @@ Las pérdidas bloqueadas se integran cuando se transmiten los valores que perman
 
 DeclaRenta usa exclusivamente los **tipos de cambio diarios del BCE** (European Central Bank), publicados a las 16:00 CET cada día TARGET. Para fines de semana y festivos, se utiliza el último tipo disponible (día hábil anterior).
 
-**Base legal:** Art. 47 LGT (Ley General Tributaria) y consultas vinculantes de la DGT (Dirección General de Tributos).
+**Base legal:** PGC NRV 11a (partidas monetarias en moneda extranjera) y consultas vinculantes de la DGT (V2324-10, V0583-16). No existe ningún artículo en la LGT que prescriba una fuente concreta de tipos de cambio; el BCE constituye un safe harbor por su carácter institucional.
 
 ## Método FIFO (Art. 37.2 LIRPF)
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -433,12 +433,16 @@ function formatReport(report: ReturnType<typeof generateTaxReport>) {
       "0033_intereses_cuentas": report.interest.earned.toFixed(2),
       "0327_valor_transmision": report.capitalGains.transmissionValue.toFixed(2),
       "0328_valor_adquisicion": report.capitalGains.acquisitionValue.toFixed(2),
+      "1626_valor_transmision_fx": report.fxGains.transmissionValue.toFixed(2),
+      "1631_valor_adquisicion_fx": report.fxGains.acquisitionValue.toFixed(2),
       "0588_deduccion_doble_imposicion": report.doubleTaxation.deduction.toFixed(2),
     },
     resumen: {
       ganancia_neta: report.capitalGains.netGainLoss.toFixed(2),
       perdidas_bloqueadas_antichurning: report.capitalGains.blockedLosses.toFixed(2),
+      ganancia_neta_fx: report.fxGains.netGainLoss.toFixed(2),
       num_operaciones: report.capitalGains.disposals.length,
+      num_operaciones_fx: report.fxGains.disposals.length,
       num_dividendos: report.dividends.entries.length,
     },
     doble_imposicion_por_pais: Object.fromEntries(
@@ -465,6 +469,17 @@ function formatReport(report: ReturnType<typeof generateTaxReport>) {
       tipo_ecb_venta: d.sellEcbRate.toFixed(6),
       bloqueada_antichurning: d.washSaleBlocked,
     })),
+    operaciones_fx: report.fxGains.disposals.map((d) => ({
+      divisa: d.currency,
+      fecha_venta: d.disposeDate,
+      fecha_compra: d.acquireDate,
+      cantidad: d.quantity.toString(),
+      importe_venta_eur: d.proceedsEur.toFixed(2),
+      coste_eur: d.costBasisEur.toFixed(2),
+      ganancia_eur: d.gainLossEur.toFixed(2),
+      dias_tenencia: d.holdingPeriodDays,
+      origen: d.trigger,
+    })),
     dividendos: report.dividends.entries.map((d) => ({
       isin: d.isin,
       simbolo: d.symbol,
@@ -488,6 +503,13 @@ function printSummary(report: ReturnType<typeof generateTaxReport>) {
   console.error(`    Ganancia/Pérdida neta:             ${report.capitalGains.netGainLoss.toFixed(2)} EUR`);
   if (report.capitalGains.blockedLosses.greaterThan(0)) {
     console.error(`    ⚠ Pérdidas bloqueadas (2 meses):   ${report.capitalGains.blockedLosses.toFixed(2)} EUR`);
+  }
+  if (report.fxGains.disposals.length > 0) {
+    console.error("");
+    console.error("  GANANCIAS FX — MONEDA EXTRANJERA (Art. 37.1.l)");
+    console.error(`    Casilla 1626 (Valor transmisión):  ${report.fxGains.transmissionValue.toFixed(2)} EUR`);
+    console.error(`    Casilla 1631 (Valor adquisición):  ${report.fxGains.acquisitionValue.toFixed(2)} EUR`);
+    console.error(`    Ganancia/Pérdida neta FX:          ${report.fxGains.netGainLoss.toFixed(2)} EUR`);
   }
   console.error("");
   console.error("  RENDIMIENTOS CAPITAL MOBILIARIO");

--- a/src/engine/ecb.ts
+++ b/src/engine/ecb.ts
@@ -2,8 +2,8 @@
  * ECB exchange rate fetcher.
  *
  * Fetches official ECB daily reference rates via the SDMX REST API.
- * Spanish tax law requires using official exchange rates (Art. 47 LGT,
- * DGT consultas vinculantes), not broker-provided rates.
+ * DGT consultas vinculantes (V2324-10, V0583-16) require "tipo de cambio
+ * vigente" — ECB daily rates serve as the safe-harbor official source.
  */
 
 import Decimal from "decimal.js";

--- a/src/engine/fx-fifo.ts
+++ b/src/engine/fx-fifo.ts
@@ -1,0 +1,192 @@
+/**
+ * FX FIFO engine — tracks currency lots per Art. 37.1.l LIRPF.
+ *
+ * Each EUR→FCY conversion creates a lot; each FCY disposal (conversion
+ * back to EUR, or spending FCY on stock purchases) consumes lots via FIFO.
+ * DGT V2324-10 confirms FIFO applies to foreign currency holdings.
+ */
+
+import Decimal from "decimal.js";
+import type { FxLot, FxDisposal } from "../types/tax.js";
+import type { Trade } from "../types/ibkr.js";
+import type { EcbRateMap } from "../types/ecb.js";
+import { getEcbRate } from "./ecb.js";
+import { daysBetween, normalizeDate } from "./dates.js";
+
+export interface FxEvent {
+  date: string;
+  currency: string;
+  /** Positive = acquiring FCY (EUR→FCY), Negative = disposing FCY (FCY→EUR or FCY spent) */
+  quantity: Decimal;
+  /** EUR rate at event time (EUR per 1 FCY) */
+  ecbRate: Decimal;
+  trigger: "conversion" | "stock_purchase" | "stock_sale";
+}
+
+export class FxFifoEngine {
+  private lots: Map<string, FxLot[]> = new Map();
+  private disposals: FxDisposal[] = [];
+  private nextLotId = 1;
+  warnings: string[] = [];
+
+  /**
+   * Process FX events extracted from trades.
+   * CASH trades with assetCategory="CASH" that represent actual forex conversions
+   * (not automatic FXCONV) generate FX lots and disposals.
+   */
+  processEvents(events: FxEvent[]): FxDisposal[] {
+    const sorted = [...events].sort((a, b) => a.date.localeCompare(b.date));
+
+    for (const event of sorted) {
+      if (event.currency === "EUR") continue;
+
+      if (event.quantity.greaterThan(0)) {
+        this.addLot(event);
+      } else if (event.quantity.lessThan(0)) {
+        this.consumeLots(event);
+      }
+    }
+
+    return this.disposals;
+  }
+
+  /**
+   * Extract FX events from trades.
+   *
+   * Two sources of FX events:
+   * 1. CASH trades (assetCategory=CASH): direct forex conversions
+   *    - BUY CASH in USD = acquiring USD (add lot)
+   *    - SELL CASH in USD = disposing USD (consume lots)
+   * 2. Securities trades in non-EUR: implicit currency disposal/acquisition
+   *    - BUY stock in USD = spending USD (dispose FCY lots)
+   *    - SELL stock in USD = receiving USD (add FCY lot)
+   *
+   * We skip FXCONV (automatic broker conversions for settlement) since those
+   * are not independent trading decisions. Detection: notes field contains
+   * "FXCONV" or description contains "CASH RECEIPTS / DISBURSEMENTS".
+   */
+  static extractFxEvents(trades: Trade[], rateMap: EcbRateMap): FxEvent[] {
+    const events: FxEvent[] = [];
+
+    for (const trade of trades) {
+      if (trade.currency === "EUR") continue;
+
+      const date = normalizeDate(trade.tradeDate);
+      const ecbRate = getEcbRate(rateMap, date, trade.currency);
+
+      if (trade.assetCategory === "CASH") {
+        // Direct forex trade — skip FXCONV (automatic conversions)
+        if (FxFifoEngine.isFxconv(trade)) continue;
+
+        const quantity = new Decimal(trade.quantity).abs();
+        if (trade.buySell === "BUY") {
+          events.push({ date, currency: trade.currency, quantity, ecbRate, trigger: "conversion" });
+        } else {
+          events.push({ date, currency: trade.currency, quantity: quantity.negated(), ecbRate, trigger: "conversion" });
+        }
+      } else if (trade.assetCategory !== "WAR") {
+        // Securities trade in foreign currency — implicit FX event
+        const tradeMoney = new Decimal(trade.tradeMoney).abs();
+        if (tradeMoney.isZero()) continue;
+
+        if (trade.buySell === "BUY") {
+          // Buying stock = spending FCY
+          events.push({ date, currency: trade.currency, quantity: tradeMoney.negated(), ecbRate, trigger: "stock_purchase" });
+        } else {
+          // Selling stock = receiving FCY
+          events.push({ date, currency: trade.currency, quantity: tradeMoney, ecbRate, trigger: "stock_sale" });
+        }
+      }
+    }
+
+    return events;
+  }
+
+  /** Detect FXCONV (automatic broker conversions for settlement) */
+  private static isFxconv(trade: Trade): boolean {
+    const desc = (trade.description || "").toUpperCase();
+    return desc.includes("FXCONV") || desc.includes("CASH RECEIPTS") || desc.includes("CASH DISBURSEMENTS");
+  }
+
+  private addLot(event: FxEvent): void {
+    const lot: FxLot = {
+      id: `FX-${this.nextLotId++}`,
+      currency: event.currency,
+      acquireDate: event.date,
+      quantity: event.quantity,
+      costPerUnit: event.ecbRate,
+      costInEur: event.quantity.mul(event.ecbRate),
+    };
+
+    if (!this.lots.has(event.currency)) {
+      this.lots.set(event.currency, []);
+    }
+    this.lots.get(event.currency)!.push(lot);
+  }
+
+  private consumeLots(event: FxEvent): void {
+    let remaining = event.quantity.abs();
+    const lots = this.lots.get(event.currency);
+
+    if (!lots || lots.length === 0) {
+      // No lots to consume — FCY was acquired before our data window
+      // Add a synthetic lot at the current rate (gain = 0) and warn
+      this.warnings.push(`⚠ Venta de ${event.currency} sin lotes previos el ${event.date}. Posible adquisición anterior al período declarado.`);
+      return;
+    }
+
+    while (remaining.greaterThan(0) && lots.length > 0) {
+      const lot = lots[0]!;
+      const consumed = Decimal.min(remaining, lot.quantity);
+
+      const proceedsEur = consumed.mul(event.ecbRate);
+      const costBasisEur = consumed.mul(lot.costPerUnit);
+      const holdingDays = daysBetween(lot.acquireDate, event.date);
+
+      this.disposals.push({
+        currency: event.currency,
+        disposeDate: event.date,
+        acquireDate: lot.acquireDate,
+        quantity: consumed,
+        proceedsEur,
+        costBasisEur,
+        gainLossEur: proceedsEur.minus(costBasisEur),
+        trigger: event.trigger,
+        holdingPeriodDays: holdingDays,
+      });
+
+      lot.quantity = lot.quantity.minus(consumed);
+      lot.costInEur = lot.costInEur.minus(costBasisEur);
+
+      if (lot.quantity.isZero()) {
+        lots.shift();
+      }
+
+      remaining = remaining.minus(consumed);
+    }
+
+    if (remaining.greaterThan(0)) {
+      this.warnings.push(`⚠ Lotes FX insuficientes: ${event.currency} × ${remaining} el ${event.date}. Coste = 0.`);
+      const proceedsEur = remaining.mul(event.ecbRate);
+      this.disposals.push({
+        currency: event.currency,
+        disposeDate: event.date,
+        acquireDate: event.date,
+        quantity: remaining,
+        proceedsEur,
+        costBasisEur: new Decimal(0),
+        gainLossEur: proceedsEur,
+        trigger: event.trigger,
+        holdingPeriodDays: 0,
+      });
+    }
+  }
+
+  getDisposals(): FxDisposal[] {
+    return this.disposals;
+  }
+
+  getRemainingLots(): Map<string, FxLot[]> {
+    return this.lots;
+  }
+}

--- a/src/generators/csv.ts
+++ b/src/generators/csv.ts
@@ -46,11 +46,28 @@ export function formatCsv(report: TaxSummary): string {
 
   lines.push("");
 
+  // FX gains section
+  if (report.fxGains.disposals.length > 0) {
+    lines.push("# GANANCIAS FX (Art. 37.1.l LIRPF)");
+    lines.push("Divisa,Fecha_Compra,Fecha_Venta,Cantidad,Coste_EUR,Venta_EUR,Ganancia_EUR,Dias,Origen");
+    for (const d of report.fxGains.disposals) {
+      lines.push([
+        escapeCsv(d.currency), d.acquireDate, d.disposeDate,
+        d.quantity.toFixed(2), d.costBasisEur.toFixed(2), d.proceedsEur.toFixed(2),
+        d.gainLossEur.toFixed(2), d.holdingPeriodDays.toString(),
+        escapeCsv(d.trigger),
+      ].join(","));
+    }
+    lines.push("");
+  }
+
   // Summary section
   lines.push("# RESUMEN CASILLAS");
   lines.push("Casilla,Concepto,Valor_EUR");
   lines.push(`0327,Valor de transmision,${report.capitalGains.transmissionValue.toFixed(2)}`);
   lines.push(`0328,Valor de adquisicion,${report.capitalGains.acquisitionValue.toFixed(2)}`);
+  lines.push(`1626,Valor de transmision FX,${report.fxGains.transmissionValue.toFixed(2)}`);
+  lines.push(`1631,Valor de adquisicion FX,${report.fxGains.acquisitionValue.toFixed(2)}`);
   lines.push(`0029,Dividendos brutos,${report.dividends.grossIncome.toFixed(2)}`);
   lines.push(`—,Intereses pagados al broker (margen no deducible — informativo),${report.interest.paid.toFixed(2)}`);
   lines.push(`0033,Intereses de cuentas,${report.interest.earned.toFixed(2)}`);

--- a/src/generators/report.ts
+++ b/src/generators/report.ts
@@ -11,6 +11,7 @@ import type { FlexStatement } from "../types/ibkr.js";
 import type { TaxSummary } from "../types/tax.js";
 import type { EcbRateMap } from "../types/ecb.js";
 import { FifoEngine } from "../engine/fifo.js";
+import { FxFifoEngine } from "../engine/fx-fifo.js";
 import { detectWashSales } from "../engine/wash-sale.js";
 import { calculateDividends } from "../engine/dividends.js";
 import { calculateDoubleTaxation } from "../engine/double-taxation.js";
@@ -89,7 +90,16 @@ export function generateTaxReport(
     };
   });
 
-  // 4. Double taxation
+  // 4. FX gains (Art. 37.1.l LIRPF — currency conversions as taxable events)
+  const fxEngine = new FxFifoEngine();
+  const fxEvents = FxFifoEngine.extractFxEvents(statement.trades, rateMap);
+  const allFxDisposals = fxEngine.processEvents(fxEvents);
+  const fxDisposals = allFxDisposals.filter((d) => d.disposeDate.startsWith(yearStr));
+
+  const fxTransmissionValue = fxDisposals.reduce((sum, d) => sum.plus(d.proceedsEur), new Decimal(0));
+  const fxAcquisitionValue = fxDisposals.reduce((sum, d) => sum.plus(d.costBasisEur), new Decimal(0));
+
+  // 5. Double taxation
   const doubleTaxation = calculateDoubleTaxation(dividendEntries);
 
   // Filter warnings to those relevant to the selected year
@@ -99,8 +109,14 @@ export function generateTaxReport(
     return dateMatch[1] === yearStr;
   });
 
+  const fxWarnings = fxEngine.warnings.filter((w) => {
+    const dateMatch = w.match(/\b(\d{4})-\d{2}-\d{2}\b/);
+    if (!dateMatch) return true;
+    return dateMatch[1] === yearStr;
+  });
+
   // Prepend parser warnings (unparsed sections, etc.)
-  const allWarnings = [...(statement.parserWarnings ?? []), ...yearWarnings];
+  const allWarnings = [...(statement.parserWarnings ?? []), ...yearWarnings, ...fxWarnings];
 
   return {
     year,
@@ -125,6 +141,12 @@ export function generateTaxReport(
     doubleTaxation: {
       deduction: doubleTaxation.total,
       byCountry: doubleTaxation.byCountry,
+    },
+    fxGains: {
+      transmissionValue: fxTransmissionValue,
+      acquisitionValue: fxAcquisitionValue,
+      netGainLoss: fxTransmissionValue.minus(fxAcquisitionValue),
+      disposals: fxDisposals,
     },
   };
 }

--- a/src/i18n/locales/ca.ts
+++ b/src/i18n/locales/ca.ts
@@ -54,7 +54,10 @@ const ca: TranslationKeys = {
 
   "casilla.transmission_value": "Valor de transmissió",
   "casilla.acquisition_value": "Valor d'adquisició",
-  "casilla.net_gain_loss": "Guany/Pèrdua net",
+  "casilla.fx_transmission_value": "Valor de transmissió FX (moneda estrangera)",
+  "casilla.fx_acquisition_value": "Valor d'adquisició FX (moneda estrangera)",
+  "casilla.fx_net_gain_loss": "Guany/Pèrdua net FX (moneda estrangera)",
+  "casilla.net_gain_loss": "Guany/Pèrdua net (total)",
   "casilla.gross_dividends": "Dividends bruts",
   "casilla.interest_earned": "Interessos guanyats",
   "casilla.interest_paid": "Interessos pagats al broker (marge, no deduïble — informatiu)",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -53,7 +53,10 @@ const en: TranslationKeys = {
 
   "casilla.transmission_value": "Transmission value",
   "casilla.acquisition_value": "Acquisition value",
-  "casilla.net_gain_loss": "Net gain/loss",
+  "casilla.fx_transmission_value": "FX transmission value (foreign currency)",
+  "casilla.fx_acquisition_value": "FX acquisition value (foreign currency)",
+  "casilla.fx_net_gain_loss": "FX net gain/loss (foreign currency)",
+  "casilla.net_gain_loss": "Net gain/loss (total)",
   "casilla.gross_dividends": "Gross dividends",
   "casilla.interest_earned": "Interest earned",
   "casilla.interest_paid": "Interest paid to broker (margin, not deductible — informational)",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -57,7 +57,10 @@ const es = {
   // Casillas
   "casilla.transmission_value": "Valor de transmisión",
   "casilla.acquisition_value": "Valor de adquisición",
-  "casilla.net_gain_loss": "Ganancia/Pérdida neta",
+  "casilla.fx_transmission_value": "Valor de transmisión FX (moneda extranjera)",
+  "casilla.fx_acquisition_value": "Valor de adquisición FX (moneda extranjera)",
+  "casilla.fx_net_gain_loss": "Ganancia/Pérdida neta FX (moneda extranjera)",
+  "casilla.net_gain_loss": "Ganancia/Pérdida neta (total)",
   "casilla.gross_dividends": "Dividendos brutos",
   "casilla.interest_earned": "Intereses ganados",
   "casilla.interest_paid": "Intereses pagados al broker (margen, no deducible — informativo)",

--- a/src/i18n/locales/eu.ts
+++ b/src/i18n/locales/eu.ts
@@ -54,7 +54,10 @@ const eu: TranslationKeys = {
 
   "casilla.transmission_value": "Transmisio-balioa",
   "casilla.acquisition_value": "Eskuratze-balioa",
-  "casilla.net_gain_loss": "Irabazi/Galera garbia",
+  "casilla.fx_transmission_value": "FX transmisio-balioa (atzerriko moneta)",
+  "casilla.fx_acquisition_value": "FX eskuratze-balioa (atzerriko moneta)",
+  "casilla.fx_net_gain_loss": "FX irabazi/galera garbia (atzerriko moneta)",
+  "casilla.net_gain_loss": "Irabazi/Galera garbia (guztira)",
   "casilla.gross_dividends": "Dibidendu gordinak",
   "casilla.interest_earned": "Jasotako interesak",
   "casilla.interest_paid": "Brokerrari ordaindutako interesak (marjina, ez kengarria — informatiboa)",

--- a/src/i18n/locales/gl.ts
+++ b/src/i18n/locales/gl.ts
@@ -54,7 +54,10 @@ const gl: TranslationKeys = {
 
   "casilla.transmission_value": "Valor de transmisión",
   "casilla.acquisition_value": "Valor de adquisición",
-  "casilla.net_gain_loss": "Ganancia/Perda neta",
+  "casilla.fx_transmission_value": "Valor de transmisión FX (moeda estranxeira)",
+  "casilla.fx_acquisition_value": "Valor de adquisición FX (moeda estranxeira)",
+  "casilla.fx_net_gain_loss": "Ganancia/Perda neta FX (moeda estranxeira)",
+  "casilla.net_gain_loss": "Ganancia/Perda neta (total)",
   "casilla.gross_dividends": "Dividendos brutos",
   "casilla.interest_earned": "Xuros gañados",
   "casilla.interest_paid": "Xuros pagados ao broker (marxe, non deducible — informativo)",

--- a/src/parsers/ibkr.ts
+++ b/src/parsers/ibkr.ts
@@ -80,7 +80,6 @@ export function parseIbkrFlexXml(xml: string): FlexStatement {
   // Detect important sections present in XML but not parsed
   const parserWarnings: string[] = [];
   const importantUnparsed: Record<string, string> = {
-    FXTransactions: "operaciones forex (FX P&L standalone)",
     OptionEAE: "ejercicios y asignaciones de opciones",
     TransfersInTransit: "transferencias en tránsito",
     UnbookedTrades: "operaciones no liquidadas",

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -116,6 +116,44 @@ export interface TaxSummary {
     /** Breakdown by country */
     byCountry: Record<string, { taxPaid: Decimal; deductionAllowed: Decimal }>;
   };
+
+  /** FX gains: Ganancias/pérdidas por transmisión de moneda extranjera (Casillas 1626/1631) */
+  fxGains: {
+    /** Casilla 1626: Valor de transmisión (FX) */
+    transmissionValue: Decimal;
+    /** Casilla 1631: Valor de adquisición (FX) */
+    acquisitionValue: Decimal;
+    /** Net gain/loss (1626 - 1631) */
+    netGainLoss: Decimal;
+    /** Individual FX disposals */
+    disposals: FxDisposal[];
+  };
+}
+
+/** A single lot in the FX FIFO queue (Art. 37.1.l LIRPF) */
+export interface FxLot {
+  id: string;
+  currency: string;
+  acquireDate: string;
+  quantity: Decimal;
+  /** EUR cost per unit of foreign currency at acquisition */
+  costPerUnit: Decimal;
+  /** Total EUR cost for this lot */
+  costInEur: Decimal;
+}
+
+/** Result of consuming FX lots via FIFO for a currency disposal */
+export interface FxDisposal {
+  currency: string;
+  disposeDate: string;
+  acquireDate: string;
+  quantity: Decimal;
+  proceedsEur: Decimal;
+  costBasisEur: Decimal;
+  gainLossEur: Decimal;
+  /** What triggered the disposal: "conversion" | "stock_purchase" | "stock_sale" */
+  trigger: "conversion" | "stock_purchase" | "stock_sale";
+  holdingPeriodDays: number;
 }
 
 /** Loss carryforward entry (Art. 49 LIRPF) */

--- a/src/web/casilla-detail.ts
+++ b/src/web/casilla-detail.ts
@@ -5,7 +5,7 @@
  * operations (disposals, dividends, interest entries) that compose it.
  */
 
-import type { TaxSummary, FifoDisposal, DividendEntry, InterestEntry } from "../types/tax.js";
+import type { TaxSummary, FifoDisposal, FxDisposal, DividendEntry, InterestEntry } from "../types/tax.js";
 import { t } from "../i18n/index.js";
 
 /** Escape HTML special characters to prevent XSS in rendered strings. */
@@ -114,6 +114,28 @@ function renderDoubleTaxDetail(report: TaxSummary): string {
     </table>`;
 }
 
+/** Render a detail table of FX disposals for casilla 1626/1631 drill-down. */
+function renderFxDisposalsDetail(disposals: FxDisposal[], label: string): string {
+  if (disposals.length === 0) return `<p class="muted">${t("casilla.no_operations")}</p>`;
+  return `
+    <p class="detail-label">${esc(label)} (${disposals.length})</p>
+    <table class="detail-table">
+      <thead><tr>
+        <th>${t("table.currency")}</th><th>${t("table.sell_date")}</th><th>${t("table.buy_date")}</th>
+        <th>${t("table.units")}</th><th>EUR</th>
+      </tr></thead>
+      <tbody>${disposals.map((d) => `
+        <tr>
+          <td>${esc(d.currency)}</td>
+          <td>${formatDate(d.disposeDate)}</td>
+          <td>${formatDate(d.acquireDate)}</td>
+          <td>${d.quantity.toFixed(2)}</td>
+          <td class="${d.gainLossEur.greaterThanOrEqualTo(0) ? "gain" : "loss"}">${d.gainLossEur.toFixed(2)}</td>
+        </tr>`).join("")}
+      </tbody>
+    </table>`;
+}
+
 const CASILLAS: CasillaConfig[] = [
   {
     code: "0327",
@@ -130,10 +152,24 @@ const CASILLAS: CasillaConfig[] = [
     getDetail: (r) => renderDisposalsDetail(r.capitalGains.disposals, t("casilla.acquisition_value")),
   },
   {
+    code: "1626",
+    i18nKey: "casilla.fx_transmission_value",
+    getValue: (r) => r.fxGains.transmissionValue.toFixed(2),
+    getClass: () => "",
+    getDetail: (r) => renderFxDisposalsDetail(r.fxGains.disposals, t("casilla.fx_transmission_value" as Parameters<typeof t>[0])),
+  },
+  {
+    code: "1631",
+    i18nKey: "casilla.fx_acquisition_value",
+    getValue: (r) => r.fxGains.acquisitionValue.toFixed(2),
+    getClass: () => "",
+    getDetail: (r) => renderFxDisposalsDetail(r.fxGains.disposals, t("casilla.fx_acquisition_value" as Parameters<typeof t>[0])),
+  },
+  {
     code: "",
     i18nKey: "casilla.net_gain_loss",
-    getValue: (r) => r.capitalGains.netGainLoss.toFixed(2),
-    getClass: (r) => r.capitalGains.netGainLoss.greaterThanOrEqualTo(0) ? "gain" : "loss",
+    getValue: (r) => r.capitalGains.netGainLoss.plus(r.fxGains.netGainLoss).toFixed(2),
+    getClass: (r) => r.capitalGains.netGainLoss.plus(r.fxGains.netGainLoss).greaterThanOrEqualTo(0) ? "gain" : "loss",
     getDetail: () => "",
   },
   {

--- a/src/web/docs.html
+++ b/src/web/docs.html
@@ -434,7 +434,7 @@ declarenta d6 --input informe.xml --year 2025 --nif 12345678A --name "Apellidos,
           <li>Inicia sesión en <strong>Client Portal</strong> o <strong>Account Management</strong>.</li>
           <li>Ve a <em>Informes &gt; Flex Queries</em> (o <em>Reports &gt; Flex Queries</em>).</li>
           <li>Crea una nueva Flex Query de tipo <strong>Activity Flex Query</strong>.</li>
-          <li>En las secciones, activa: <strong>Trades</strong>, <strong>Cash Transactions</strong>, <strong>Corporate Actions</strong>, <strong>Open Positions</strong> y <strong>Securities Info</strong>.</li>
+          <li>En las secciones, activa <strong>todas las disponibles</strong> (recomendado). Como mínimo: <strong>Trades</strong>, <strong>Cash Transactions</strong>, <strong>Corporate Actions</strong>, <strong>Open Positions</strong>, <strong>Securities Info</strong> y <strong>Cash Report</strong>. Activar todas las secciones permite a DeclaRenta procesar operaciones forex, ejercicios de opciones y saldos en cuenta.</li>
           <li>Selecciona el período que cubra todos los ejercicios necesarios (incluye ejercicios anteriores si tienes posiciones abiertas de años previos, para que FIFO funcione correctamente).</li>
           <li>Formato de salida: <strong>XML</strong>.</li>
           <li>Ejecuta la query y descarga el fichero <code>.xml</code>.</li>
@@ -898,9 +898,14 @@ declarenta d6 --input informe.xml --year 2025 --nif 12345678A --name "Apellidos,
         <p>Los contratos de futuros se procesan con FIFO por símbolo, aplicando el multiplicador del contrato. Las ganancias y pérdidas tributan como ganancias patrimoniales en la base del ahorro.</p>
         <p class="muted">La regla anti-churning no se aplica a futuros.</p>
 
-        <h3>Forex (CASH)</h3>
-        <p>Las operaciones de compraventa de divisas (forex spot) tributan como ganancias y pérdidas patrimoniales (DGT V2324-10, Art. 37.1.l LIRPF). Actualmente, DeclaRenta <strong>excluye</strong> la categoría CASH del motor FIFO porque las ganancias/pérdidas por tipo de cambio ya están implícitas en la conversión EUR de cada operación de valores.</p>
-        <p>Las conversiones de divisa standalone (comprar USD para depositar y venderlos meses después) generan su propia ganancia o pérdida patrimonial que debe declararse en las casillas 1626/1631. Esta funcionalidad está pendiente de implementación: distinguir entre FXCONV (conversiones automáticas del broker) y operaciones de trading FX independientes.</p>
+        <h3>Forex (CASH) — Art. 37.1.l LIRPF</h3>
+        <p>Las operaciones de compraventa de divisas tributan como ganancias y pérdidas patrimoniales (DGT V2324-10, Art. 37.1.l LIRPF). DeclaRenta implementa un <strong>motor FX FIFO independiente</strong> que genera dos eventos fiscales al operar en divisa extranjera:</p>
+        <ol>
+          <li><strong>Ganancia/pérdida del valor</strong> (casillas 0327/0328): calculada sobre el precio del activo × tipo ECB en cada fecha.</li>
+          <li><strong>Ganancia/pérdida FX</strong> (casillas 1626/1631): diferencia entre el tipo de cambio al adquirir la divisa y el tipo al disponer de ella.</li>
+        </ol>
+        <p>Cada adquisición de divisa extranjera (depósito EUR→USD, venta de acciones que genera USD) crea un lote en la cola FIFO de esa divisa. Cada disposición (conversión USD→EUR, compra de acciones en USD) consume lotes por orden cronológico.</p>
+        <p>Las conversiones automáticas del broker para liquidación (FXCONV) se excluyen automáticamente — solo las operaciones de forex deliberadas generan eventos fiscales.</p>
         <p class="muted">La regla anti-churning no se aplica a operaciones forex.</p>
 
         <h3>Bonos y renta fija (BOND)</h3>
@@ -1074,8 +1079,8 @@ declarenta d6 --input informe.xml --year 2025 --nif 12345678A --name "Apellidos,
                 <td>Deducción por doble imposición internacional: menor entre impuesto pagado en origen y cuota española.</td>
               </tr>
               <tr>
-                <td>Art. 47 LGT</td>
-                <td>Tipos de cambio: obligación de usar tipos oficiales (BCE) para la conversión de moneda extranjera.</td>
+                <td>PGC NRV 11a / DGT V0583-16</td>
+                <td>Tipos de cambio: el BCE constituye la referencia oficial para la conversión de moneda extranjera (safe harbor).</td>
               </tr>
               <tr>
                 <td>Ley 7/2024</td>

--- a/src/web/main.ts
+++ b/src/web/main.ts
@@ -594,7 +594,7 @@ function renderResults(report: TaxSummary) {
   const yearHeader = document.getElementById("results-year-header");
   if (yearHeader) {
     const year = report.year;
-    const hasData = report.capitalGains.disposals.length > 0 || report.dividends.entries.length > 0;
+    const hasData = report.capitalGains.disposals.length > 0 || report.fxGains.disposals.length > 0 || report.dividends.entries.length > 0;
 
     const yearOptions = (detectedYears.length > 0 ? detectedYears : [year])
       .slice().sort((a, b) => a - b)
@@ -639,6 +639,7 @@ function renderResults(report: TaxSummary) {
   const taxableBase = Math.max(0,
     report.capitalGains.netGainLoss.toNumber()
     + report.capitalGains.blockedLosses.toNumber()
+    + report.fxGains.netGainLoss.toNumber()
     + report.dividends.grossIncome.toNumber()
     + report.interest.earned.toNumber()
   );

--- a/src/web/storage.ts
+++ b/src/web/storage.ts
@@ -19,6 +19,7 @@ export interface StoredReport {
     acquisitionValue: number;
     netGainLoss: number;
     blockedLosses: number;
+    fxNetGainLoss: number;
     grossDividends: number;
     interestEarned: number;
     interestPaid: number;
@@ -27,6 +28,7 @@ export interface StoredReport {
   /** Summary stats */
   stats: {
     disposalsCount: number;
+    fxDisposalsCount: number;
     dividendsCount: number;
     warningsCount: number;
     currencies: string[];

--- a/src/web/year-compare.ts
+++ b/src/web/year-compare.ts
@@ -35,6 +35,7 @@ export function persistReport(report: TaxSummary, brokers: string[]): void {
       acquisitionValue: report.capitalGains.acquisitionValue.toNumber(),
       netGainLoss: report.capitalGains.netGainLoss.toNumber(),
       blockedLosses: report.capitalGains.blockedLosses.toNumber(),
+      fxNetGainLoss: report.fxGains.netGainLoss.toNumber(),
       grossDividends: report.dividends.grossIncome.toNumber(),
       interestEarned: report.interest.earned.toNumber(),
       interestPaid: report.interest.paid.toNumber(),
@@ -42,6 +43,7 @@ export function persistReport(report: TaxSummary, brokers: string[]): void {
     },
     stats: {
       disposalsCount: report.capitalGains.disposals.length,
+      fxDisposalsCount: report.fxGains.disposals.length,
       dividendsCount: report.dividends.entries.length,
       warningsCount: report.warnings.length,
       currencies: [...currencies],
@@ -81,6 +83,7 @@ const COMPARISON_ROWS: ComparisonRow[] = [
   { label: "casilla.transmission_value", key: "transmissionValue" },
   { label: "casilla.acquisition_value", key: "acquisitionValue" },
   { label: "casilla.net_gain_loss", key: "netGainLoss" },
+  { label: "casilla.fx_net_gain_loss", key: "fxNetGainLoss" },
   { label: "casilla.gross_dividends", key: "grossDividends" },
   { label: "casilla.interest_earned", key: "interestEarned" },
   { label: "casilla.interest_paid", key: "interestPaid" },

--- a/tests/engine/fx-fifo.test.ts
+++ b/tests/engine/fx-fifo.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect } from "vitest";
+import Decimal from "decimal.js";
+import { FxFifoEngine } from "../../src/engine/fx-fifo.js";
+import type { FxEvent } from "../../src/engine/fx-fifo.js";
+import type { Trade } from "../../src/types/ibkr.js";
+import type { EcbRateMap } from "../../src/types/ecb.js";
+
+function makeEvent(overrides: Partial<FxEvent> = {}): FxEvent {
+  return {
+    date: "2025-03-15",
+    currency: "USD",
+    quantity: new Decimal(1000),
+    ecbRate: new Decimal("0.92"),
+    trigger: "conversion",
+    ...overrides,
+  };
+}
+
+function makeTrade(overrides: Partial<Trade> = {}): Trade {
+  return {
+    tradeID: "1",
+    accountId: "U1",
+    symbol: "EUR.USD",
+    description: "",
+    isin: "",
+    assetCategory: "CASH",
+    currency: "USD",
+    tradeDate: "20250315",
+    settlementDate: "20250317",
+    quantity: "1000",
+    tradePrice: "1.08",
+    tradeMoney: "1080",
+    proceeds: "0",
+    cost: "0",
+    fifoPnlRealized: "0",
+    fxRateToBase: "0.92",
+    buySell: "BUY",
+    openCloseIndicator: "O",
+    exchange: "IDEALFX",
+    commissionCurrency: "USD",
+    commission: "2",
+    taxes: "0",
+    multiplier: "1",
+    ...overrides,
+  };
+}
+
+const rateMap: EcbRateMap = new Map([
+  ["2025-03-15", new Map([["USD", new Decimal("0.92")]])],
+  ["2025-03-14", new Map([["USD", new Decimal("0.92")]])],
+  ["2025-06-15", new Map([["USD", new Decimal("0.95")]])],
+  ["2025-06-14", new Map([["USD", new Decimal("0.95")]])],
+  ["2025-09-01", new Map([["USD", new Decimal("0.90")]])],
+]);
+
+describe("FxFifoEngine", () => {
+  describe("processEvents", () => {
+    it("should create lot on positive quantity (acquiring FCY)", () => {
+      const engine = new FxFifoEngine();
+      engine.processEvents([makeEvent()]);
+
+      const lots = engine.getRemainingLots().get("USD");
+      expect(lots).toHaveLength(1);
+      expect(lots![0]!.quantity.toString()).toBe("1000");
+      expect(lots![0]!.costPerUnit.toString()).toBe("0.92");
+    });
+
+    it("should consume lots on negative quantity (disposing FCY)", () => {
+      const engine = new FxFifoEngine();
+      engine.processEvents([
+        makeEvent({ quantity: new Decimal(1000) }),
+        makeEvent({ date: "2025-06-15", quantity: new Decimal(-500), ecbRate: new Decimal("0.95") }),
+      ]);
+
+      const lots = engine.getRemainingLots().get("USD");
+      expect(lots).toHaveLength(1);
+      expect(lots![0]!.quantity.toString()).toBe("500");
+
+      const disposals = engine.getDisposals();
+      expect(disposals).toHaveLength(1);
+      expect(disposals[0]!.quantity.toString()).toBe("500");
+      expect(disposals[0]!.proceedsEur.toFixed(2)).toBe("475.00"); // 500 * 0.95
+      expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("460.00"); // 500 * 0.92
+      expect(disposals[0]!.gainLossEur.toFixed(2)).toBe("15.00");
+    });
+
+    it("should apply FIFO — consume oldest lots first", () => {
+      const engine = new FxFifoEngine();
+      engine.processEvents([
+        makeEvent({ date: "2025-03-15", quantity: new Decimal(1000), ecbRate: new Decimal("0.92") }),
+        makeEvent({ date: "2025-06-15", quantity: new Decimal(500), ecbRate: new Decimal("0.95") }),
+        makeEvent({ date: "2025-09-01", quantity: new Decimal(-1200), ecbRate: new Decimal("0.90") }),
+      ]);
+
+      const disposals = engine.getDisposals();
+      expect(disposals).toHaveLength(2);
+
+      // First disposal: 1000 from lot 1 (cost 0.92, proceeds 0.90 → loss)
+      expect(disposals[0]!.quantity.toString()).toBe("1000");
+      expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("920.00");
+      expect(disposals[0]!.proceedsEur.toFixed(2)).toBe("900.00");
+      expect(disposals[0]!.gainLossEur.toFixed(2)).toBe("-20.00");
+
+      // Second disposal: 200 from lot 2 (cost 0.95, proceeds 0.90 → loss)
+      expect(disposals[1]!.quantity.toString()).toBe("200");
+      expect(disposals[1]!.costBasisEur.toFixed(2)).toBe("190.00");
+      expect(disposals[1]!.proceedsEur.toFixed(2)).toBe("180.00");
+      expect(disposals[1]!.gainLossEur.toFixed(2)).toBe("-10.00");
+    });
+
+    it("should skip EUR events", () => {
+      const engine = new FxFifoEngine();
+      engine.processEvents([makeEvent({ currency: "EUR", quantity: new Decimal(5000) })]);
+
+      expect(engine.getRemainingLots().size).toBe(0);
+      expect(engine.getDisposals()).toHaveLength(0);
+    });
+
+    it("should warn when disposing without prior lots", () => {
+      const engine = new FxFifoEngine();
+      engine.processEvents([
+        makeEvent({ quantity: new Decimal(-500) }),
+      ]);
+
+      expect(engine.warnings).toHaveLength(1);
+      expect(engine.warnings[0]).toMatch(/sin lotes previos/);
+    });
+
+    it("should warn and record zero-cost disposal for insufficient lots", () => {
+      const engine = new FxFifoEngine();
+      engine.processEvents([
+        makeEvent({ quantity: new Decimal(300), ecbRate: new Decimal("0.92") }),
+        makeEvent({ date: "2025-06-15", quantity: new Decimal(-500), ecbRate: new Decimal("0.95") }),
+      ]);
+
+      const disposals = engine.getDisposals();
+      expect(disposals).toHaveLength(2);
+      // First: 300 from lot
+      expect(disposals[0]!.quantity.toString()).toBe("300");
+      // Second: 200 with zero cost (overflow)
+      expect(disposals[1]!.quantity.toString()).toBe("200");
+      expect(disposals[1]!.costBasisEur.toFixed(2)).toBe("0.00");
+      expect(engine.warnings.some((w) => w.includes("insuficientes"))).toBe(true);
+    });
+
+    it("should calculate holding period days correctly", () => {
+      const engine = new FxFifoEngine();
+      engine.processEvents([
+        makeEvent({ date: "2025-03-15", quantity: new Decimal(1000) }),
+        makeEvent({ date: "2025-06-15", quantity: new Decimal(-500), ecbRate: new Decimal("0.95") }),
+      ]);
+
+      const d = engine.getDisposals()[0]!;
+      // Mar 15 to Jun 15 = 92 days
+      expect(d.holdingPeriodDays).toBe(92);
+    });
+
+    it("should track multiple currencies independently", () => {
+      const engine = new FxFifoEngine();
+      engine.processEvents([
+        makeEvent({ currency: "USD", quantity: new Decimal(1000), ecbRate: new Decimal("0.92") }),
+        makeEvent({ currency: "GBP", quantity: new Decimal(500), ecbRate: new Decimal("1.15") }),
+        makeEvent({ date: "2025-06-15", currency: "USD", quantity: new Decimal(-1000), ecbRate: new Decimal("0.95") }),
+      ]);
+
+      const usdLots = engine.getRemainingLots().get("USD") ?? [];
+      const gbpLots = engine.getRemainingLots().get("GBP") ?? [];
+      expect(usdLots).toHaveLength(0);
+      expect(gbpLots).toHaveLength(1);
+      expect(gbpLots[0]!.quantity.toString()).toBe("500");
+    });
+  });
+
+  describe("extractFxEvents", () => {
+    it("should extract BUY CASH as positive FX event", () => {
+      const trades = [makeTrade({ buySell: "BUY", quantity: "1000" })];
+      const events = FxFifoEngine.extractFxEvents(trades, rateMap);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]!.quantity.toString()).toBe("1000");
+      expect(events[0]!.trigger).toBe("conversion");
+    });
+
+    it("should extract SELL CASH as negative FX event", () => {
+      const trades = [makeTrade({ buySell: "SELL", quantity: "1000" })];
+      const events = FxFifoEngine.extractFxEvents(trades, rateMap);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]!.quantity.toString()).toBe("-1000");
+      expect(events[0]!.trigger).toBe("conversion");
+    });
+
+    it("should skip FXCONV trades (automatic conversions)", () => {
+      const trades = [
+        makeTrade({ description: "FXCONV" }),
+        makeTrade({ description: "CASH RECEIPTS / DISBURSEMENTS" }),
+      ];
+      const events = FxFifoEngine.extractFxEvents(trades, rateMap);
+      expect(events).toHaveLength(0);
+    });
+
+    it("should extract stock BUY as negative FX event (spending FCY)", () => {
+      const trades = [makeTrade({
+        assetCategory: "STK",
+        symbol: "AAPL",
+        isin: "US0378331005",
+        buySell: "BUY",
+        tradeMoney: "5000",
+        currency: "USD",
+      })];
+      const events = FxFifoEngine.extractFxEvents(trades, rateMap);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]!.quantity.toString()).toBe("-5000");
+      expect(events[0]!.trigger).toBe("stock_purchase");
+    });
+
+    it("should extract stock SELL as positive FX event (receiving FCY)", () => {
+      const trades = [makeTrade({
+        assetCategory: "STK",
+        symbol: "AAPL",
+        isin: "US0378331005",
+        buySell: "SELL",
+        tradeMoney: "6000",
+        currency: "USD",
+      })];
+      const events = FxFifoEngine.extractFxEvents(trades, rateMap);
+
+      expect(events).toHaveLength(1);
+      expect(events[0]!.quantity.toString()).toBe("6000");
+      expect(events[0]!.trigger).toBe("stock_sale");
+    });
+
+    it("should skip EUR trades", () => {
+      const trades = [makeTrade({ currency: "EUR", assetCategory: "STK", tradeMoney: "5000" })];
+      const events = FxFifoEngine.extractFxEvents(trades, rateMap);
+      expect(events).toHaveLength(0);
+    });
+
+    it("should skip WAR asset category", () => {
+      const trades = [makeTrade({ assetCategory: "WAR", currency: "USD", tradeMoney: "1000" })];
+      const events = FxFifoEngine.extractFxEvents(trades, rateMap);
+      expect(events).toHaveLength(0);
+    });
+  });
+
+  describe("integration: two-event model", () => {
+    it("should produce correct FX gain for a stock round-trip in USD", () => {
+      // Day 1: Convert EUR 1000 → USD 1100 (rate 0.92 EUR/USD)
+      // Day 30: Buy 10 AAPL @ $110 using USD 1100 (rate 0.95 EUR/USD)
+      // Day 60: Sell 10 AAPL @ $120 = USD 1200 (rate 0.90 EUR/USD)
+      const engine = new FxFifoEngine();
+      engine.processEvents([
+        { date: "2025-01-01", currency: "USD", quantity: new Decimal(1100), ecbRate: new Decimal("0.92"), trigger: "conversion" },
+        { date: "2025-01-31", currency: "USD", quantity: new Decimal(-1100), ecbRate: new Decimal("0.95"), trigger: "stock_purchase" },
+        { date: "2025-03-01", currency: "USD", quantity: new Decimal(1200), ecbRate: new Decimal("0.90"), trigger: "stock_sale" },
+      ]);
+
+      const disposals = engine.getDisposals();
+      expect(disposals).toHaveLength(1);
+
+      // FX gain on the stock purchase:
+      // Acquired 1100 USD at 0.92 = cost 1012 EUR
+      // Disposed at 0.95 = proceeds 1045 EUR
+      // FX gain = 1045 - 1012 = 33 EUR
+      expect(disposals[0]!.gainLossEur.toFixed(2)).toBe("33.00");
+      expect(disposals[0]!.trigger).toBe("stock_purchase");
+
+      // Remaining: 1200 USD lot from stock_sale at rate 0.90
+      const remaining = engine.getRemainingLots().get("USD");
+      expect(remaining).toHaveLength(1);
+      expect(remaining![0]!.quantity.toString()).toBe("1200");
+      expect(remaining![0]!.costPerUnit.toString()).toBe("0.9");
+    });
+  });
+});

--- a/tests/generators/csv.test.ts
+++ b/tests/generators/csv.test.ts
@@ -88,6 +88,12 @@ function makeReport(overrides?: Partial<TaxSummary>): TaxSummary {
       deduction: new Decimal(7.5),
       byCountry: {},
     },
+    fxGains: {
+      transmissionValue: new Decimal(0),
+      acquisitionValue: new Decimal(0),
+      netGainLoss: new Decimal(0),
+      disposals: [],
+    },
     ...overrides,
   };
 }

--- a/tests/generators/pdf.test.ts
+++ b/tests/generators/pdf.test.ts
@@ -75,6 +75,12 @@ function makeReport(overrides: Partial<TaxSummary> = {}): TaxSummary {
         US: { taxPaid: new Decimal("75"), deductionAllowed: new Decimal("75") },
       },
     },
+    fxGains: {
+      transmissionValue: new Decimal(0),
+      acquisitionValue: new Decimal(0),
+      netGainLoss: new Decimal(0),
+      disposals: [],
+    },
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

- **New FX FIFO engine** implementing Art. 37.1.l LIRPF two-event model for forex gains from securities trades in foreign currency
- Stock BUY = dispose FCY (negative FX event), stock SELL = acquire FCY (positive FX event), with FXCONV auto-detection to exclude automatic broker conversions
- **Casillas 1626/1631** added for FX transmission/acquisition values across CLI, CSV, PDF, and web UI
- **Fixed incorrect legal citation**: Art. 47 LGT → PGC NRV 11a / DGT V0583-16 (consultas vinculantes V2324-10, V0583-16)
- **Updated docs**: Flex Query guide now recommends "activa todas las disponibles", ECB vs IBKR rate explanation, forex section rewritten with two-event model
- **16 new tests** covering FIFO lot creation, multi-currency tracking, holding period, edge cases, and integration scenarios

## Test plan

- [x] All 840 tests pass (including 16 new FX FIFO tests)
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Verify web UI shows FX gains in casilla detail view
- [ ] Verify year comparison table includes FX row
- [ ] Verify CSV output includes FX section
- [ ] Test with real IBKR Flex Query containing USD trades