### PR TITLE
feat: complete FX FIFO — dividends, interest, commissions + traceability

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -479,6 +479,7 @@ function formatReport(report: ReturnType<typeof generateTaxReport>) {
       ganancia_eur: d.gainLossEur.toFixed(2),
       dias_tenencia: d.holdingPeriodDays,
       origen: d.trigger,
+      lote_fifo: d.lotId,
     })),
     dividendos: report.dividends.entries.map((d) => ({
       isin: d.isin,

--- a/src/engine/fx-fifo.ts
+++ b/src/engine/fx-fifo.ts
@@ -7,8 +7,8 @@
  */
 
 import Decimal from "decimal.js";
-import type { FxLot, FxDisposal } from "../types/tax.js";
-import type { Trade } from "../types/ibkr.js";
+import type { FxLot, FxDisposal, FxTrigger } from "../types/tax.js";
+import type { Trade, CashTransaction } from "../types/ibkr.js";
 import type { EcbRateMap } from "../types/ecb.js";
 import { getEcbRate } from "./ecb.js";
 import { daysBetween, normalizeDate } from "./dates.js";
@@ -20,7 +20,7 @@ export interface FxEvent {
   quantity: Decimal;
   /** EUR rate at event time (EUR per 1 FCY) */
   ecbRate: Decimal;
-  trigger: "conversion" | "stock_purchase" | "stock_sale";
+  trigger: FxTrigger;
 }
 
 export class FxFifoEngine {
@@ -96,6 +96,56 @@ export class FxFifoEngine {
           // Selling stock = receiving FCY
           events.push({ date, currency: trade.currency, quantity: tradeMoney, ecbRate, trigger: "stock_sale" });
         }
+
+        // Commission also consumes FCY (paid in commissionCurrency)
+        const commission = new Decimal(trade.commission).abs();
+        if (commission.greaterThan(0) && trade.commissionCurrency !== "EUR") {
+          const commRate = getEcbRate(rateMap, date, trade.commissionCurrency);
+          events.push({ date, currency: trade.commissionCurrency, quantity: commission.negated(), ecbRate: commRate, trigger: "commission" });
+        }
+      }
+    }
+
+    return events;
+  }
+
+  /**
+   * Extract FX events from cash transactions (dividends, interest).
+   *
+   * Receiving dividends/interest in FCY = acquiring FCY (creates lot).
+   * Paying interest/fees in FCY = disposing FCY (consumes lots).
+   */
+  static extractCashFxEvents(cashTransactions: CashTransaction[], rateMap: EcbRateMap): FxEvent[] {
+    const events: FxEvent[] = [];
+
+    for (const tx of cashTransactions) {
+      if (tx.currency === "EUR") continue;
+
+      const amount = new Decimal(tx.amount);
+      if (amount.isZero()) continue;
+
+      const date = normalizeDate(tx.dateTime);
+      const ecbRate = getEcbRate(rateMap, date, tx.currency);
+
+      if (tx.type === "Dividends" || tx.type === "Payment In Lieu Of Dividends") {
+        // Receiving dividend in FCY = acquiring FCY
+        events.push({ date, currency: tx.currency, quantity: amount.abs(), ecbRate, trigger: "dividend" });
+      } else if (tx.type === "Withholding Tax") {
+        // WHT reduces FCY balance (negative amount in IBKR) = disposing FCY
+        events.push({ date, currency: tx.currency, quantity: amount.abs().negated(), ecbRate, trigger: "dividend" });
+      } else if (tx.type === "Broker Interest Received" || tx.type === "Bond Interest Received") {
+        // Interest received in FCY = acquiring FCY
+        events.push({ date, currency: tx.currency, quantity: amount.abs(), ecbRate, trigger: "interest" });
+      } else if (tx.type === "Broker Interest Paid" || tx.type === "Bond Interest Paid") {
+        // Interest paid in FCY = disposing FCY
+        events.push({ date, currency: tx.currency, quantity: amount.abs().negated(), ecbRate, trigger: "interest" });
+      } else if (tx.type === "Other Fees" || tx.type === "Commission Adjustments") {
+        // Fees paid in FCY = disposing FCY
+        if (amount.lessThan(0)) {
+          events.push({ date, currency: tx.currency, quantity: amount.abs().negated(), ecbRate, trigger: "commission" });
+        } else {
+          events.push({ date, currency: tx.currency, quantity: amount.abs(), ecbRate, trigger: "commission" });
+        }
       }
     }
 
@@ -129,8 +179,6 @@ export class FxFifoEngine {
     const lots = this.lots.get(event.currency);
 
     if (!lots || lots.length === 0) {
-      // No lots to consume — FCY was acquired before our data window
-      // Add a synthetic lot at the current rate (gain = 0) and warn
       this.warnings.push(`⚠ Venta de ${event.currency} sin lotes previos el ${event.date}. Posible adquisición anterior al período declarado.`);
       return;
     }
@@ -153,6 +201,7 @@ export class FxFifoEngine {
         gainLossEur: proceedsEur.minus(costBasisEur),
         trigger: event.trigger,
         holdingPeriodDays: holdingDays,
+        lotId: lot.id,
       });
 
       lot.quantity = lot.quantity.minus(consumed);
@@ -178,6 +227,7 @@ export class FxFifoEngine {
         gainLossEur: proceedsEur,
         trigger: event.trigger,
         holdingPeriodDays: 0,
+        lotId: "UNKNOWN",
       });
     }
   }

--- a/src/generators/csv.ts
+++ b/src/generators/csv.ts
@@ -49,13 +49,13 @@ export function formatCsv(report: TaxSummary): string {
   // FX gains section
   if (report.fxGains.disposals.length > 0) {
     lines.push("# GANANCIAS FX (Art. 37.1.l LIRPF)");
-    lines.push("Divisa,Fecha_Compra,Fecha_Venta,Cantidad,Coste_EUR,Venta_EUR,Ganancia_EUR,Dias,Origen");
+    lines.push("Divisa,Fecha_Compra,Fecha_Venta,Cantidad,Coste_EUR,Venta_EUR,Ganancia_EUR,Dias,Origen,Lote_FIFO");
     for (const d of report.fxGains.disposals) {
       lines.push([
         escapeCsv(d.currency), d.acquireDate, d.disposeDate,
         d.quantity.toFixed(2), d.costBasisEur.toFixed(2), d.proceedsEur.toFixed(2),
         d.gainLossEur.toFixed(2), d.holdingPeriodDays.toString(),
-        escapeCsv(d.trigger),
+        escapeCsv(d.trigger), escapeCsv(d.lotId),
       ].join(","));
     }
     lines.push("");

--- a/src/generators/report.ts
+++ b/src/generators/report.ts
@@ -92,8 +92,9 @@ export function generateTaxReport(
 
   // 4. FX gains (Art. 37.1.l LIRPF — currency conversions as taxable events)
   const fxEngine = new FxFifoEngine();
-  const fxEvents = FxFifoEngine.extractFxEvents(statement.trades, rateMap);
-  const allFxDisposals = fxEngine.processEvents(fxEvents);
+  const tradeFxEvents = FxFifoEngine.extractFxEvents(statement.trades, rateMap);
+  const cashFxEvents = FxFifoEngine.extractCashFxEvents(statement.cashTransactions, rateMap);
+  const allFxDisposals = fxEngine.processEvents([...tradeFxEvents, ...cashFxEvents]);
   const fxDisposals = allFxDisposals.filter((d) => d.disposeDate.startsWith(yearStr));
 
   const fxTransmissionValue = fxDisposals.reduce((sum, d) => sum.plus(d.proceedsEur), new Decimal(0));

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -142,6 +142,9 @@ export interface FxLot {
   costInEur: Decimal;
 }
 
+/** What triggered an FX disposal */
+export type FxTrigger = "conversion" | "stock_purchase" | "stock_sale" | "dividend" | "interest" | "commission";
+
 /** Result of consuming FX lots via FIFO for a currency disposal */
 export interface FxDisposal {
   currency: string;
@@ -151,9 +154,10 @@ export interface FxDisposal {
   proceedsEur: Decimal;
   costBasisEur: Decimal;
   gainLossEur: Decimal;
-  /** What triggered the disposal: "conversion" | "stock_purchase" | "stock_sale" */
-  trigger: "conversion" | "stock_purchase" | "stock_sale";
+  trigger: FxTrigger;
   holdingPeriodDays: number;
+  /** FIFO lot ID consumed (for audit traceability) */
+  lotId: string;
 }
 
 /** Loss carryforward entry (Art. 49 LIRPF) */

--- a/src/web/casilla-detail.ts
+++ b/src/web/casilla-detail.ts
@@ -122,7 +122,7 @@ function renderFxDisposalsDetail(disposals: FxDisposal[], label: string): string
     <table class="detail-table">
       <thead><tr>
         <th>${t("table.currency")}</th><th>${t("table.sell_date")}</th><th>${t("table.buy_date")}</th>
-        <th>${t("table.units")}</th><th>EUR</th>
+        <th>${t("table.units")}</th><th>EUR</th><th>Origen</th><th>Lote FIFO</th>
       </tr></thead>
       <tbody>${disposals.map((d) => `
         <tr>
@@ -131,6 +131,8 @@ function renderFxDisposalsDetail(disposals: FxDisposal[], label: string): string
           <td>${formatDate(d.acquireDate)}</td>
           <td>${d.quantity.toFixed(2)}</td>
           <td class="${d.gainLossEur.greaterThanOrEqualTo(0) ? "gain" : "loss"}">${d.gainLossEur.toFixed(2)}</td>
+          <td>${esc(d.trigger)}</td>
+          <td>${esc(d.lotId)}</td>
         </tr>`).join("")}
       </tbody>
     </table>`;

--- a/tests/engine/fx-fifo.test.ts
+++ b/tests/engine/fx-fifo.test.ts
@@ -199,7 +199,7 @@ describe("FxFifoEngine", () => {
       expect(events).toHaveLength(0);
     });
 
-    it("should extract stock BUY as negative FX event (spending FCY)", () => {
+    it("should extract stock BUY as negative FX event (spending FCY) + commission", () => {
       const trades = [makeTrade({
         assetCategory: "STK",
         symbol: "AAPL",
@@ -210,12 +210,14 @@ describe("FxFifoEngine", () => {
       })];
       const events = FxFifoEngine.extractFxEvents(trades, rateMap);
 
-      expect(events).toHaveLength(1);
+      expect(events).toHaveLength(2);
       expect(events[0]!.quantity.toString()).toBe("-5000");
       expect(events[0]!.trigger).toBe("stock_purchase");
+      expect(events[1]!.quantity.toString()).toBe("-2");
+      expect(events[1]!.trigger).toBe("commission");
     });
 
-    it("should extract stock SELL as positive FX event (receiving FCY)", () => {
+    it("should extract stock SELL as positive FX event (receiving FCY) + commission", () => {
       const trades = [makeTrade({
         assetCategory: "STK",
         symbol: "AAPL",
@@ -226,9 +228,11 @@ describe("FxFifoEngine", () => {
       })];
       const events = FxFifoEngine.extractFxEvents(trades, rateMap);
 
-      expect(events).toHaveLength(1);
+      expect(events).toHaveLength(2);
       expect(events[0]!.quantity.toString()).toBe("6000");
       expect(events[0]!.trigger).toBe("stock_sale");
+      expect(events[1]!.quantity.toString()).toBe("-2");
+      expect(events[1]!.trigger).toBe("commission");
     });
 
     it("should skip EUR trades", () => {
@@ -271,6 +275,96 @@ describe("FxFifoEngine", () => {
       expect(remaining).toHaveLength(1);
       expect(remaining![0]!.quantity.toString()).toBe("1200");
       expect(remaining![0]!.costPerUnit.toString()).toBe("0.9");
+
+      // Verify lotId traceability
+      expect(disposals[0]!.lotId).toBe("FX-1");
+    });
+  });
+
+  describe("extractCashFxEvents", () => {
+    it("should extract dividend as positive FX event (acquiring FCY)", () => {
+      const txs = [{
+        transactionID: "1", accountId: "U1", symbol: "AAPL", description: "AAPL dividend",
+        isin: "US0378331005", currency: "USD", dateTime: "20250315",
+        settleDate: "20250317", amount: "100", fxRateToBase: "0.92", type: "Dividends" as const,
+      }];
+      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap);
+      expect(events).toHaveLength(1);
+      expect(events[0]!.quantity.toString()).toBe("100");
+      expect(events[0]!.trigger).toBe("dividend");
+    });
+
+    it("should extract withholding tax as negative FX event (disposing FCY)", () => {
+      const txs = [{
+        transactionID: "2", accountId: "U1", symbol: "AAPL", description: "US WHT",
+        isin: "US0378331005", currency: "USD", dateTime: "20250315",
+        settleDate: "20250317", amount: "-15", fxRateToBase: "0.92", type: "Withholding Tax" as const,
+      }];
+      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap);
+      expect(events).toHaveLength(1);
+      expect(events[0]!.quantity.toString()).toBe("-15");
+      expect(events[0]!.trigger).toBe("dividend");
+    });
+
+    it("should extract interest received as positive FX event", () => {
+      const txs = [{
+        transactionID: "3", accountId: "U1", symbol: "", description: "USD Interest",
+        isin: "", currency: "USD", dateTime: "20250315",
+        settleDate: "20250317", amount: "25", fxRateToBase: "0.92", type: "Broker Interest Received" as const,
+      }];
+      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap);
+      expect(events).toHaveLength(1);
+      expect(events[0]!.quantity.toString()).toBe("25");
+      expect(events[0]!.trigger).toBe("interest");
+    });
+
+    it("should extract interest paid as negative FX event", () => {
+      const txs = [{
+        transactionID: "4", accountId: "U1", symbol: "", description: "USD Margin Interest",
+        isin: "", currency: "USD", dateTime: "20250315",
+        settleDate: "20250317", amount: "-10", fxRateToBase: "0.92", type: "Broker Interest Paid" as const,
+      }];
+      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap);
+      expect(events).toHaveLength(1);
+      expect(events[0]!.quantity.toString()).toBe("-10");
+      expect(events[0]!.trigger).toBe("interest");
+    });
+
+    it("should skip EUR transactions", () => {
+      const txs = [{
+        transactionID: "5", accountId: "U1", symbol: "VWCE", description: "VWCE dividend",
+        isin: "IE00BK5BQT80", currency: "EUR", dateTime: "20250315",
+        settleDate: "20250317", amount: "50", fxRateToBase: "1", type: "Dividends" as const,
+      }];
+      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap);
+      expect(events).toHaveLength(0);
+    });
+
+    it("should extract fees as negative FX event", () => {
+      const txs = [{
+        transactionID: "6", accountId: "U1", symbol: "", description: "Other fee",
+        isin: "", currency: "USD", dateTime: "20250315",
+        settleDate: "20250317", amount: "-5", fxRateToBase: "0.92", type: "Other Fees" as const,
+      }];
+      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap);
+      expect(events).toHaveLength(1);
+      expect(events[0]!.quantity.toString()).toBe("-5");
+      expect(events[0]!.trigger).toBe("commission");
+    });
+  });
+
+  describe("lotId traceability", () => {
+    it("should assign unique lot IDs and reference them in disposals", () => {
+      const engine = new FxFifoEngine();
+      engine.processEvents([
+        makeEvent({ date: "2025-03-15", quantity: new Decimal(1000), ecbRate: new Decimal("0.92") }),
+        makeEvent({ date: "2025-06-15", quantity: new Decimal(500), ecbRate: new Decimal("0.95") }),
+        makeEvent({ date: "2025-09-01", quantity: new Decimal(-1200), ecbRate: new Decimal("0.90") }),
+      ]);
+
+      const disposals = engine.getDisposals();
+      expect(disposals[0]!.lotId).toBe("FX-1");
+      expect(disposals[1]!.lotId).toBe("FX-2");
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Dividends/interest/commissions now feed the FX FIFO engine** — all FCY cash flows create or consume currency lots as required by Art. 37.1.l LIRPF
- **Lot traceability (`lotId`)** on every FxDisposal — each disposal references which FIFO lot was consumed, enabling full audit justification for Hacienda
- New `extractCashFxEvents()` method handles: dividends (positive), withholding tax (negative), interest received/paid, other fees
- Trade commissions in FCY also generate FX disposal events
- CSV, CLI JSON output, and web detail view all show origin trigger + lot ID

## Test plan

- [x] All 847 tests pass (7 new tests for cash FX events + lot traceability)
- [x] TypeScript compiles cleanly
- [ ] Verify with real IBKR Flex Query containing USD dividends
- [ ] Verify CSV output shows `Lote_FIFO` column
- [ ] Verify web detail table shows Origen + Lote FIFO columns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FX gains reports now display FIFO lot identifiers for each disposed position, enabling detailed lot tracking.
  * FX gains calculation extended to include foreign exchange events from cash transactions (dividends, interest, fees, commissions) alongside trade activity, providing more comprehensive FX gain/loss reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->