### PR TITLE
fix: skip implicit FX events for auto-convert accounts

### DIFF
--- a/src/engine/fx-fifo.ts
+++ b/src/engine/fx-fifo.ts
@@ -51,21 +51,31 @@ export class FxFifoEngine {
   }
 
   /**
+   * Detect whether the account uses automatic currency conversion.
+   * If FXCONV trades exist, the broker converts FCY instantly on each trade —
+   * the user never holds FCY between operations, so securities trades
+   * don't generate independent FX exposure.
+   */
+  static detectAutoConvert(trades: Trade[]): boolean {
+    return trades.some((t) => t.assetCategory === "CASH" && FxFifoEngine.isFxconv(t));
+  }
+
+  /**
    * Extract FX events from trades.
    *
    * Two sources of FX events:
    * 1. CASH trades (assetCategory=CASH): direct forex conversions
    *    - BUY CASH in USD = acquiring USD (add lot)
    *    - SELL CASH in USD = disposing USD (consume lots)
-   * 2. Securities trades in non-EUR: implicit currency disposal/acquisition
+   * 2. Securities trades in non-EUR (ONLY in multi-currency accounts):
    *    - BUY stock in USD = spending USD (dispose FCY lots)
    *    - SELL stock in USD = receiving USD (add FCY lot)
    *
-   * We skip FXCONV (automatic broker conversions for settlement) since those
-   * are not independent trading decisions. Detection: notes field contains
-   * "FXCONV" or description contains "CASH RECEIPTS / DISBURSEMENTS".
+   * Auto-convert accounts: only manual CASH conversions generate FX events.
+   * Stock trades are settled instantly via FXCONV — no FX exposure.
    */
   static extractFxEvents(trades: Trade[], rateMap: EcbRateMap): FxEvent[] {
+    const autoConvert = FxFifoEngine.detectAutoConvert(trades);
     const events: FxEvent[] = [];
 
     for (const trade of trades) {
@@ -84,16 +94,14 @@ export class FxFifoEngine {
         } else {
           events.push({ date, currency: trade.currency, quantity: quantity.negated(), ecbRate, trigger: "conversion" });
         }
-      } else if (trade.assetCategory !== "WAR") {
-        // Securities trade in foreign currency — implicit FX event
+      } else if (!autoConvert && trade.assetCategory !== "WAR") {
+        // Multi-currency account: securities trade = implicit FX event
         const tradeMoney = new Decimal(trade.tradeMoney).abs();
         if (tradeMoney.isZero()) continue;
 
         if (trade.buySell === "BUY") {
-          // Buying stock = spending FCY
           events.push({ date, currency: trade.currency, quantity: tradeMoney.negated(), ecbRate, trigger: "stock_purchase" });
         } else {
-          // Selling stock = receiving FCY
           events.push({ date, currency: trade.currency, quantity: tradeMoney, ecbRate, trigger: "stock_sale" });
         }
 
@@ -112,10 +120,13 @@ export class FxFifoEngine {
   /**
    * Extract FX events from cash transactions (dividends, interest).
    *
-   * Receiving dividends/interest in FCY = acquiring FCY (creates lot).
-   * Paying interest/fees in FCY = disposing FCY (consumes lots).
+   * Only relevant for multi-currency accounts where FCY is held.
+   * Auto-convert accounts don't hold FCY — dividends/interest are
+   * converted instantly, so no FX lots are created.
    */
-  static extractCashFxEvents(cashTransactions: CashTransaction[], rateMap: EcbRateMap): FxEvent[] {
+  static extractCashFxEvents(cashTransactions: CashTransaction[], rateMap: EcbRateMap, autoConvert: boolean): FxEvent[] {
+    if (autoConvert) return [];
+
     const events: FxEvent[] = [];
 
     for (const tx of cashTransactions) {
@@ -128,19 +139,14 @@ export class FxFifoEngine {
       const ecbRate = getEcbRate(rateMap, date, tx.currency);
 
       if (tx.type === "Dividends" || tx.type === "Payment In Lieu Of Dividends") {
-        // Receiving dividend in FCY = acquiring FCY
         events.push({ date, currency: tx.currency, quantity: amount.abs(), ecbRate, trigger: "dividend" });
       } else if (tx.type === "Withholding Tax") {
-        // WHT reduces FCY balance (negative amount in IBKR) = disposing FCY
         events.push({ date, currency: tx.currency, quantity: amount.abs().negated(), ecbRate, trigger: "dividend" });
       } else if (tx.type === "Broker Interest Received" || tx.type === "Bond Interest Received") {
-        // Interest received in FCY = acquiring FCY
         events.push({ date, currency: tx.currency, quantity: amount.abs(), ecbRate, trigger: "interest" });
       } else if (tx.type === "Broker Interest Paid" || tx.type === "Bond Interest Paid") {
-        // Interest paid in FCY = disposing FCY
         events.push({ date, currency: tx.currency, quantity: amount.abs().negated(), ecbRate, trigger: "interest" });
       } else if (tx.type === "Other Fees" || tx.type === "Commission Adjustments") {
-        // Fees paid in FCY = disposing FCY
         if (amount.lessThan(0)) {
           events.push({ date, currency: tx.currency, quantity: amount.abs().negated(), ecbRate, trigger: "commission" });
         } else {

--- a/src/generators/report.ts
+++ b/src/generators/report.ts
@@ -91,9 +91,11 @@ export function generateTaxReport(
   });
 
   // 4. FX gains (Art. 37.1.l LIRPF — currency conversions as taxable events)
+  // Auto-convert accounts (FXCONV present) don't hold FCY — no implicit FX events from trades
   const fxEngine = new FxFifoEngine();
+  const autoConvert = FxFifoEngine.detectAutoConvert(statement.trades);
   const tradeFxEvents = FxFifoEngine.extractFxEvents(statement.trades, rateMap);
-  const cashFxEvents = FxFifoEngine.extractCashFxEvents(statement.cashTransactions, rateMap);
+  const cashFxEvents = FxFifoEngine.extractCashFxEvents(statement.cashTransactions, rateMap, autoConvert);
   const allFxDisposals = fxEngine.processEvents([...tradeFxEvents, ...cashFxEvents]);
   const fxDisposals = allFxDisposals.filter((d) => d.disposeDate.startsWith(yearStr));
 

--- a/tests/engine/fx-fifo.test.ts
+++ b/tests/engine/fx-fifo.test.ts
@@ -288,7 +288,7 @@ describe("FxFifoEngine", () => {
         isin: "US0378331005", currency: "USD", dateTime: "20250315",
         settleDate: "20250317", amount: "100", fxRateToBase: "0.92", type: "Dividends" as const,
       }];
-      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap);
+      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap, false);
       expect(events).toHaveLength(1);
       expect(events[0]!.quantity.toString()).toBe("100");
       expect(events[0]!.trigger).toBe("dividend");
@@ -300,7 +300,7 @@ describe("FxFifoEngine", () => {
         isin: "US0378331005", currency: "USD", dateTime: "20250315",
         settleDate: "20250317", amount: "-15", fxRateToBase: "0.92", type: "Withholding Tax" as const,
       }];
-      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap);
+      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap, false);
       expect(events).toHaveLength(1);
       expect(events[0]!.quantity.toString()).toBe("-15");
       expect(events[0]!.trigger).toBe("dividend");
@@ -312,7 +312,7 @@ describe("FxFifoEngine", () => {
         isin: "", currency: "USD", dateTime: "20250315",
         settleDate: "20250317", amount: "25", fxRateToBase: "0.92", type: "Broker Interest Received" as const,
       }];
-      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap);
+      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap, false);
       expect(events).toHaveLength(1);
       expect(events[0]!.quantity.toString()).toBe("25");
       expect(events[0]!.trigger).toBe("interest");
@@ -324,7 +324,7 @@ describe("FxFifoEngine", () => {
         isin: "", currency: "USD", dateTime: "20250315",
         settleDate: "20250317", amount: "-10", fxRateToBase: "0.92", type: "Broker Interest Paid" as const,
       }];
-      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap);
+      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap, false);
       expect(events).toHaveLength(1);
       expect(events[0]!.quantity.toString()).toBe("-10");
       expect(events[0]!.trigger).toBe("interest");
@@ -336,7 +336,7 @@ describe("FxFifoEngine", () => {
         isin: "IE00BK5BQT80", currency: "EUR", dateTime: "20250315",
         settleDate: "20250317", amount: "50", fxRateToBase: "1", type: "Dividends" as const,
       }];
-      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap);
+      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap, false);
       expect(events).toHaveLength(0);
     });
 
@@ -346,7 +346,7 @@ describe("FxFifoEngine", () => {
         isin: "", currency: "USD", dateTime: "20250315",
         settleDate: "20250317", amount: "-5", fxRateToBase: "0.92", type: "Other Fees" as const,
       }];
-      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap);
+      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap, false);
       expect(events).toHaveLength(1);
       expect(events[0]!.quantity.toString()).toBe("-5");
       expect(events[0]!.trigger).toBe("commission");
@@ -365,6 +365,71 @@ describe("FxFifoEngine", () => {
       const disposals = engine.getDisposals();
       expect(disposals[0]!.lotId).toBe("FX-1");
       expect(disposals[1]!.lotId).toBe("FX-2");
+    });
+  });
+
+  describe("auto-convert detection", () => {
+    it("should detect auto-convert when FXCONV trades exist", () => {
+      const trades = [
+        makeTrade({ assetCategory: "CASH", description: "FXCONV", currency: "USD" }),
+        makeTrade({ assetCategory: "STK", symbol: "AAPL", currency: "USD" }),
+      ];
+      expect(FxFifoEngine.detectAutoConvert(trades)).toBe(true);
+    });
+
+    it("should detect auto-convert when CASH RECEIPTS trades exist", () => {
+      const trades = [
+        makeTrade({ assetCategory: "CASH", description: "CASH RECEIPTS / DISBURSEMENTS", currency: "USD" }),
+      ];
+      expect(FxFifoEngine.detectAutoConvert(trades)).toBe(true);
+    });
+
+    it("should NOT detect auto-convert when only manual CASH trades exist", () => {
+      const trades = [
+        makeTrade({ assetCategory: "CASH", description: "EUR.USD", buySell: "BUY", currency: "USD" }),
+      ];
+      expect(FxFifoEngine.detectAutoConvert(trades)).toBe(false);
+    });
+
+    it("should skip stock FX events in auto-convert mode", () => {
+      const trades = [
+        makeTrade({ assetCategory: "CASH", description: "FXCONV", currency: "USD" }),
+        makeTrade({ assetCategory: "STK", symbol: "AAPL", buySell: "BUY", tradeMoney: "5000", currency: "USD" }),
+      ];
+      const events = FxFifoEngine.extractFxEvents(trades, rateMap);
+      // Only the FXCONV is detected (and skipped) — no stock event generated
+      expect(events).toHaveLength(0);
+    });
+
+    it("should generate stock FX events in multi-currency mode (no FXCONV)", () => {
+      const trades = [
+        makeTrade({ assetCategory: "STK", symbol: "AAPL", buySell: "BUY", tradeMoney: "5000", currency: "USD" }),
+      ];
+      const events = FxFifoEngine.extractFxEvents(trades, rateMap);
+      expect(events.length).toBeGreaterThan(0);
+      expect(events[0]!.trigger).toBe("stock_purchase");
+    });
+
+    it("should return empty cash events in auto-convert mode", () => {
+      const txs = [{
+        transactionID: "1", accountId: "U1", symbol: "AAPL", description: "AAPL dividend",
+        isin: "US0378331005", currency: "USD", dateTime: "20250315",
+        settleDate: "20250317", amount: "100", fxRateToBase: "0.92", type: "Dividends" as const,
+      }];
+      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap, true);
+      expect(events).toHaveLength(0);
+    });
+
+    it("should still allow manual conversions in auto-convert accounts", () => {
+      const trades = [
+        makeTrade({ assetCategory: "CASH", description: "FXCONV", currency: "USD" }),
+        makeTrade({ assetCategory: "CASH", description: "EUR.USD", buySell: "BUY", quantity: "1000", currency: "USD" }),
+      ];
+      const events = FxFifoEngine.extractFxEvents(trades, rateMap);
+      // FXCONV skipped, manual conversion preserved
+      expect(events).toHaveLength(1);
+      expect(events[0]!.trigger).toBe("conversion");
+      expect(events[0]!.quantity.toString()).toBe("1000");
     });
   });
 });


### PR DESCRIPTION
## Summary

- Accounts with automatic currency conversion (FXCONV present) don't hold FCY — IBKR converts instantly on each trade
- Securities trades, dividends, interest, and commissions in auto-convert accounts no longer generate spurious FX lots/disposals
- Manual conversions (actual EUR.USD CASH trades) still work correctly in both account types
- Fixes the issue where auto-convert accounts showed thousands of EUR in phantom FX gains

## Test plan

- [x] All 854 tests pass (7 new tests for auto-convert detection)
- [x] TypeScript compiles cleanly
- [ ] Verify with auto-convert IBKR account: FX section should be empty or near-zero
- [ ] Verify with multi-currency IBKR account: FX events still generated correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic detection of currency conversion settings at the account level.
  * Improved handling of foreign exchange (FX) events for auto-convert accounts—dividends, interest, and fees no longer generate implicit FX events when auto-convert is enabled.
  * Manual currency conversions continue to generate FX events as expected.

* **Tests**
  * Enhanced test coverage for auto-convert account detection and FX event behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->