### PR TITLE
feat: Telegram release notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,3 +138,43 @@ jobs:
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  notify:
+    name: Telegram notification
+    needs: release
+    if: needs.release.outputs.new_tag != ''
+    runs-on: [self-hosted, linux, x64]
+    steps:
+      - name: Checkout for changelog
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build message
+        id: msg
+        run: |
+          TAG="${{ needs.release.outputs.new_tag }}"
+          PREV_TAG=$(git tag -l "v*" --sort=-version:refname | grep -v "^${TAG}$" | head -1)
+          COMMITS=$(git log "${PREV_TAG}..${TAG}" --pretty=format:"• %s" 2>/dev/null | grep -v "\[skip ci\]" | head -10)
+
+          MSG=$(cat <<MSGEOF
+          🚀 *DeclaRenta ${TAG}*
+
+          ${COMMITS}
+
+          [Ver release](https://github.com/${{ github.repository }}/releases/tag/${TAG}) · [Usar online](https://declarenta.com)
+          MSGEOF
+          )
+
+          # Escape for GitHub Actions
+          echo "text<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$MSG" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Send to Telegram
+        run: |
+          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d chat_id="${{ secrets.TELEGRAM_CHAT_ID }}" \
+            -d parse_mode="Markdown" \
+            -d disable_web_page_preview="true" \
+            --data-urlencode "text=${{ steps.msg.outputs.text }}"


### PR DESCRIPTION
## Summary

- Adds a `notify` job to the Auto Release workflow
- On each release, sends a Markdown message to @declarenta Telegram group with version, commits, and links
- Uses `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` secrets (already configured)

## Test plan

- [ ] Merge this PR → auto-release triggers → check Telegram group for message