### PR TITLE
fix: prevent release race condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Bump version and release
@@ -73,7 +77,13 @@ jobs:
             npm version "$VERSION" --no-git-tag-version
             git add package.json package-lock.json
             git commit -m "chore: bump version to $VERSION [skip ci]"
-            git push origin HEAD:main
+
+            # Retry push with rebase to handle concurrent merges
+            for i in 1 2 3; do
+              git pull --rebase origin main && git push origin HEAD:main && break
+              echo "Push attempt $i failed, retrying..."
+              sleep 5
+            done
           fi
 
           git tag -a "${{ steps.version.outputs.new_tag }}" -m "Release ${{ steps.version.outputs.new_tag }}"


### PR DESCRIPTION
## Summary

- Add `concurrency` group so release jobs queue instead of running in parallel
- Add `pull --rebase` retry loop (3 attempts) for the version bump push
- Fixes the issue where two PRs merged close together caused the version bump push to be rejected (remote had new commits)

## Root cause

PR #124 and #125 merged within seconds. The Auto Release for #124 tried to push `chore: bump version` but #125 had already landed on main → push rejected → no v0.27.1 release created.

## Test plan

- [x] Workflow YAML is valid
- [ ] Next release should succeed without race conditions