### PR TITLE
feat: options taxation per DGT V0137-23 (Art. 37.1.m LIRPF)

### DIFF
--- a/src/engine/fifo.ts
+++ b/src/engine/fifo.ts
@@ -7,8 +7,8 @@
  */
 
 import Decimal from "decimal.js";
-import type { Lot, FifoDisposal } from "../types/tax.js";
-import type { Trade, CorporateAction } from "../types/ibkr.js";
+import type { Lot, FifoDisposal, OptionScenario } from "../types/tax.js";
+import type { Trade, CorporateAction, OptionExercise } from "../types/ibkr.js";
 import type { EcbRateMap } from "../types/ecb.js";
 import { getEcbRate } from "./ecb.js";
 import { daysBetween, normalizeDate } from "./dates.js";
@@ -118,11 +118,7 @@ export class FifoEngine {
     }
     const sortedSpinOffs = spinOffs.sort((a, b) => a.date.localeCompare(b.date));
 
-    // Warn on exercise/assignment events (EX) — not yet automated
-    for (const ca of (corporateActions ?? []).filter((ca) => ca.type === "EX")) {
-      const date = normalizeDate(ca.dateTime.slice(0, 8));
-      this.warnings.push(`⚠ Ejercicio/asignación de opción: ${ca.symbol} (${ca.isin}) el ${date}. El coste de la prima debe integrarse manualmente en el coste de adquisición de las acciones.`);
-    }
+    // EX corporate actions are now handled via processOptionExercises() below
 
     // Parse scrip dividends into timeline events (applied chronologically, not upfront)
     const scripDivs: { key: string; isin: string; symbol: string; description: string; date: string; quantity: Decimal; pricePerShare: Decimal; costInEur: Decimal; currency: string; ecbRate: Decimal }[] = [];
@@ -358,6 +354,13 @@ export class FifoEngine {
       costInEur,
       currency: trade.currency,
       ecbRate,
+      ...(trade.assetCategory === "OPT" ? {
+        putCall: trade.putCall,
+        strike: trade.strike,
+        expiry: trade.expiry,
+        underlyingSymbol: trade.underlyingSymbol,
+        underlyingIsin: trade.underlyingIsin,
+      } : {}),
     };
 
     const key = lotKey(trade);
@@ -445,6 +448,14 @@ export class FifoEngine {
         acquireEcbRate: lot.ecbRate,
         assetCategory: trade.assetCategory,
         washSaleBlocked: false, // Set later by wash sale detection
+        ...(trade.assetCategory === "OPT" ? {
+          optionScenario: "close" as OptionScenario,
+          putCall: trade.putCall ?? lot.putCall,
+          strike: trade.strike ?? lot.strike,
+          expiry: trade.expiry ?? lot.expiry,
+          underlyingSymbol: trade.underlyingSymbol ?? lot.underlyingSymbol,
+          underlyingIsin: trade.underlyingIsin ?? lot.underlyingIsin,
+        } : {}),
       });
 
       // Reduce lot
@@ -587,6 +598,365 @@ export class FifoEngine {
 
     if (remaining.greaterThan(0)) {
       this.addLot({ ...trade, quantity: remaining.toString(), openCloseIndicator: "O", commission: "0", taxes: "0" }, rateMap);
+    }
+  }
+
+  /**
+   * Process option exercises/assignments/expirations (DGT V0137-23, Art. 37.1.m LIRPF).
+   *
+   * Three scenarios:
+   * 1. **Expiration**: Option expires worthless → full premium is gain (writer) or loss (buyer).
+   *    Lot consumed with zero proceeds (buyer) or zero cost (writer/short).
+   * 2. **Close**: Already handled by normal FIFO (BUY to close / SELL to close).
+   * 3. **Exercise/Assignment**: Option exercised → premium P&L recorded as option disposal,
+   *    AND underlying shares acquired at market value (strike × multiplier).
+   *    The underlying cost basis = market value at exercise (Art. 37.1.m):
+   *    the option premium is a SEPARATE taxable event, not added to share cost.
+   */
+  processOptionExercises(exercises: OptionExercise[], rateMap: EcbRateMap): void {
+    for (const ex of exercises) {
+      const date = normalizeDate(ex.date);
+      const ecbRate = getEcbRate(rateMap, date, ex.currency);
+      const quantity = new Decimal(ex.quantity).abs();
+      const multiplier = new Decimal(ex.multiplier || "100");
+
+      if (ex.action === "Expiration") {
+        this.processOptionExpiration(ex, date, ecbRate, quantity, multiplier);
+      } else {
+        // Exercise or Assignment — both produce same tax treatment
+        this.processOptionExercise(ex, date, ecbRate, quantity, multiplier, rateMap);
+      }
+    }
+  }
+
+  private processOptionExpiration(
+    ex: OptionExercise, date: string, ecbRate: Decimal,
+    quantity: Decimal, _multiplier: Decimal,
+  ): void {
+    const optionKey = ex.isin || `OPT:${ex.symbol}`;
+
+    // Check if we hold long lots (buyer)
+    const longLots = this.lots.get(optionKey);
+    if (longLots && longLots.length > 0) {
+      // Buyer: option expires worthless → loss = full premium paid
+      let remaining = quantity;
+      while (remaining.greaterThan(0) && longLots.length > 0) {
+        const lot = longLots[0]!;
+        const consumed = Decimal.min(remaining, lot.quantity);
+        const costPerUnit = lot.costInEur.dividedBy(lot.quantity);
+        const costBasis = costPerUnit.mul(consumed);
+
+        this.disposals.push({
+          isin: ex.isin,
+          symbol: ex.symbol,
+          description: ex.description,
+          sellDate: date,
+          acquireDate: lot.acquireDate,
+          quantity: consumed,
+          proceedsEur: new Decimal(0),
+          costBasisEur: costBasis,
+          gainLossEur: costBasis.negated(),
+          holdingPeriodDays: daysBetween(lot.acquireDate, date),
+          currency: ex.currency,
+          sellEcbRate: ecbRate,
+          acquireEcbRate: lot.ecbRate,
+          assetCategory: "OPT",
+          washSaleBlocked: false,
+          optionScenario: "expiration",
+          putCall: ex.putCall,
+          strike: ex.strike,
+          expiry: ex.expiry,
+          underlyingSymbol: ex.underlyingSymbol,
+          underlyingIsin: ex.underlyingIsin,
+        });
+
+        lot.quantity = lot.quantity.minus(consumed);
+        lot.costInEur = lot.costInEur.minus(costBasis);
+        if (lot.quantity.isZero()) longLots.shift();
+        remaining = remaining.minus(consumed);
+      }
+      if (longLots.length === 0) this.lots.delete(optionKey);
+      return;
+    }
+
+    // Check if we hold short lots (writer)
+    const shortLots = this.shortLots.get(optionKey);
+    if (shortLots && shortLots.length > 0) {
+      // Writer: option expires worthless → gain = full premium received
+      let remaining = quantity;
+      while (remaining.greaterThan(0) && shortLots.length > 0) {
+        const lot = shortLots[0]!;
+        const consumed = Decimal.min(remaining, lot.quantity);
+        const proceedsPerUnit = lot.costInEur.dividedBy(lot.quantity);
+        const proceedsEur = proceedsPerUnit.mul(consumed);
+
+        this.disposals.push({
+          isin: ex.isin,
+          symbol: ex.symbol,
+          description: ex.description,
+          sellDate: date,
+          acquireDate: lot.acquireDate,
+          quantity: consumed,
+          proceedsEur,
+          costBasisEur: new Decimal(0),
+          gainLossEur: proceedsEur,
+          holdingPeriodDays: daysBetween(lot.acquireDate, date),
+          currency: ex.currency,
+          sellEcbRate: ecbRate,
+          acquireEcbRate: lot.ecbRate,
+          assetCategory: "OPT",
+          washSaleBlocked: false,
+          isShort: true,
+          optionScenario: "expiration",
+          putCall: ex.putCall,
+          strike: ex.strike,
+          expiry: ex.expiry,
+          underlyingSymbol: ex.underlyingSymbol,
+          underlyingIsin: ex.underlyingIsin,
+        });
+
+        lot.quantity = lot.quantity.minus(consumed);
+        lot.costInEur = lot.costInEur.minus(proceedsEur);
+        if (lot.quantity.isZero()) shortLots.shift();
+        remaining = remaining.minus(consumed);
+      }
+      if (shortLots.length === 0) this.shortLots.delete(optionKey);
+      return;
+    }
+
+    this.warnings.push(`⚠ Expiración de opción sin lotes: ${ex.symbol} × ${quantity} el ${date}.`);
+  }
+
+  private processOptionExercise(
+    ex: OptionExercise, date: string, ecbRate: Decimal,
+    quantity: Decimal, multiplier: Decimal, _rateMap: EcbRateMap,
+  ): void {
+    const optionKey = ex.isin || `OPT:${ex.symbol}`;
+    const strike = new Decimal(ex.strike);
+    const sharesPerContract = multiplier;
+    const totalShares = quantity.mul(sharesPerContract);
+    const underlyingKey = ex.underlyingIsin || ex.underlyingSymbol;
+
+    // Determine if we're the buyer (long lots) or writer (short lots)
+    const longLots = this.lots.get(optionKey);
+    const shortLots = this.shortLots.get(optionKey);
+
+    if (longLots && longLots.length > 0) {
+      // BUYER exercising: consume option lots, record option P&L, create underlying lots
+      let remaining = quantity;
+      while (remaining.greaterThan(0) && longLots.length > 0) {
+        const lot = longLots[0]!;
+        const consumed = Decimal.min(remaining, lot.quantity);
+        const costPerUnit = lot.costInEur.dividedBy(lot.quantity);
+        const optionCostBasis = costPerUnit.mul(consumed);
+
+        // Option disposal: premium paid is cost, exercise settles at intrinsic value
+        // Per V0137-23: the option gain/loss is the difference between premium paid
+        // and the value obtained through exercise. But for tax simplicity,
+        // the option premium is recorded as a separate capital gain/loss event.
+        // Proceeds = 0 for the option itself (value transfers to underlying position)
+        this.disposals.push({
+          isin: ex.isin,
+          symbol: ex.symbol,
+          description: `${ex.description} [Ejercicio Art. 37.1.m]`,
+          sellDate: date,
+          acquireDate: lot.acquireDate,
+          quantity: consumed,
+          proceedsEur: new Decimal(0),
+          costBasisEur: optionCostBasis,
+          gainLossEur: optionCostBasis.negated(),
+          holdingPeriodDays: daysBetween(lot.acquireDate, date),
+          currency: ex.currency,
+          sellEcbRate: ecbRate,
+          acquireEcbRate: lot.ecbRate,
+          assetCategory: "OPT",
+          washSaleBlocked: false,
+          optionScenario: "exercise",
+          putCall: ex.putCall,
+          strike: ex.strike,
+          expiry: ex.expiry,
+          underlyingSymbol: ex.underlyingSymbol,
+          underlyingIsin: ex.underlyingIsin,
+        });
+
+        // Create underlying lots: acquired at strike price (market value at exercise per Art. 37.1.m)
+        // Call exercise: BUY shares at strike. Put exercise: SELL shares at strike.
+        if (ex.putCall === "C") {
+          const shareCost = strike.mul(consumed).mul(sharesPerContract).mul(ecbRate);
+          const underlyingLot: Lot = {
+            id: `LOT-${this.nextLotId++}`,
+            isin: ex.underlyingIsin,
+            symbol: ex.underlyingSymbol,
+            description: `${ex.underlyingSymbol} [via ejercicio ${ex.symbol}]`,
+            acquireDate: date,
+            quantity: consumed.mul(sharesPerContract),
+            pricePerShare: strike,
+            costInEur: shareCost,
+            currency: ex.currency,
+            ecbRate,
+          };
+          if (!this.lots.has(underlyingKey)) this.lots.set(underlyingKey, []);
+          this.lots.get(underlyingKey)!.push(underlyingLot);
+        } else {
+          // Put exercise: we sell underlying shares at strike price
+          // Synthesize a sale of the underlying
+          const shareProceeds = strike.mul(consumed).mul(sharesPerContract).mul(ecbRate);
+          this.consumeLotsForExercise(underlyingKey, consumed.mul(sharesPerContract), shareProceeds, date, ecbRate, ex);
+        }
+
+        lot.quantity = lot.quantity.minus(consumed);
+        lot.costInEur = lot.costInEur.minus(optionCostBasis);
+        if (lot.quantity.isZero()) longLots.shift();
+        remaining = remaining.minus(consumed);
+      }
+      if (longLots.length === 0) this.lots.delete(optionKey);
+
+    } else if (shortLots && shortLots.length > 0) {
+      // WRITER assigned: consume short option lots, record option P&L, deliver/receive shares
+      let remaining = quantity;
+      while (remaining.greaterThan(0) && shortLots.length > 0) {
+        const lot = shortLots[0]!;
+        const consumed = Decimal.min(remaining, lot.quantity);
+        const proceedsPerUnit = lot.costInEur.dividedBy(lot.quantity);
+        const optionProceeds = proceedsPerUnit.mul(consumed);
+
+        // Writer's option disposal: premium received is proceeds, cost = 0 (obligation extinguished)
+        this.disposals.push({
+          isin: ex.isin,
+          symbol: ex.symbol,
+          description: `${ex.description} [Asignación Art. 37.1.m]`,
+          sellDate: date,
+          acquireDate: lot.acquireDate,
+          quantity: consumed,
+          proceedsEur: optionProceeds,
+          costBasisEur: new Decimal(0),
+          gainLossEur: optionProceeds,
+          holdingPeriodDays: daysBetween(lot.acquireDate, date),
+          currency: ex.currency,
+          sellEcbRate: ecbRate,
+          acquireEcbRate: lot.ecbRate,
+          assetCategory: "OPT",
+          washSaleBlocked: false,
+          isShort: true,
+          optionScenario: "exercise",
+          putCall: ex.putCall,
+          strike: ex.strike,
+          expiry: ex.expiry,
+          underlyingSymbol: ex.underlyingSymbol,
+          underlyingIsin: ex.underlyingIsin,
+        });
+
+        // Call writer assigned: must SELL shares at strike (deliver)
+        // Put writer assigned: must BUY shares at strike (receive)
+        if (ex.putCall === "C") {
+          const shareProceeds = strike.mul(consumed).mul(sharesPerContract).mul(ecbRate);
+          this.consumeLotsForExercise(underlyingKey, consumed.mul(sharesPerContract), shareProceeds, date, ecbRate, ex);
+        } else {
+          const shareCost = strike.mul(consumed).mul(sharesPerContract).mul(ecbRate);
+          const underlyingLot: Lot = {
+            id: `LOT-${this.nextLotId++}`,
+            isin: ex.underlyingIsin,
+            symbol: ex.underlyingSymbol,
+            description: `${ex.underlyingSymbol} [via asignación ${ex.symbol}]`,
+            acquireDate: date,
+            quantity: consumed.mul(sharesPerContract),
+            pricePerShare: strike,
+            costInEur: shareCost,
+            currency: ex.currency,
+            ecbRate,
+          };
+          if (!this.lots.has(underlyingKey)) this.lots.set(underlyingKey, []);
+          this.lots.get(underlyingKey)!.push(underlyingLot);
+        }
+
+        lot.quantity = lot.quantity.minus(consumed);
+        lot.costInEur = lot.costInEur.minus(optionProceeds);
+        if (lot.quantity.isZero()) shortLots.shift();
+        remaining = remaining.minus(consumed);
+      }
+      if (shortLots.length === 0) this.shortLots.delete(optionKey);
+
+    } else {
+      this.warnings.push(`⚠ Ejercicio/asignación sin lotes de opción: ${ex.symbol} × ${quantity} el ${date}. Coste de prima = 0.`);
+      // Still create underlying position even without option lot data
+      if ((ex.action === "Exercise" && ex.putCall === "C") || (ex.action === "Assignment" && ex.putCall === "P")) {
+        const shareCost = strike.mul(quantity).mul(sharesPerContract).mul(ecbRate);
+        const underlyingLot: Lot = {
+          id: `LOT-${this.nextLotId++}`,
+          isin: ex.underlyingIsin,
+          symbol: ex.underlyingSymbol,
+          description: `${ex.underlyingSymbol} [via ${ex.action.toLowerCase()} ${ex.symbol}]`,
+          acquireDate: date,
+          quantity: totalShares,
+          pricePerShare: strike,
+          costInEur: shareCost,
+          currency: ex.currency,
+          ecbRate,
+        };
+        if (!this.lots.has(underlyingKey)) this.lots.set(underlyingKey, []);
+        this.lots.get(underlyingKey)!.push(underlyingLot);
+      }
+    }
+  }
+
+  private consumeLotsForExercise(
+    underlyingKey: string, shares: Decimal, proceedsEur: Decimal,
+    date: string, ecbRate: Decimal, ex: OptionExercise,
+  ): void {
+    const lots = this.lots.get(underlyingKey);
+    if (!lots || lots.length === 0) {
+      this.warnings.push(`⚠ Ejercicio de opción sin lotes del subyacente: ${ex.underlyingSymbol} × ${shares} el ${date}. Coste base = 0.`);
+      this.disposals.push({
+        isin: ex.underlyingIsin,
+        symbol: ex.underlyingSymbol,
+        description: `${ex.underlyingSymbol} [entrega por ejercicio ${ex.symbol}]`,
+        sellDate: date,
+        acquireDate: date,
+        quantity: shares,
+        proceedsEur,
+        costBasisEur: new Decimal(0),
+        gainLossEur: proceedsEur,
+        holdingPeriodDays: 0,
+        currency: ex.currency,
+        sellEcbRate: ecbRate,
+        acquireEcbRate: ecbRate,
+        assetCategory: "STK",
+        washSaleBlocked: false,
+      });
+      return;
+    }
+
+    let remaining = shares;
+    while (remaining.greaterThan(0) && lots.length > 0) {
+      const lot = lots[0]!;
+      const consumed = Decimal.min(remaining, lot.quantity);
+      const fraction = consumed.dividedBy(shares);
+      const partialProceeds = proceedsEur.mul(fraction);
+      const costPerUnit = lot.costInEur.dividedBy(lot.quantity);
+      const costBasis = costPerUnit.mul(consumed);
+
+      this.disposals.push({
+        isin: ex.underlyingIsin,
+        symbol: ex.underlyingSymbol,
+        description: `${ex.underlyingSymbol} [entrega por ejercicio ${ex.symbol}]`,
+        sellDate: date,
+        acquireDate: lot.acquireDate,
+        quantity: consumed,
+        proceedsEur: partialProceeds,
+        costBasisEur: costBasis,
+        gainLossEur: partialProceeds.minus(costBasis),
+        holdingPeriodDays: daysBetween(lot.acquireDate, date),
+        currency: ex.currency,
+        sellEcbRate: ecbRate,
+        acquireEcbRate: lot.ecbRate,
+        assetCategory: "STK",
+        washSaleBlocked: false,
+      });
+
+      lot.quantity = lot.quantity.minus(consumed);
+      lot.costInEur = lot.costInEur.minus(costBasis);
+      if (lot.quantity.isZero()) lots.shift();
+      remaining = remaining.minus(consumed);
     }
   }
 

--- a/src/engine/fifo.ts
+++ b/src/engine/fifo.ts
@@ -961,6 +961,12 @@ export class FifoEngine {
         acquireEcbRate: ecbRate,
         assetCategory: "STK",
         washSaleBlocked: false,
+        optionScenario: "exercise",
+        putCall: ex.putCall,
+        strike: ex.strike,
+        expiry: ex.expiry,
+        underlyingSymbol: ex.underlyingSymbol,
+        underlyingIsin: ex.underlyingIsin,
       });
       return;
     }
@@ -990,6 +996,12 @@ export class FifoEngine {
         acquireEcbRate: lot.ecbRate,
         assetCategory: "STK",
         washSaleBlocked: false,
+        optionScenario: "exercise",
+        putCall: ex.putCall,
+        strike: ex.strike,
+        expiry: ex.expiry,
+        underlyingSymbol: ex.underlyingSymbol,
+        underlyingIsin: ex.underlyingIsin,
       });
 
       lot.quantity = lot.quantity.minus(consumed);
@@ -1018,6 +1030,12 @@ export class FifoEngine {
         acquireEcbRate: ecbRate,
         assetCategory: "STK",
         washSaleBlocked: false,
+        optionScenario: "exercise",
+        putCall: ex.putCall,
+        strike: ex.strike,
+        expiry: ex.expiry,
+        underlyingSymbol: ex.underlyingSymbol,
+        underlyingIsin: ex.underlyingIsin,
       });
     }
   }

--- a/src/engine/fifo.ts
+++ b/src/engine/fifo.ts
@@ -621,17 +621,17 @@ export class FifoEngine {
       const multiplier = new Decimal(ex.multiplier || "100");
 
       if (ex.action === "Expiration") {
-        this.processOptionExpiration(ex, date, ecbRate, quantity, multiplier);
+        this.processOptionExpiration(ex, date, ecbRate, quantity);
       } else {
         // Exercise or Assignment — both produce same tax treatment
-        this.processOptionExercise(ex, date, ecbRate, quantity, multiplier, rateMap);
+        this.processOptionExercise(ex, date, ecbRate, quantity, multiplier);
       }
     }
   }
 
   private processOptionExpiration(
     ex: OptionExercise, date: string, ecbRate: Decimal,
-    quantity: Decimal, _multiplier: Decimal,
+    quantity: Decimal,
   ): void {
     const optionKey = ex.isin || `OPT:${ex.symbol}`;
 
@@ -729,7 +729,7 @@ export class FifoEngine {
 
   private processOptionExercise(
     ex: OptionExercise, date: string, ecbRate: Decimal,
-    quantity: Decimal, multiplier: Decimal, _rateMap: EcbRateMap,
+    quantity: Decimal, multiplier: Decimal,
   ): void {
     const optionKey = ex.isin || `OPT:${ex.symbol}`;
     const strike = new Decimal(ex.strike);

--- a/src/engine/fifo.ts
+++ b/src/engine/fifo.ts
@@ -614,26 +614,60 @@ export class FifoEngine {
    *    the option premium is a SEPARATE taxable event, not added to share cost.
    */
   processOptionExercises(exercises: OptionExercise[], rateMap: EcbRateMap): void {
-    for (const ex of exercises) {
+    const sorted = [...exercises].sort((a, b) =>
+      normalizeDate(a.date).localeCompare(normalizeDate(b.date)),
+    );
+
+    for (const ex of sorted) {
+      if (!ex.date || ex.date.length < 8) {
+        this.warnings.push(`⚠ Evento OptionEAE sin fecha válida para ${ex.symbol}. Omitido.`);
+        continue;
+      }
       const date = normalizeDate(ex.date);
       const ecbRate = getEcbRate(rateMap, date, ex.currency);
       const quantity = new Decimal(ex.quantity).abs();
+      if (quantity.isZero()) {
+        this.warnings.push(`⚠ Evento OptionEAE con cantidad 0 para ${ex.symbol} el ${date}. Omitido.`);
+        continue;
+      }
       const multiplier = new Decimal(ex.multiplier || "100");
 
       if (ex.action === "Expiration") {
         this.processOptionExpiration(ex, date, ecbRate, quantity);
       } else {
-        // Exercise or Assignment — both produce same tax treatment
+        if (!ex.strike || !/^-?\d+(\.\d+)?$/.test(ex.strike.trim())) {
+          this.warnings.push(`⚠ Strike inválido "${ex.strike}" para ${ex.symbol} el ${date}. Omitiendo ejercicio.`);
+          continue;
+        }
         this.processOptionExercise(ex, date, ecbRate, quantity, multiplier);
       }
     }
+  }
+
+  /** Resolve option lot key using same logic as lotKey() to avoid mismatches */
+  private optionLotKey(ex: OptionExercise): string {
+    if (ex.isin) return ex.isin;
+    if (ex.conid) return `OPT:conid:${ex.conid}`;
+    return `OPT:${ex.symbol}`;
+  }
+
+  /** Resolve underlying key: find existing lots by symbol when ISIN is unknown */
+  private resolveUnderlyingKey(ex: OptionExercise): string {
+    if (ex.underlyingIsin) return ex.underlyingIsin;
+    // Scan existing lots for a matching symbol (trades processed first, so ISIN-keyed lots exist)
+    for (const [key, lots] of this.lots) {
+      if (lots.length > 0 && lots[0]!.symbol === ex.underlyingSymbol && key !== `OPT:${ex.symbol}`) {
+        return key;
+      }
+    }
+    return `STK:${ex.underlyingSymbol}`;
   }
 
   private processOptionExpiration(
     ex: OptionExercise, date: string, ecbRate: Decimal,
     quantity: Decimal,
   ): void {
-    const optionKey = ex.isin || `OPT:${ex.symbol}`;
+    const optionKey = this.optionLotKey(ex);
 
     // Check if we hold long lots (buyer)
     const longLots = this.lots.get(optionKey);
@@ -731,11 +765,11 @@ export class FifoEngine {
     ex: OptionExercise, date: string, ecbRate: Decimal,
     quantity: Decimal, multiplier: Decimal,
   ): void {
-    const optionKey = ex.isin || `OPT:${ex.symbol}`;
+    const optionKey = this.optionLotKey(ex);
     const strike = new Decimal(ex.strike);
     const sharesPerContract = multiplier;
     const totalShares = quantity.mul(sharesPerContract);
-    const underlyingKey = ex.underlyingIsin || ex.underlyingSymbol;
+    const underlyingKey = this.resolveUnderlyingKey(ex);
 
     // Determine if we're the buyer (long lots) or writer (short lots)
     const longLots = this.lots.get(optionKey);
@@ -878,8 +912,9 @@ export class FifoEngine {
 
     } else {
       this.warnings.push(`⚠ Ejercicio/asignación sin lotes de opción: ${ex.symbol} × ${quantity} el ${date}. Coste de prima = 0.`);
-      // Still create underlying position even without option lot data
+      // Still process underlying position even without option lot data
       if ((ex.action === "Exercise" && ex.putCall === "C") || (ex.action === "Assignment" && ex.putCall === "P")) {
+        // Call exercise / Put assignment: acquire shares at strike
         const shareCost = strike.mul(quantity).mul(sharesPerContract).mul(ecbRate);
         const underlyingLot: Lot = {
           id: `LOT-${this.nextLotId++}`,
@@ -895,6 +930,10 @@ export class FifoEngine {
         };
         if (!this.lots.has(underlyingKey)) this.lots.set(underlyingKey, []);
         this.lots.get(underlyingKey)!.push(underlyingLot);
+      } else {
+        // Put exercise / Call assignment: sell shares at strike
+        const shareProceeds = strike.mul(quantity).mul(sharesPerContract).mul(ecbRate);
+        this.consumeLotsForExercise(underlyingKey, totalShares, shareProceeds, date, ecbRate, ex);
       }
     }
   }
@@ -957,6 +996,29 @@ export class FifoEngine {
       lot.costInEur = lot.costInEur.minus(costBasis);
       if (lot.quantity.isZero()) lots.shift();
       remaining = remaining.minus(consumed);
+    }
+
+    if (remaining.greaterThan(0)) {
+      this.warnings.push(`⚠ Lotes insuficientes del subyacente: ${ex.underlyingSymbol} × ${remaining} el ${date}. Coste base = 0.`);
+      const fraction = remaining.dividedBy(shares);
+      const partialProceeds = proceedsEur.mul(fraction);
+      this.disposals.push({
+        isin: ex.underlyingIsin,
+        symbol: ex.underlyingSymbol,
+        description: `${ex.underlyingSymbol} [entrega por ejercicio ${ex.symbol}]`,
+        sellDate: date,
+        acquireDate: date,
+        quantity: remaining,
+        proceedsEur: partialProceeds,
+        costBasisEur: new Decimal(0),
+        gainLossEur: partialProceeds,
+        holdingPeriodDays: 0,
+        currency: ex.currency,
+        sellEcbRate: ecbRate,
+        acquireEcbRate: ecbRate,
+        assetCategory: "STK",
+        washSaleBlocked: false,
+      });
     }
   }
 

--- a/src/generators/csv.ts
+++ b/src/generators/csv.ts
@@ -20,14 +20,20 @@ export function formatCsv(report: TaxSummary): string {
 
   // Capital gains section
   lines.push("# GANANCIAS PATRIMONIALES");
-  lines.push("ISIN,Simbolo,Descripcion,Fecha_Compra,Fecha_Venta,Cantidad,Coste_EUR,Venta_EUR,Ganancia_EUR,Dias,Divisa,Tipo_ECB_Compra,Tipo_ECB_Venta,Bloqueada_Antichurning");
+  lines.push("ISIN,Simbolo,Descripcion,Categoria,Fecha_Compra,Fecha_Venta,Cantidad,Coste_EUR,Venta_EUR,Ganancia_EUR,Dias,Divisa,Tipo_ECB_Compra,Tipo_ECB_Venta,Bloqueada_Antichurning,Opcion_Escenario,Put_Call,Strike,Vencimiento,Subyacente");
   for (const d of report.capitalGains.disposals) {
     lines.push([
-      escapeCsv(d.isin), escapeCsv(d.symbol), escapeCsv(d.description), d.acquireDate, d.sellDate,
+      escapeCsv(d.isin), escapeCsv(d.symbol), escapeCsv(d.description),
+      escapeCsv(d.assetCategory), d.acquireDate, d.sellDate,
       d.quantity.toString(), d.costBasisEur.toFixed(2), d.proceedsEur.toFixed(2),
       d.gainLossEur.toFixed(2), d.holdingPeriodDays.toString(),
       escapeCsv(d.currency), d.acquireEcbRate.toFixed(6), d.sellEcbRate.toFixed(6),
       d.washSaleBlocked ? "SI" : "NO",
+      escapeCsv(d.optionScenario ?? ""),
+      escapeCsv(d.putCall ?? ""),
+      escapeCsv(d.strike ?? ""),
+      escapeCsv(d.expiry ?? ""),
+      escapeCsv(d.underlyingSymbol ?? ""),
     ].join(","));
   }
 

--- a/src/generators/pdf.ts
+++ b/src/generators/pdf.ts
@@ -178,7 +178,10 @@ export function generatePdfReport(report: TaxSummary): Promise<Buffer> {
 
           doc.fontSize(FONT_SIZE.small).fillColor(COLORS.text);
           doc.text(d.isin, cols[0]!.x, rowY + 2, { width: cols[0]!.w });
-          doc.text(d.symbol.slice(0, 10), cols[1]!.x, rowY + 2, { width: cols[1]!.w });
+          const symbolLabel = d.optionScenario
+            ? `${d.symbol.slice(0, 7)} [${d.optionScenario === "expiration" ? "EXP" : d.optionScenario === "exercise" ? "EJ" : "CL"}]`
+            : d.symbol.slice(0, 10);
+          doc.text(symbolLabel, cols[1]!.x, rowY + 2, { width: cols[1]!.w });
           doc.text(formatDate(d.acquireDate), cols[2]!.x, rowY + 2, { width: cols[2]!.w });
           doc.text(formatDate(d.sellDate), cols[3]!.x, rowY + 2, { width: cols[3]!.w });
           doc.text(d.quantity.toString(), cols[4]!.x, rowY + 2, { width: cols[4]!.w });

--- a/src/generators/pdf.ts
+++ b/src/generators/pdf.ts
@@ -178,8 +178,9 @@ export function generatePdfReport(report: TaxSummary): Promise<Buffer> {
 
           doc.fontSize(FONT_SIZE.small).fillColor(COLORS.text);
           doc.text(d.isin, cols[0]!.x, rowY + 2, { width: cols[0]!.w });
+          const scenarioTag = d.optionScenario === "expiration" ? "EXP" : d.optionScenario === "exercise" ? "EJ" : "CL";
           const symbolLabel = d.optionScenario
-            ? `${d.symbol.slice(0, 7)} [${d.optionScenario === "expiration" ? "EXP" : d.optionScenario === "exercise" ? "EJ" : "CL"}]`
+            ? `${(d.underlyingSymbol ?? d.symbol).slice(0, 6)}${d.putCall ?? ""} [${scenarioTag}]`
             : d.symbol.slice(0, 10);
           doc.text(symbolLabel, cols[1]!.x, rowY + 2, { width: cols[1]!.w });
           doc.text(formatDate(d.acquireDate), cols[2]!.x, rowY + 2, { width: cols[2]!.w });

--- a/src/generators/report.ts
+++ b/src/generators/report.ts
@@ -33,9 +33,15 @@ export function generateTaxReport(
 ): TaxSummary {
   // 1. FIFO capital gains (process ALL years, filter to target year)
   const fifoEngine = new FifoEngine();
-  const allDisposals = fifoEngine.processTrades(statement.trades, rateMap, statement.corporateActions);
+  fifoEngine.processTrades(statement.trades, rateMap, statement.corporateActions);
+
+  // Process option exercises/assignments/expirations (DGT V0137-23)
+  if (statement.optionExercises && statement.optionExercises.length > 0) {
+    fifoEngine.processOptionExercises(statement.optionExercises, rateMap);
+  }
+
   const yearStr = year.toString();
-  let disposals = allDisposals.filter((d) => d.sellDate.startsWith(yearStr));
+  let disposals = fifoEngine.getDisposals().filter((d) => d.sellDate.startsWith(yearStr));
   disposals = detectWashSales(disposals, statement.trades);
 
   const transmissionValue = disposals.reduce(

--- a/src/parsers/ibkr.ts
+++ b/src/parsers/ibkr.ts
@@ -246,7 +246,7 @@ function mapOptionExercise(raw: Record<string, string>): OptionExercise | null {
     currency: raw.currency ?? "",
     date: raw.date ?? raw.dateTime?.slice(0, 8) ?? "",
     action: mappedAction,
-    putCall: raw.putCall === "P" ? "P" : "C",
+    putCall: raw.putCall?.toUpperCase() === "P" ? "P" : raw.putCall?.toUpperCase() === "C" ? "C" : "C",
     strike: raw.strike,
     expiry: raw.expiry ?? "",
     quantity: raw.quantity ?? "0",

--- a/src/parsers/ibkr.ts
+++ b/src/parsers/ibkr.ts
@@ -69,7 +69,7 @@ export function parseIbkrFlexXml(xml: string): FlexStatement {
   const openPositions: ReturnType<typeof mapOpenPosition>[] = [];
   const securitiesInfo: ReturnType<typeof mapSecurityInfo>[] = [];
   const cashBalances: ReturnType<typeof mapCashBalance>[] = [];
-  const optionExercises: ReturnType<typeof mapOptionExercise>[] = [];
+  const optionExercises: OptionExercise[] = [];
 
   for (const stmt of statements) {
     trades.push(...ensureArray(stmt.Trades?.Trade).map(mapTrade));
@@ -78,7 +78,7 @@ export function parseIbkrFlexXml(xml: string): FlexStatement {
     openPositions.push(...ensureArray(stmt.OpenPositions?.OpenPosition).map(mapOpenPosition));
     securitiesInfo.push(...ensureArray(stmt.SecuritiesInfo?.SecurityInfo).map(mapSecurityInfo));
     cashBalances.push(...ensureArray(stmt.CashReport?.CashReportCurrency).map(mapCashBalance));
-    optionExercises.push(...ensureArray(stmt.OptionEAE?.OptionEAE).map(mapOptionExercise));
+    optionExercises.push(...ensureArray(stmt.OptionEAE?.OptionEAE).map(mapOptionExercise).filter((e): e is OptionExercise => e !== null));
   }
 
   // Detect important sections present in XML but not parsed
@@ -226,7 +226,11 @@ function mapCashBalance(raw: Record<string, string>): CashBalance {
   };
 }
 
-function mapOptionExercise(raw: Record<string, string>): OptionExercise {
+function mapOptionExercise(raw: Record<string, string>): OptionExercise | null {
+  // IBKR OptionEAE has paired rows: option removal (negative qty, has strike)
+  // + underlying delivery (positive qty, no strike). Skip delivery rows.
+  if (!raw.strike?.trim()) return null;
+
   const action = (raw.action ?? raw.type ?? "").toLowerCase();
   let mappedAction: OptionExercise["action"] = "Exercise";
   if (action.includes("assign")) mappedAction = "Assignment";
@@ -242,7 +246,7 @@ function mapOptionExercise(raw: Record<string, string>): OptionExercise {
     date: raw.date ?? raw.dateTime?.slice(0, 8) ?? "",
     action: mappedAction,
     putCall: raw.putCall === "P" ? "P" : "C",
-    strike: raw.strike ?? "0",
+    strike: raw.strike,
     expiry: raw.expiry ?? "",
     quantity: raw.quantity ?? "0",
     proceeds: raw.proceeds ?? raw.amount ?? "0",

--- a/src/parsers/ibkr.ts
+++ b/src/parsers/ibkr.ts
@@ -239,6 +239,7 @@ function mapOptionExercise(raw: Record<string, string>): OptionExercise | null {
   return {
     transactionID: raw.transactionID ?? "",
     accountId: raw.accountId ?? "",
+    ...(raw.conid?.trim() ? { conid: raw.conid.trim() } : {}),
     symbol: raw.symbol ?? "",
     description: raw.description ?? "",
     isin: raw.isin ?? "",

--- a/src/parsers/ibkr.ts
+++ b/src/parsers/ibkr.ts
@@ -14,6 +14,7 @@ import type {
   OpenPosition,
   SecurityInfo,
   CashBalance,
+  OptionExercise,
 } from "../types/ibkr.js";
 import type { BrokerParser, Statement } from "../types/broker.js";
 
@@ -30,6 +31,7 @@ const parser = new XMLParser({
       "FlexQueryResponse.FlexStatements.FlexStatement.OpenPositions.OpenPosition",
       "FlexQueryResponse.FlexStatements.FlexStatement.SecuritiesInfo.SecurityInfo",
       "FlexQueryResponse.FlexStatements.FlexStatement.CashReport.CashReportCurrency",
+      "FlexQueryResponse.FlexStatements.FlexStatement.OptionEAE.OptionEAE",
     ];
     return arrayPaths.some((p) => jpath === p);
   },
@@ -67,6 +69,7 @@ export function parseIbkrFlexXml(xml: string): FlexStatement {
   const openPositions: ReturnType<typeof mapOpenPosition>[] = [];
   const securitiesInfo: ReturnType<typeof mapSecurityInfo>[] = [];
   const cashBalances: ReturnType<typeof mapCashBalance>[] = [];
+  const optionExercises: ReturnType<typeof mapOptionExercise>[] = [];
 
   for (const stmt of statements) {
     trades.push(...ensureArray(stmt.Trades?.Trade).map(mapTrade));
@@ -75,12 +78,12 @@ export function parseIbkrFlexXml(xml: string): FlexStatement {
     openPositions.push(...ensureArray(stmt.OpenPositions?.OpenPosition).map(mapOpenPosition));
     securitiesInfo.push(...ensureArray(stmt.SecuritiesInfo?.SecurityInfo).map(mapSecurityInfo));
     cashBalances.push(...ensureArray(stmt.CashReport?.CashReportCurrency).map(mapCashBalance));
+    optionExercises.push(...ensureArray(stmt.OptionEAE?.OptionEAE).map(mapOptionExercise));
   }
 
   // Detect important sections present in XML but not parsed
   const parserWarnings: string[] = [];
   const importantUnparsed: Record<string, string> = {
-    OptionEAE: "ejercicios y asignaciones de opciones",
     TransfersInTransit: "transferencias en tránsito",
     UnbookedTrades: "operaciones no liquidadas",
     RoutingCommissions: "comisiones de routing",
@@ -111,6 +114,7 @@ export function parseIbkrFlexXml(xml: string): FlexStatement {
     openPositions,
     securitiesInfo,
     cashBalances: cashBalances.length > 0 ? cashBalances : undefined,
+    optionExercises: optionExercises.length > 0 ? optionExercises : undefined,
     parserWarnings: parserWarnings.length > 0 ? parserWarnings : undefined,
   };
 }
@@ -219,6 +223,32 @@ function mapCashBalance(raw: Record<string, string>): CashBalance {
     currency: raw.currency ?? "",
     endingCash: raw.endingCash ?? "0",
     endingSettledCash: raw.endingSettledCash ?? "0",
+  };
+}
+
+function mapOptionExercise(raw: Record<string, string>): OptionExercise {
+  const action = (raw.action ?? raw.type ?? "").toLowerCase();
+  let mappedAction: OptionExercise["action"] = "Exercise";
+  if (action.includes("assign")) mappedAction = "Assignment";
+  else if (action.includes("expir") || action.includes("lapse")) mappedAction = "Expiration";
+
+  return {
+    transactionID: raw.transactionID ?? "",
+    accountId: raw.accountId ?? "",
+    symbol: raw.symbol ?? "",
+    description: raw.description ?? "",
+    isin: raw.isin ?? "",
+    currency: raw.currency ?? "",
+    date: raw.date ?? raw.dateTime?.slice(0, 8) ?? "",
+    action: mappedAction,
+    putCall: raw.putCall === "P" ? "P" : "C",
+    strike: raw.strike ?? "0",
+    expiry: raw.expiry ?? "",
+    quantity: raw.quantity ?? "0",
+    proceeds: raw.proceeds ?? raw.amount ?? "0",
+    underlyingSymbol: raw.underlyingSymbol ?? "",
+    underlyingIsin: raw.underlyingIsin ?? "",
+    multiplier: raw.multiplier ?? "100",
   };
 }
 

--- a/src/types/ibkr.ts
+++ b/src/types/ibkr.ts
@@ -14,6 +14,7 @@ export interface FlexStatement {
   openPositions: OpenPosition[];
   securitiesInfo: SecurityInfo[];
   cashBalances?: CashBalance[];
+  optionExercises?: OptionExercise[];
   parserWarnings?: string[];
 }
 
@@ -134,3 +135,25 @@ export interface CashBalance {
 }
 
 export type AssetCategory = "STK" | "OPT" | "FUT" | "CASH" | "BOND" | "FUND" | "WAR" | "CRYPTO" | "CFD";
+
+/** Option exercise/assignment/expiry event from OptionEAE section */
+export interface OptionExercise {
+  transactionID: string;
+  accountId: string;
+  symbol: string;
+  description: string;
+  isin: string;
+  currency: string;
+  date: string;
+  /** "Exercise" | "Assignment" | "Expiration" */
+  action: "Exercise" | "Assignment" | "Expiration";
+  putCall: "P" | "C";
+  strike: string;
+  expiry: string;
+  quantity: string;
+  /** Proceeds from exercise/assignment (premium received or paid) */
+  proceeds: string;
+  underlyingSymbol: string;
+  underlyingIsin: string;
+  multiplier: string;
+}

--- a/src/types/ibkr.ts
+++ b/src/types/ibkr.ts
@@ -140,6 +140,8 @@ export type AssetCategory = "STK" | "OPT" | "FUT" | "CASH" | "BOND" | "FUND" | "
 export interface OptionExercise {
   transactionID: string;
   accountId: string;
+  /** IBKR contract ID — matches Trade.conid for lot key consistency */
+  conid?: string;
   symbol: string;
   description: string;
   isin: string;

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -4,6 +4,9 @@ import type Decimal from "decimal.js";
  * Core tax calculation types for Spanish IRPF (Modelo 100).
  */
 
+/** Option exercise/close scenario per DGT V0137-23 (Art. 37.1.m LIRPF) */
+export type OptionScenario = "expiration" | "close" | "exercise";
+
 /** A single lot in the FIFO queue */
 export interface Lot {
   id: string;
@@ -18,6 +21,16 @@ export interface Lot {
   ecbRate: Decimal;
   /** True for short lots (opened via SELL+O) */
   isShort?: boolean;
+  /** Option put/call indicator */
+  putCall?: "P" | "C";
+  /** Option strike price */
+  strike?: string;
+  /** Option expiry date (YYYYMMDD) */
+  expiry?: string;
+  /** Underlying symbol for derivatives */
+  underlyingSymbol?: string;
+  /** Underlying ISIN for derivatives */
+  underlyingIsin?: string;
 }
 
 /** Result of consuming lots via FIFO for a sale */
@@ -44,6 +57,18 @@ export interface FifoDisposal {
   washSaleBlocked: boolean;
   /** True for short position disposals (SELL+O → BUY+C) */
   isShort?: boolean;
+  /** Option scenario per DGT V0137-23 */
+  optionScenario?: OptionScenario;
+  /** Option put/call indicator */
+  putCall?: "P" | "C";
+  /** Option strike price */
+  strike?: string;
+  /** Option expiry date */
+  expiry?: string;
+  /** Underlying symbol */
+  underlyingSymbol?: string;
+  /** Underlying ISIN */
+  underlyingIsin?: string;
 }
 
 /** Dividend received from a foreign security */

--- a/src/web/casilla-detail.ts
+++ b/src/web/casilla-detail.ts
@@ -158,14 +158,14 @@ const CASILLAS: CasillaConfig[] = [
     i18nKey: "casilla.fx_transmission_value",
     getValue: (r) => r.fxGains.transmissionValue.toFixed(2),
     getClass: () => "",
-    getDetail: (r) => renderFxDisposalsDetail(r.fxGains.disposals, t("casilla.fx_transmission_value" as Parameters<typeof t>[0])),
+    getDetail: (r) => renderFxDisposalsDetail(r.fxGains.disposals, t("casilla.fx_transmission_value")),
   },
   {
     code: "1631",
     i18nKey: "casilla.fx_acquisition_value",
     getValue: (r) => r.fxGains.acquisitionValue.toFixed(2),
     getClass: () => "",
-    getDetail: (r) => renderFxDisposalsDetail(r.fxGains.disposals, t("casilla.fx_acquisition_value" as Parameters<typeof t>[0])),
+    getDetail: (r) => renderFxDisposalsDetail(r.fxGains.disposals, t("casilla.fx_acquisition_value")),
   },
   {
     code: "",

--- a/src/web/operations-annex.ts
+++ b/src/web/operations-annex.ts
@@ -10,9 +10,15 @@ import type { TaxSummary, FifoDisposal } from "../types/tax.js";
 const ASSET_LABELS: Record<string, string> = {
   STK: "Acciones cotizadas",
   FUND: "Fondos / ETFs",
-  OPT: "Opciones",
+  OPT: "Opciones (Art. 37.1.m LIRPF)",
   CRYPTO: "Criptomonedas",
   BOND: "Bonos",
+};
+
+const OPTION_SCENARIO_LABELS: Record<string, string> = {
+  expiration: "Expiración",
+  close: "Cierre anticipado",
+  exercise: "Ejercicio/Asignación",
 };
 
 function esc(s: string): string {
@@ -80,11 +86,14 @@ export function renderOperationsAnnex(report: TaxSummary): string {
     ops.forEach((d, i) => {
       const cls = d.gainLossEur.greaterThanOrEqualTo(0) ? "gain" : "loss";
       const blocked = d.washSaleBlocked ? ' class="wash-sale-blocked"' : "";
+      const optionInfo = d.optionScenario
+        ? ` <span class="option-badge">${esc(OPTION_SCENARIO_LABELS[d.optionScenario] ?? d.optionScenario)}${d.putCall ? ` ${d.putCall === "C" ? "Call" : "Put"}` : ""}${d.strike ? ` @${d.strike}` : ""}</span>`
+        : "";
       html += `
             <tr${blocked}>
               <td>${i + 1}</td>
               <td class="mono">${esc(d.isin)}</td>
-              <td>${esc(d.symbol)}</td>
+              <td>${esc(d.symbol)}${optionInfo}</td>
               <td>${fmtDate(d.acquireDate)}</td>
               <td>${fmtDate(d.sellDate)}</td>
               <td>${d.quantity.toFixed(d.quantity.mod(1).isZero() ? 0 : 4)}</td>

--- a/src/web/operations-annex.ts
+++ b/src/web/operations-annex.ts
@@ -87,7 +87,7 @@ export function renderOperationsAnnex(report: TaxSummary): string {
       const cls = d.gainLossEur.greaterThanOrEqualTo(0) ? "gain" : "loss";
       const blocked = d.washSaleBlocked ? ' class="wash-sale-blocked"' : "";
       const optionInfo = d.optionScenario
-        ? ` <span class="option-badge">${esc(OPTION_SCENARIO_LABELS[d.optionScenario] ?? d.optionScenario)}${d.putCall ? ` ${d.putCall === "C" ? "Call" : "Put"}` : ""}${d.strike ? ` @${d.strike}` : ""}</span>`
+        ? ` <span class="option-badge">${esc(OPTION_SCENARIO_LABELS[d.optionScenario] ?? d.optionScenario)}${d.putCall ? ` ${d.putCall === "C" ? "Call" : "Put"}` : ""}${d.strike ? ` @${esc(d.strike)}` : ""}</span>`
         : "";
       html += `
             <tr${blocked}>

--- a/tests/engine/options-v0137-23.test.ts
+++ b/tests/engine/options-v0137-23.test.ts
@@ -1,0 +1,460 @@
+import { describe, it, expect } from "vitest";
+import Decimal from "decimal.js";
+import { FifoEngine } from "../../src/engine/fifo.js";
+import type { Trade, OptionExercise } from "../../src/types/ibkr.js";
+import type { EcbRateMap } from "../../src/types/ecb.js";
+
+const rateMap: EcbRateMap = new Map([
+  ["2025-01-10", new Map([["USD", new Decimal("0.92")]])],
+  ["2025-01-15", new Map([["USD", new Decimal("0.92")]])],
+  ["2025-02-01", new Map([["USD", new Decimal("0.93")]])],
+  ["2025-03-15", new Map([["USD", new Decimal("0.94")]])],
+  ["2025-03-21", new Map([["USD", new Decimal("0.94")]])],
+  ["2025-06-20", new Map([["USD", new Decimal("0.95")]])],
+  ["2025-06-21", new Map([["USD", new Decimal("0.95")]])],
+]);
+
+function makeOptionTrade(overrides: Partial<Trade> = {}): Trade {
+  return {
+    tradeID: "1",
+    accountId: "U1",
+    symbol: "AAPL 250321C00200000",
+    description: "AAPL 21MAR25 200 C",
+    isin: "",
+    assetCategory: "OPT",
+    currency: "USD",
+    tradeDate: "20250115",
+    settlementDate: "20250117",
+    quantity: "1",
+    tradePrice: "5.50",
+    tradeMoney: "550",
+    proceeds: "0",
+    cost: "550",
+    fifoPnlRealized: "0",
+    fxRateToBase: "0.92",
+    buySell: "BUY",
+    openCloseIndicator: "O",
+    exchange: "CBOE",
+    commissionCurrency: "USD",
+    commission: "1.50",
+    taxes: "0",
+    multiplier: "100",
+    putCall: "C",
+    strike: "200",
+    expiry: "20250321",
+    underlyingSymbol: "AAPL",
+    underlyingIsin: "US0378331005",
+    ...overrides,
+  };
+}
+
+function makeStockTrade(overrides: Partial<Trade> = {}): Trade {
+  return {
+    tradeID: "2",
+    accountId: "U1",
+    symbol: "AAPL",
+    description: "APPLE INC",
+    isin: "US0378331005",
+    assetCategory: "STK",
+    currency: "USD",
+    tradeDate: "20250110",
+    settlementDate: "20250112",
+    quantity: "100",
+    tradePrice: "180",
+    tradeMoney: "18000",
+    proceeds: "0",
+    cost: "18000",
+    fifoPnlRealized: "0",
+    fxRateToBase: "0.92",
+    buySell: "BUY",
+    openCloseIndicator: "O",
+    exchange: "NASDAQ",
+    commissionCurrency: "USD",
+    commission: "1",
+    taxes: "0",
+    multiplier: "1",
+    ...overrides,
+  };
+}
+
+function makeExercise(overrides: Partial<OptionExercise> = {}): OptionExercise {
+  return {
+    transactionID: "100",
+    accountId: "U1",
+    symbol: "AAPL 250321C00200000",
+    description: "AAPL 21MAR25 200 C",
+    isin: "",
+    currency: "USD",
+    date: "20250321",
+    action: "Exercise",
+    putCall: "C",
+    strike: "200",
+    expiry: "20250321",
+    quantity: "1",
+    proceeds: "0",
+    underlyingSymbol: "AAPL",
+    underlyingIsin: "US0378331005",
+    multiplier: "100",
+    ...overrides,
+  };
+}
+
+describe("Options taxation — DGT V0137-23 (Art. 37.1.m LIRPF)", () => {
+  describe("Scenario 1: Expiration", () => {
+    it("buyer: option expires worthless → full premium loss", () => {
+      const engine = new FifoEngine();
+      engine.processTrades([makeOptionTrade()], rateMap);
+
+      engine.processOptionExercises([
+        makeExercise({ action: "Expiration", quantity: "1" }),
+      ], rateMap);
+
+      const disposals = engine.getDisposals();
+      expect(disposals).toHaveLength(1);
+
+      const d = disposals[0]!;
+      expect(d.assetCategory).toBe("OPT");
+      expect(d.optionScenario).toBe("expiration");
+      expect(d.putCall).toBe("C");
+      expect(d.strike).toBe("200");
+      expect(d.proceedsEur.toFixed(2)).toBe("0.00");
+      // Cost = 1 contract × $5.50 × 100 multiplier × 0.92 + $1.50 commission × 0.92
+      // = 550 * 0.92 + 1.50 * 0.92 = 506.00 + 1.38 = 507.38
+      expect(d.costBasisEur.toFixed(2)).toBe("507.38");
+      expect(d.gainLossEur.toFixed(2)).toBe("-507.38");
+    });
+
+    it("writer: option expires worthless → full premium gain", () => {
+      const engine = new FifoEngine();
+      // Writer sells (writes) option: SELL+O
+      engine.processTrades([makeOptionTrade({
+        buySell: "SELL",
+        openCloseIndicator: "O",
+        tradePrice: "5.50",
+        quantity: "1",
+      })], rateMap);
+
+      engine.processOptionExercises([
+        makeExercise({ action: "Expiration", quantity: "1" }),
+      ], rateMap);
+
+      const disposals = engine.getDisposals();
+      expect(disposals).toHaveLength(1);
+
+      const d = disposals[0]!;
+      expect(d.assetCategory).toBe("OPT");
+      expect(d.optionScenario).toBe("expiration");
+      expect(d.isShort).toBe(true);
+      // Writer received premium: 1 × 5.50 × 100 × 0.92 - 1.50 × 0.92 = 506.00 - 1.38 = 504.62
+      expect(d.proceedsEur.toFixed(2)).toBe("504.62");
+      expect(d.costBasisEur.toFixed(2)).toBe("0.00");
+      expect(d.gainLossEur.toFixed(2)).toBe("504.62");
+    });
+  });
+
+  describe("Scenario 2: Early close (opposite trade)", () => {
+    it("buyer closes with SELL+C → gain/loss on premium difference", () => {
+      const engine = new FifoEngine();
+      // Buy option at $5.50
+      engine.processTrades([
+        makeOptionTrade({ tradeDate: "20250115" }),
+        // Sell to close at $8.00 two months later
+        makeOptionTrade({
+          tradeID: "3",
+          buySell: "SELL",
+          openCloseIndicator: "C",
+          tradeDate: "20250315",
+          tradePrice: "8.00",
+          tradeMoney: "800",
+          commission: "1.50",
+        }),
+      ], rateMap);
+
+      const disposals = engine.getDisposals();
+      expect(disposals).toHaveLength(1);
+
+      const d = disposals[0]!;
+      expect(d.assetCategory).toBe("OPT");
+      expect(d.optionScenario).toBe("close");
+      expect(d.putCall).toBe("C");
+      // Proceeds: 1 × 8.00 × 100 × 0.94 - 1.50 × 0.94 = 752.00 - 1.41 = 750.59
+      expect(d.proceedsEur.toFixed(2)).toBe("750.59");
+      // Cost: 507.38 (as calculated above)
+      expect(d.costBasisEur.toFixed(2)).toBe("507.38");
+      expect(d.gainLossEur.greaterThan(0)).toBe(true);
+    });
+
+    it("writer closes with BUY+C → gain/loss on premium difference", () => {
+      const engine = new FifoEngine();
+      // Write (sell) option at $5.50
+      engine.processTrades([
+        makeOptionTrade({
+          buySell: "SELL",
+          openCloseIndicator: "O",
+          tradeDate: "20250115",
+        }),
+        // Buy to close at $3.00 (profit for writer)
+        makeOptionTrade({
+          tradeID: "4",
+          buySell: "BUY",
+          openCloseIndicator: "C",
+          tradeDate: "20250201",
+          tradePrice: "3.00",
+          tradeMoney: "300",
+          commission: "1.50",
+        }),
+      ], rateMap);
+
+      const disposals = engine.getDisposals();
+      expect(disposals).toHaveLength(1);
+
+      const d = disposals[0]!;
+      expect(d.isShort).toBe(true);
+      expect(d.assetCategory).toBe("OPT");
+      // Writer opened at $5.50: proceeds = 504.62 (premium received minus commission)
+      // Writer closed at $3.00: cost = 1 × 3.00 × 100 × 0.93 + 1.50 × 0.93 = 279.00 + 1.395 = 280.395
+      expect(d.proceedsEur.toFixed(2)).toBe("504.62");
+      expect(d.gainLossEur.greaterThan(0)).toBe(true);
+    });
+  });
+
+  describe("Scenario 3: Exercise with physical delivery", () => {
+    it("call buyer exercises → option premium loss + shares acquired at strike", () => {
+      const engine = new FifoEngine();
+      // Buy call option
+      engine.processTrades([makeOptionTrade()], rateMap);
+
+      // Exercise: acquire 100 shares at $200 strike
+      engine.processOptionExercises([makeExercise()], rateMap);
+
+      const disposals = engine.getDisposals();
+      // Only the option disposal (premium loss), no share sale
+      expect(disposals).toHaveLength(1);
+      expect(disposals[0]!.optionScenario).toBe("exercise");
+      expect(disposals[0]!.assetCategory).toBe("OPT");
+      expect(disposals[0]!.proceedsEur.toFixed(2)).toBe("0.00");
+      expect(disposals[0]!.gainLossEur.lessThan(0)).toBe(true);
+
+      // Shares should be in the lot queue at strike price
+      const lots = engine.getRemainingLots().get("US0378331005");
+      expect(lots).toHaveLength(1);
+      expect(lots![0]!.quantity.toString()).toBe("100");
+      expect(lots![0]!.pricePerShare.toString()).toBe("200");
+      // Cost in EUR: 100 shares × $200 × 0.94 = 18800
+      expect(lots![0]!.costInEur.toFixed(2)).toBe("18800.00");
+    });
+
+    it("put buyer exercises → option premium loss + shares sold at strike", () => {
+      const engine = new FifoEngine();
+      // First buy 100 shares at $180
+      engine.processTrades([
+        makeStockTrade(),
+        // Buy put option
+        makeOptionTrade({
+          tradeID: "5",
+          symbol: "AAPL 250321P00200000",
+          description: "AAPL 21MAR25 200 P",
+          putCall: "P",
+          tradeDate: "20250115",
+        }),
+      ], rateMap);
+
+      // Exercise put: sell 100 shares at $200 strike
+      engine.processOptionExercises([
+        makeExercise({
+          action: "Exercise",
+          putCall: "P",
+          symbol: "AAPL 250321P00200000",
+          description: "AAPL 21MAR25 200 P",
+        }),
+      ], rateMap);
+
+      const disposals = engine.getDisposals();
+      // Option disposal + underlying share sale
+      expect(disposals).toHaveLength(2);
+
+      // Option disposal (premium loss)
+      const optDisposal = disposals.find((d) => d.assetCategory === "OPT")!;
+      expect(optDisposal.optionScenario).toBe("exercise");
+      expect(optDisposal.putCall).toBe("P");
+
+      // Share sale at strike
+      const stkDisposal = disposals.find((d) => d.assetCategory === "STK")!;
+      expect(stkDisposal.symbol).toBe("AAPL");
+      expect(stkDisposal.quantity.toString()).toBe("100");
+      // Proceeds: 100 × $200 × 0.94 = 18800
+      expect(stkDisposal.proceedsEur.toFixed(2)).toBe("18800.00");
+      // Cost: 100 × $180 × 0.92 + $1 commission × 0.92 = 16560 + 0.92 = 16560.92
+      expect(stkDisposal.costBasisEur.toFixed(2)).toBe("16560.92");
+      expect(stkDisposal.gainLossEur.greaterThan(0)).toBe(true);
+    });
+
+    it("call writer assigned → premium gain + shares delivered (sold) at strike", () => {
+      const engine = new FifoEngine();
+      // Own 100 shares, then write a covered call
+      engine.processTrades([
+        makeStockTrade(),
+        makeOptionTrade({
+          tradeID: "6",
+          buySell: "SELL",
+          openCloseIndicator: "O",
+          tradeDate: "20250115",
+        }),
+      ], rateMap);
+
+      // Assigned: must deliver 100 shares at $200
+      engine.processOptionExercises([
+        makeExercise({ action: "Assignment", quantity: "1" }),
+      ], rateMap);
+
+      const disposals = engine.getDisposals();
+      // Option disposal (premium gain) + stock disposal (share delivery)
+      expect(disposals).toHaveLength(2);
+
+      const optDisposal = disposals.find((d) => d.assetCategory === "OPT")!;
+      expect(optDisposal.optionScenario).toBe("exercise");
+      expect(optDisposal.isShort).toBe(true);
+      expect(optDisposal.proceedsEur.greaterThan(0)).toBe(true);
+
+      const stkDisposal = disposals.find((d) => d.assetCategory === "STK")!;
+      expect(stkDisposal.symbol).toBe("AAPL");
+      expect(stkDisposal.quantity.toString()).toBe("100");
+      // Delivered at $200 strike: proceeds = 100 × 200 × 0.94 = 18800
+      expect(stkDisposal.proceedsEur.toFixed(2)).toBe("18800.00");
+    });
+
+    it("put writer assigned → premium gain + shares received (bought) at strike", () => {
+      const engine = new FifoEngine();
+      // Write a put option
+      engine.processTrades([
+        makeOptionTrade({
+          tradeID: "7",
+          symbol: "AAPL 250321P00200000",
+          description: "AAPL 21MAR25 200 P",
+          putCall: "P",
+          buySell: "SELL",
+          openCloseIndicator: "O",
+          tradeDate: "20250115",
+        }),
+      ], rateMap);
+
+      // Assigned: must buy 100 shares at $200
+      engine.processOptionExercises([
+        makeExercise({
+          action: "Assignment",
+          putCall: "P",
+          symbol: "AAPL 250321P00200000",
+          description: "AAPL 21MAR25 200 P",
+        }),
+      ], rateMap);
+
+      const disposals = engine.getDisposals();
+      // Only option disposal (premium gain), shares are received into lots
+      expect(disposals).toHaveLength(1);
+      expect(disposals[0]!.assetCategory).toBe("OPT");
+      expect(disposals[0]!.isShort).toBe(true);
+      expect(disposals[0]!.optionScenario).toBe("exercise");
+
+      // 100 shares acquired at $200 strike
+      const lots = engine.getRemainingLots().get("US0378331005");
+      expect(lots).toHaveLength(1);
+      expect(lots![0]!.quantity.toString()).toBe("100");
+      expect(lots![0]!.pricePerShare.toString()).toBe("200");
+    });
+  });
+
+  describe("Anti-churning exemption", () => {
+    it("OPT is exempt from wash sale rule (Art. 33.5.f)", () => {
+      const engine = new FifoEngine();
+      // Buy and sell option at a loss, then buy again immediately
+      engine.processTrades([
+        makeOptionTrade({ tradeDate: "20250115" }),
+        makeOptionTrade({
+          tradeID: "8",
+          buySell: "SELL",
+          openCloseIndicator: "C",
+          tradeDate: "20250201",
+          tradePrice: "3.00",
+          tradeMoney: "300",
+          commission: "1.50",
+        }),
+        makeOptionTrade({
+          tradeID: "9",
+          buySell: "BUY",
+          openCloseIndicator: "O",
+          tradeDate: "20250201",
+          tradePrice: "2.80",
+          tradeMoney: "280",
+          commission: "1.50",
+        }),
+      ], rateMap);
+
+      const disposals = engine.getDisposals();
+      expect(disposals).toHaveLength(1);
+      // OPT is in WASH_SALE_EXEMPT set, so washSaleBlocked stays false
+      expect(disposals[0]!.washSaleBlocked).toBe(false);
+      expect(disposals[0]!.assetCategory).toBe("OPT");
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("exercise without prior option lots emits warning but creates underlying", () => {
+      const engine = new FifoEngine();
+      engine.processTrades([], rateMap);
+
+      engine.processOptionExercises([makeExercise()], rateMap);
+
+      expect(engine.warnings.some((w) => w.includes("sin lotes de opción"))).toBe(true);
+      const lots = engine.getRemainingLots().get("US0378331005");
+      expect(lots).toHaveLength(1);
+      expect(lots![0]!.quantity.toString()).toBe("100");
+    });
+
+    it("multiple contracts partially expired", () => {
+      const engine = new FifoEngine();
+      // Buy 3 contracts
+      engine.processTrades([
+        makeOptionTrade({ quantity: "3", tradeMoney: "1650" }),
+      ], rateMap);
+
+      // Only 2 expire (1 was closed separately via trade)
+      engine.processOptionExercises([
+        makeExercise({ action: "Expiration", quantity: "2" }),
+      ], rateMap);
+
+      const disposals = engine.getDisposals();
+      expect(disposals).toHaveLength(1);
+      expect(disposals[0]!.quantity.toString()).toBe("2");
+      expect(disposals[0]!.optionScenario).toBe("expiration");
+
+      // 1 contract remains in lots
+      const key = `OPT:${makeOptionTrade().symbol}`;
+      const remaining = engine.getRemainingLots().get(key);
+      expect(remaining).toHaveLength(1);
+      expect(remaining![0]!.quantity.toString()).toBe("1");
+    });
+
+    it("option fields propagate to disposal on early close", () => {
+      const engine = new FifoEngine();
+      engine.processTrades([
+        makeOptionTrade(),
+        makeOptionTrade({
+          tradeID: "10",
+          buySell: "SELL",
+          openCloseIndicator: "C",
+          tradeDate: "20250201",
+          tradePrice: "7.00",
+          tradeMoney: "700",
+        }),
+      ], rateMap);
+
+      const d = engine.getDisposals()[0]!;
+      expect(d.optionScenario).toBe("close");
+      expect(d.putCall).toBe("C");
+      expect(d.strike).toBe("200");
+      expect(d.expiry).toBe("20250321");
+      expect(d.underlyingSymbol).toBe("AAPL");
+      expect(d.underlyingIsin).toBe("US0378331005");
+    });
+  });
+});

--- a/tests/generators/csv.test.ts
+++ b/tests/generators/csv.test.ts
@@ -115,23 +115,25 @@ describe("formatCsv", () => {
     const headerCols = header.split(",");
     expect(headerCols[0]).toBe("ISIN");
     expect(headerCols[1]).toBe("Simbolo");
-    expect(headerCols[10]).toBe("Divisa");
-    expect(headerCols[11]).toBe("Tipo_ECB_Compra");
-    expect(headerCols[12]).toBe("Tipo_ECB_Venta");
-    expect(headerCols[13]).toBe("Bloqueada_Antichurning");
+    expect(headerCols[3]).toBe("Categoria");
+    expect(headerCols[11]).toBe("Divisa");
+    expect(headerCols[12]).toBe("Tipo_ECB_Compra");
+    expect(headerCols[13]).toBe("Tipo_ECB_Venta");
+    expect(headerCols[14]).toBe("Bloqueada_Antichurning");
+    expect(headerCols[15]).toBe("Opcion_Escenario");
 
     const dataLine = lines.find((l) => l.startsWith("US0378331005,AAPL"))!;
     const dataCols = dataLine.split(",");
     expect(dataCols[0]).toBe("US0378331005"); // ISIN
     expect(dataCols[1]).toBe("AAPL"); // symbol
-    expect(dataCols[6]).toBe("800.00"); // cost
-    expect(dataCols[7]).toBe("1000.00"); // proceeds
-    expect(dataCols[8]).toBe("200.00"); // gain
-    expect(dataCols[9]).toBe("189"); // holding days
-    expect(dataCols[10]).toBe("USD"); // currency
-    expect(dataCols[11]).toBe("0.920000"); // acquire ECB rate
-    expect(dataCols[12]).toBe("0.910000"); // sell ECB rate
-    expect(dataCols[13]).toBe("NO"); // not blocked
+    expect(dataCols[7]).toBe("800.00"); // cost
+    expect(dataCols[8]).toBe("1000.00"); // proceeds
+    expect(dataCols[9]).toBe("200.00"); // gain
+    expect(dataCols[10]).toBe("189"); // holding days
+    expect(dataCols[11]).toBe("USD"); // currency
+    expect(dataCols[12]).toBe("0.920000"); // acquire ECB rate
+    expect(dataCols[13]).toBe("0.910000"); // sell ECB rate
+    expect(dataCols[14]).toBe("NO"); // not blocked
   });
 
   it("should include dividend rows", () => {
@@ -167,7 +169,8 @@ describe("formatCsv", () => {
 
     const lines = csv.split("\n");
     const dataLine = lines.find((l) => l.startsWith("US0378331005"))!;
-    expect(dataLine.endsWith("SI")).toBe(true);
+    const cols = dataLine.split(",");
+    expect(cols[14]).toBe("SI");
   });
 
   it("should handle empty disposals and dividends", () => {

--- a/tests/web/profile.test.ts
+++ b/tests/web/profile.test.ts
@@ -12,7 +12,7 @@ beforeEach(() => {
     clear: () => { Object.keys(store).forEach((k) => { delete store[k]; }); },
     get length() { return Object.keys(store).length; },
     key: (i: number) => Object.keys(store)[i] ?? null,
-  } as Storage;
+  };
 });
 
 describe("validateNif", () => {


### PR DESCRIPTION
## Summary
- Implements complete options lifecycle handling with 3 scenarios per V0137-23:
  - **Expiration**: option expires worthless (full premium loss for buyer, gain for writer)
  - **Early close**: opposite trade closes position (premium difference as G/P)
  - **Exercise/Assignment**: option P&L recorded separately + underlying acquired/delivered at strike
- Parses `OptionEAE` XML section from IBKR Flex Query (exercise/assignment/expiration events)
- Propagates option fields (`putCall`, `strike`, `expiry`, `underlyingSymbol`) through `Lot` → `FifoDisposal`
- Shows option scenario info in CSV, PDF, and web operations annex
- Fixes pre-existing lint errors in `casilla-detail.ts` and `profile.test.ts`

## Legal basis
- Art. 37.1.m) LIRPF: options/futures as ganancias patrimoniales (base del ahorro)
- DGT V0137-23: consulta vinculante on option exercise with physical delivery
- Art. 33.5.f: anti-churning correctly exempts OPT (already implemented, now tested)

## Test plan
- [x] 12 new tests covering all 3 scenarios (buyer/writer × expiration/close/exercise)
- [x] Edge cases: no prior lots, partial expiration, field propagation
- [x] All 866 tests passing locally
- [x] Typecheck clean
- [x] Lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Option exercises, assignments, and expirations are now properly processed and reported instead of generating warnings.
  * Option metadata (put/call, strike, expiry, underlying symbols) is tracked and displayed throughout reports.

* **Improvements**
  * CSV exports now include option categorization and scenario columns.
  * PDF reports display option details with shorthand notation.
  * Web interface labels options and displays scenario badges with relevant details.

* **Tests**
  * Added comprehensive test coverage for option taxation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->