### PR TITLE
fix: options exercise uses market price per DGT V0137-23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "declarenta",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "declarenta",
-      "version": "0.31.3",
+      "version": "0.31.4",
       "license": "GPL-3.0",
       "dependencies": {
         "@types/pdfkit": "^0.17.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "declarenta",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "description": "Open-source tool to convert foreign broker reports (IBKR, Degiro, Scalable Capital, eToro, Freedom24) into Spanish tax declarations (Modelo 100, 720, D-6). Browser-first, privacy-focused.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/engine/fifo.ts
+++ b/src/engine/fifo.ts
@@ -776,47 +776,22 @@ export class FifoEngine {
     const shortLots = this.shortLots.get(optionKey);
 
     if (longLots && longLots.length > 0) {
-      // BUYER exercising: consume option lots, record option P&L, create underlying lots
+      // BUYER exercising: consume option lots, integrate premium into underlying cost basis
+      // Per DGT V0137-23: no separate option disposal — premium integrates into stock cost
+      const useMarketPrice = ex.marketPrice && /^-?\d+(\.\d+)?$/.test(ex.marketPrice.trim());
+      const priceForUnderlying = useMarketPrice ? new Decimal(ex.marketPrice!) : strike;
+
       let remaining = quantity;
       while (remaining.greaterThan(0) && longLots.length > 0) {
         const lot = longLots[0]!;
         const consumed = Decimal.min(remaining, lot.quantity);
         const costPerUnit = lot.costInEur.dividedBy(lot.quantity);
-        const optionCostBasis = costPerUnit.mul(consumed);
+        const optionPremiumEur = costPerUnit.mul(consumed);
 
-        // Option disposal: premium paid is cost, exercise settles at intrinsic value
-        // Per V0137-23: the option gain/loss is the difference between premium paid
-        // and the value obtained through exercise. But for tax simplicity,
-        // the option premium is recorded as a separate capital gain/loss event.
-        // Proceeds = 0 for the option itself (value transfers to underlying position)
-        this.disposals.push({
-          isin: ex.isin,
-          symbol: ex.symbol,
-          description: `${ex.description} [Ejercicio Art. 37.1.m]`,
-          sellDate: date,
-          acquireDate: lot.acquireDate,
-          quantity: consumed,
-          proceedsEur: new Decimal(0),
-          costBasisEur: optionCostBasis,
-          gainLossEur: optionCostBasis.negated(),
-          holdingPeriodDays: daysBetween(lot.acquireDate, date),
-          currency: ex.currency,
-          sellEcbRate: ecbRate,
-          acquireEcbRate: lot.ecbRate,
-          assetCategory: "OPT",
-          washSaleBlocked: false,
-          optionScenario: "exercise",
-          putCall: ex.putCall,
-          strike: ex.strike,
-          expiry: ex.expiry,
-          underlyingSymbol: ex.underlyingSymbol,
-          underlyingIsin: ex.underlyingIsin,
-        });
-
-        // Create underlying lots: acquired at strike price (market value at exercise per Art. 37.1.m)
-        // Call exercise: BUY shares at strike. Put exercise: SELL shares at strike.
         if (ex.putCall === "C") {
-          const shareCost = strike.mul(consumed).mul(sharesPerContract).mul(ecbRate);
+          // Call buyer: acquires shares at market price + premium (DGT V0137-23)
+          const baseShareCost = priceForUnderlying.mul(consumed).mul(sharesPerContract).mul(ecbRate);
+          const totalCost = baseShareCost.plus(optionPremiumEur);
           const underlyingLot: Lot = {
             id: `LOT-${this.nextLotId++}`,
             isin: ex.underlyingIsin,
@@ -824,69 +799,49 @@ export class FifoEngine {
             description: `${ex.underlyingSymbol} [via ejercicio ${ex.symbol}]`,
             acquireDate: date,
             quantity: consumed.mul(sharesPerContract),
-            pricePerShare: strike,
-            costInEur: shareCost,
+            pricePerShare: priceForUnderlying,
+            costInEur: totalCost,
             currency: ex.currency,
             ecbRate,
           };
           if (!this.lots.has(underlyingKey)) this.lots.set(underlyingKey, []);
           this.lots.get(underlyingKey)!.push(underlyingLot);
         } else {
-          // Put exercise: we sell underlying shares at strike price
-          // Synthesize a sale of the underlying
-          const shareProceeds = strike.mul(consumed).mul(sharesPerContract).mul(ecbRate);
-          this.consumeLotsForExercise(underlyingKey, consumed.mul(sharesPerContract), shareProceeds, date, ecbRate, ex);
+          // Put buyer exercising: sells shares at market price, premium reduces proceeds
+          const shareProceeds = priceForUnderlying.mul(consumed).mul(sharesPerContract).mul(ecbRate);
+          const netProceeds = shareProceeds.minus(optionPremiumEur);
+          this.consumeLotsForExercise(underlyingKey, consumed.mul(sharesPerContract), netProceeds, date, ecbRate, ex);
         }
 
         lot.quantity = lot.quantity.minus(consumed);
-        lot.costInEur = lot.costInEur.minus(optionCostBasis);
+        lot.costInEur = lot.costInEur.minus(optionPremiumEur);
         if (lot.quantity.isZero()) longLots.shift();
         remaining = remaining.minus(consumed);
       }
       if (longLots.length === 0) this.lots.delete(optionKey);
 
     } else if (shortLots && shortLots.length > 0) {
-      // WRITER assigned: consume short option lots, record option P&L, deliver/receive shares
+      // WRITER assigned: consume short option lots, integrate premium into underlying event
+      // Per DGT V0137-23: no separate option disposal — premium integrates into stock event
+      const useMarketPrice = ex.marketPrice && /^-?\d+(\.\d+)?$/.test(ex.marketPrice.trim());
+      const priceForUnderlying = useMarketPrice ? new Decimal(ex.marketPrice!) : strike;
+
       let remaining = quantity;
       while (remaining.greaterThan(0) && shortLots.length > 0) {
         const lot = shortLots[0]!;
         const consumed = Decimal.min(remaining, lot.quantity);
         const proceedsPerUnit = lot.costInEur.dividedBy(lot.quantity);
-        const optionProceeds = proceedsPerUnit.mul(consumed);
+        const optionPremiumEur = proceedsPerUnit.mul(consumed);
 
-        // Writer's option disposal: premium received is proceeds, cost = 0 (obligation extinguished)
-        this.disposals.push({
-          isin: ex.isin,
-          symbol: ex.symbol,
-          description: `${ex.description} [Asignación Art. 37.1.m]`,
-          sellDate: date,
-          acquireDate: lot.acquireDate,
-          quantity: consumed,
-          proceedsEur: optionProceeds,
-          costBasisEur: new Decimal(0),
-          gainLossEur: optionProceeds,
-          holdingPeriodDays: daysBetween(lot.acquireDate, date),
-          currency: ex.currency,
-          sellEcbRate: ecbRate,
-          acquireEcbRate: lot.ecbRate,
-          assetCategory: "OPT",
-          washSaleBlocked: false,
-          isShort: true,
-          optionScenario: "exercise",
-          putCall: ex.putCall,
-          strike: ex.strike,
-          expiry: ex.expiry,
-          underlyingSymbol: ex.underlyingSymbol,
-          underlyingIsin: ex.underlyingIsin,
-        });
-
-        // Call writer assigned: must SELL shares at strike (deliver)
-        // Put writer assigned: must BUY shares at strike (receive)
+        // Call writer assigned: SELL shares at market price, premium adds to proceeds
+        // Put writer assigned: BUY shares at market price, premium reduces cost
         if (ex.putCall === "C") {
-          const shareProceeds = strike.mul(consumed).mul(sharesPerContract).mul(ecbRate);
-          this.consumeLotsForExercise(underlyingKey, consumed.mul(sharesPerContract), shareProceeds, date, ecbRate, ex);
+          const shareProceeds = priceForUnderlying.mul(consumed).mul(sharesPerContract).mul(ecbRate);
+          const netProceeds = shareProceeds.plus(optionPremiumEur);
+          this.consumeLotsForExercise(underlyingKey, consumed.mul(sharesPerContract), netProceeds, date, ecbRate, ex);
         } else {
-          const shareCost = strike.mul(consumed).mul(sharesPerContract).mul(ecbRate);
+          const baseShareCost = priceForUnderlying.mul(consumed).mul(sharesPerContract).mul(ecbRate);
+          const totalCost = baseShareCost.minus(optionPremiumEur);
           const underlyingLot: Lot = {
             id: `LOT-${this.nextLotId++}`,
             isin: ex.underlyingIsin,
@@ -894,8 +849,8 @@ export class FifoEngine {
             description: `${ex.underlyingSymbol} [via asignación ${ex.symbol}]`,
             acquireDate: date,
             quantity: consumed.mul(sharesPerContract),
-            pricePerShare: strike,
-            costInEur: shareCost,
+            pricePerShare: priceForUnderlying,
+            costInEur: totalCost,
             currency: ex.currency,
             ecbRate,
           };
@@ -904,7 +859,7 @@ export class FifoEngine {
         }
 
         lot.quantity = lot.quantity.minus(consumed);
-        lot.costInEur = lot.costInEur.minus(optionProceeds);
+        lot.costInEur = lot.costInEur.minus(optionPremiumEur);
         if (lot.quantity.isZero()) shortLots.shift();
         remaining = remaining.minus(consumed);
       }

--- a/src/parsers/ibkr.ts
+++ b/src/parsers/ibkr.ts
@@ -78,7 +78,7 @@ export function parseIbkrFlexXml(xml: string): FlexStatement {
     openPositions.push(...ensureArray(stmt.OpenPositions?.OpenPosition).map(mapOpenPosition));
     securitiesInfo.push(...ensureArray(stmt.SecuritiesInfo?.SecurityInfo).map(mapSecurityInfo));
     cashBalances.push(...ensureArray(stmt.CashReport?.CashReportCurrency).map(mapCashBalance));
-    optionExercises.push(...ensureArray(stmt.OptionEAE?.OptionEAE).map(mapOptionExercise).filter((e): e is OptionExercise => e !== null));
+    optionExercises.push(...parseOptionEaeRows(ensureArray(stmt.OptionEAE?.OptionEAE)));
   }
 
   // Detect important sections present in XML but not parsed
@@ -227,36 +227,69 @@ function mapCashBalance(raw: Record<string, string>): CashBalance {
   };
 }
 
-function mapOptionExercise(raw: Record<string, string>): OptionExercise | null {
-  // IBKR OptionEAE has paired rows: option removal (negative qty, has strike)
-  // + underlying delivery (positive qty, no strike). Skip delivery rows.
-  if (!raw.strike?.trim()) return null;
-
-  const action = (raw.action ?? raw.type ?? "").toLowerCase();
-  let mappedAction: OptionExercise["action"] = "Exercise";
-  if (action.includes("assign")) mappedAction = "Assignment";
-  else if (action.includes("expir") || action.includes("lapse")) mappedAction = "Expiration";
-
-  return {
-    transactionID: raw.transactionID ?? "",
-    accountId: raw.accountId ?? "",
-    ...(raw.conid?.trim() ? { conid: raw.conid.trim() } : {}),
-    symbol: raw.symbol ?? "",
-    description: raw.description ?? "",
-    isin: raw.isin ?? "",
-    currency: raw.currency ?? "",
-    date: raw.date ?? raw.dateTime?.slice(0, 8) ?? "",
-    action: mappedAction,
-    putCall: raw.putCall?.toUpperCase() === "P" ? "P" : raw.putCall?.toUpperCase() === "C" ? "C" : "C",
-    strike: raw.strike,
-    expiry: raw.expiry ?? "",
-    quantity: raw.quantity ?? "0",
-    proceeds: raw.proceeds ?? raw.amount ?? "0",
-    underlyingSymbol: raw.underlyingSymbol ?? "",
-    underlyingIsin: raw.underlyingIsin ?? "",
-    multiplier: raw.multiplier ?? "100",
-  };
+interface OptionEaeDelivery {
+  date: string;
+  symbol: string;
+  underlyingSymbol: string;
+  tradePrice: string;
+  action: string;
 }
+
+function parseOptionEaeRows(rawRows: Record<string, string>[]): OptionExercise[] {
+  const optionRows: OptionExercise[] = [];
+  const deliveryRows: OptionEaeDelivery[] = [];
+
+  for (const raw of rawRows) {
+    if (raw.strike?.trim()) {
+      const action = (raw.action ?? raw.type ?? "").toLowerCase();
+      let mappedAction: OptionExercise["action"] = "Exercise";
+      if (action.includes("assign")) mappedAction = "Assignment";
+      else if (action.includes("expir") || action.includes("lapse")) mappedAction = "Expiration";
+
+      optionRows.push({
+        transactionID: raw.transactionID ?? "",
+        accountId: raw.accountId ?? "",
+        ...(raw.conid?.trim() ? { conid: raw.conid.trim() } : {}),
+        symbol: raw.symbol ?? "",
+        description: raw.description ?? "",
+        isin: raw.isin ?? "",
+        currency: raw.currency ?? "",
+        date: raw.date ?? raw.dateTime?.slice(0, 8) ?? "",
+        action: mappedAction,
+        putCall: raw.putCall?.toUpperCase() === "P" ? "P" : raw.putCall?.toUpperCase() === "C" ? "C" : "C",
+        strike: raw.strike,
+        expiry: raw.expiry ?? "",
+        quantity: raw.quantity ?? "0",
+        proceeds: raw.proceeds ?? raw.amount ?? "0",
+        underlyingSymbol: raw.underlyingSymbol ?? raw.symbol ?? "",
+        underlyingIsin: raw.underlyingIsin ?? "",
+        multiplier: raw.multiplier ?? "100",
+      });
+    } else if (raw.tradePrice?.trim()) {
+      deliveryRows.push({
+        date: raw.date ?? raw.dateTime?.slice(0, 8) ?? "",
+        symbol: raw.symbol ?? "",
+        underlyingSymbol: raw.underlyingSymbol ?? raw.symbol ?? "",
+        tradePrice: raw.tradePrice,
+        action: (raw.action ?? raw.type ?? "").toLowerCase(),
+      });
+    }
+  }
+
+  for (const opt of optionRows) {
+    if (opt.action === "Expiration") continue;
+    const delivery = deliveryRows.find(
+      (d) => d.date === opt.date &&
+        (d.symbol === opt.underlyingSymbol || d.underlyingSymbol === opt.underlyingSymbol),
+    );
+    if (delivery) {
+      opt.marketPrice = delivery.tradePrice;
+    }
+  }
+
+  return optionRows;
+}
+
 
 /** IBKR Flex Query XML parser implementing BrokerParser interface */
 export const ibkrParser: BrokerParser = {

--- a/src/types/ibkr.ts
+++ b/src/types/ibkr.ts
@@ -160,4 +160,6 @@ export interface OptionExercise {
   underlyingSymbol: string;
   underlyingIsin: string;
   multiplier: string;
+  /** Market price of underlying at exercise (from paired delivery row, DGT V0137-23) */
+  marketPrice?: string;
 }

--- a/tests/engine/options-v0137-23.test.ts
+++ b/tests/engine/options-v0137-23.test.ts
@@ -218,38 +218,49 @@ describe("Options taxation — DGT V0137-23 (Art. 37.1.m LIRPF)", () => {
     });
   });
 
-  describe("Scenario 3: Exercise with physical delivery", () => {
-    it("call buyer exercises → option premium loss + shares acquired at strike", () => {
+  describe("Scenario 3: Exercise with physical delivery (V0137-23)", () => {
+    it("call buyer exercises → no separate OPT disposal, premium integrates into share cost", () => {
       const engine = new FifoEngine();
-      // Buy call option
       engine.processTrades([makeOptionTrade()], rateMap);
 
-      // Exercise: acquire 100 shares at $200 strike
       engine.processOptionExercises([makeExercise()], rateMap);
 
       const disposals = engine.getDisposals();
-      // Only the option disposal (premium loss), no share sale
-      expect(disposals).toHaveLength(1);
-      expect(disposals[0]!.optionScenario).toBe("exercise");
-      expect(disposals[0]!.assetCategory).toBe("OPT");
-      expect(disposals[0]!.proceedsEur.toFixed(2)).toBe("0.00");
-      expect(disposals[0]!.gainLossEur.lessThan(0)).toBe(true);
+      // V0137-23: no separate option disposal on exercise
+      expect(disposals).toHaveLength(0);
 
-      // Shares should be in the lot queue at strike price
+      // Shares acquired with cost = strike × shares × ecbRate + premium
       const lots = engine.getRemainingLots().get("US0378331005");
       expect(lots).toHaveLength(1);
       expect(lots![0]!.quantity.toString()).toBe("100");
       expect(lots![0]!.pricePerShare.toString()).toBe("200");
-      // Cost in EUR: 100 shares × $200 × 0.94 = 18800
-      expect(lots![0]!.costInEur.toFixed(2)).toBe("18800.00");
+      // Cost > bare strike cost (18800) because premium is integrated
+      const bareStrikeCost = new Decimal("18800");
+      expect(lots![0]!.costInEur.greaterThan(bareStrikeCost)).toBe(true);
     });
 
-    it("put buyer exercises → option premium loss + shares sold at strike", () => {
+    it("call buyer exercises with marketPrice → uses market price, not strike", () => {
       const engine = new FifoEngine();
-      // First buy 100 shares at $180
+      engine.processTrades([makeOptionTrade()], rateMap);
+
+      // Market price $220 (higher than $200 strike)
+      engine.processOptionExercises([makeExercise({ marketPrice: "220" })], rateMap);
+
+      const disposals = engine.getDisposals();
+      expect(disposals).toHaveLength(0);
+
+      const lots = engine.getRemainingLots().get("US0378331005");
+      expect(lots).toHaveLength(1);
+      expect(lots![0]!.pricePerShare.toString()).toBe("220");
+      // Base cost: 100 × $220 × 0.94 = 20680, plus premium
+      const bareMarketCost = new Decimal("20680");
+      expect(lots![0]!.costInEur.greaterThan(bareMarketCost)).toBe(true);
+    });
+
+    it("put buyer exercises → no OPT disposal, premium reduces sale proceeds", () => {
+      const engine = new FifoEngine();
       engine.processTrades([
         makeStockTrade(),
-        // Buy put option
         makeOptionTrade({
           tradeID: "5",
           symbol: "AAPL 250321P00200000",
@@ -259,7 +270,6 @@ describe("Options taxation — DGT V0137-23 (Art. 37.1.m LIRPF)", () => {
         }),
       ], rateMap);
 
-      // Exercise put: sell 100 shares at $200 strike
       engine.processOptionExercises([
         makeExercise({
           action: "Exercise",
@@ -270,28 +280,19 @@ describe("Options taxation — DGT V0137-23 (Art. 37.1.m LIRPF)", () => {
       ], rateMap);
 
       const disposals = engine.getDisposals();
-      // Option disposal + underlying share sale
-      expect(disposals).toHaveLength(2);
-
-      // Option disposal (premium loss)
-      const optDisposal = disposals.find((d) => d.assetCategory === "OPT")!;
-      expect(optDisposal.optionScenario).toBe("exercise");
-      expect(optDisposal.putCall).toBe("P");
-
-      // Share sale at strike
-      const stkDisposal = disposals.find((d) => d.assetCategory === "STK")!;
-      expect(stkDisposal.symbol).toBe("AAPL");
-      expect(stkDisposal.quantity.toString()).toBe("100");
-      // Proceeds: 100 × $200 × 0.94 = 18800
-      expect(stkDisposal.proceedsEur.toFixed(2)).toBe("18800.00");
-      // Cost: 100 × $180 × 0.92 + $1 commission × 0.92 = 16560 + 0.92 = 16560.92
-      expect(stkDisposal.costBasisEur.toFixed(2)).toBe("16560.92");
-      expect(stkDisposal.gainLossEur.greaterThan(0)).toBe(true);
+      // Only STK disposal (share sale), no separate OPT disposal
+      expect(disposals).toHaveLength(1);
+      expect(disposals[0]!.assetCategory).toBe("STK");
+      expect(disposals[0]!.symbol).toBe("AAPL");
+      expect(disposals[0]!.quantity.toString()).toBe("100");
+      // Proceeds < bare strike proceeds (18800) because premium is subtracted
+      const bareStrikeProceeds = new Decimal("18800");
+      expect(disposals[0]!.proceedsEur.lessThan(bareStrikeProceeds)).toBe(true);
+      expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("16560.92");
     });
 
-    it("call writer assigned → premium gain + shares delivered (sold) at strike", () => {
+    it("call writer assigned → no OPT disposal, premium adds to sale proceeds", () => {
       const engine = new FifoEngine();
-      // Own 100 shares, then write a covered call
       engine.processTrades([
         makeStockTrade(),
         makeOptionTrade({
@@ -302,30 +303,23 @@ describe("Options taxation — DGT V0137-23 (Art. 37.1.m LIRPF)", () => {
         }),
       ], rateMap);
 
-      // Assigned: must deliver 100 shares at $200
       engine.processOptionExercises([
         makeExercise({ action: "Assignment", quantity: "1" }),
       ], rateMap);
 
       const disposals = engine.getDisposals();
-      // Option disposal (premium gain) + stock disposal (share delivery)
-      expect(disposals).toHaveLength(2);
-
-      const optDisposal = disposals.find((d) => d.assetCategory === "OPT")!;
-      expect(optDisposal.optionScenario).toBe("exercise");
-      expect(optDisposal.isShort).toBe(true);
-      expect(optDisposal.proceedsEur.greaterThan(0)).toBe(true);
-
-      const stkDisposal = disposals.find((d) => d.assetCategory === "STK")!;
-      expect(stkDisposal.symbol).toBe("AAPL");
-      expect(stkDisposal.quantity.toString()).toBe("100");
-      // Delivered at $200 strike: proceeds = 100 × 200 × 0.94 = 18800
-      expect(stkDisposal.proceedsEur.toFixed(2)).toBe("18800.00");
+      // Only STK disposal (share delivery), no separate OPT disposal
+      expect(disposals).toHaveLength(1);
+      expect(disposals[0]!.assetCategory).toBe("STK");
+      expect(disposals[0]!.symbol).toBe("AAPL");
+      expect(disposals[0]!.quantity.toString()).toBe("100");
+      // Proceeds > bare strike proceeds (18800) because premium is added
+      const bareStrikeProceeds = new Decimal("18800");
+      expect(disposals[0]!.proceedsEur.greaterThan(bareStrikeProceeds)).toBe(true);
     });
 
-    it("put writer assigned → premium gain + shares received (bought) at strike", () => {
+    it("put writer assigned → no OPT disposal, premium reduces share cost", () => {
       const engine = new FifoEngine();
-      // Write a put option
       engine.processTrades([
         makeOptionTrade({
           tradeID: "7",
@@ -338,7 +332,6 @@ describe("Options taxation — DGT V0137-23 (Art. 37.1.m LIRPF)", () => {
         }),
       ], rateMap);
 
-      // Assigned: must buy 100 shares at $200
       engine.processOptionExercises([
         makeExercise({
           action: "Assignment",
@@ -349,17 +342,17 @@ describe("Options taxation — DGT V0137-23 (Art. 37.1.m LIRPF)", () => {
       ], rateMap);
 
       const disposals = engine.getDisposals();
-      // Only option disposal (premium gain), shares are received into lots
-      expect(disposals).toHaveLength(1);
-      expect(disposals[0]!.assetCategory).toBe("OPT");
-      expect(disposals[0]!.isShort).toBe(true);
-      expect(disposals[0]!.optionScenario).toBe("exercise");
+      // No disposals — shares are acquired into lots
+      expect(disposals).toHaveLength(0);
 
-      // 100 shares acquired at $200 strike
+      // Shares acquired with cost = strike × shares × rate - premium
       const lots = engine.getRemainingLots().get("US0378331005");
       expect(lots).toHaveLength(1);
       expect(lots![0]!.quantity.toString()).toBe("100");
       expect(lots![0]!.pricePerShare.toString()).toBe("200");
+      // Cost < bare strike cost (18800) because writer's premium reduces it
+      const bareStrikeCost = new Decimal("18800");
+      expect(lots![0]!.costInEur.lessThan(bareStrikeCost)).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- Per DGT consulta vinculante V0137-23 (Art. 37.1.m LIRPF), option exercises now use **market price** from paired delivery rows instead of strike price for underlying cost basis
- Option premium is **integrated** into the stock event (no more separate OPT disposal on exercise):
  - Call buyer: premium adds to share cost basis
  - Put buyer: premium reduces sale proceeds
  - Call writer: premium adds to sale proceeds
  - Put writer: premium reduces share cost basis
- Falls back to strike price when delivery row / marketPrice is unavailable (e.g., older exports without OptionEAE delivery data)

## Changes
- `src/types/ibkr.ts`: Added optional `marketPrice` field to `OptionExercise`
- `src/parsers/ibkr.ts`: New `parseOptionEaeRows()` captures delivery rows (previously discarded) and pairs them with option rows to extract `tradePrice`
- `src/engine/fifo.ts`: Removed separate OPT disposal creation on exercise; integrates premium into underlying STK event
- `tests/engine/options-v0137-23.test.ts`: Rewritten Scenario 3 tests to verify V0137-23 treatment + new test for marketPrice usage

## Test plan
- [x] All 912 tests pass
- [x] TypeScript compiles cleanly
- [ ] Verify with real IBKR Flex Query containing OptionEAE section
- [ ] Confirm casilla output matches expected V0137-23 treatment

Resolves feedback from https://github.com/GeiserX/DeclaRenta/pull/129#issuecomment-4328837276