### PR TITLE
fix: remove min-width on splash broker tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "declarenta",
-  "version": "0.31.2",
+  "version": "0.31.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "declarenta",
-      "version": "0.31.2",
+      "version": "0.31.3",
       "license": "GPL-3.0",
       "dependencies": {
         "@types/pdfkit": "^0.17.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "declarenta",
-  "version": "0.31.2",
+  "version": "0.31.3",
   "description": "Open-source tool to convert foreign broker reports (IBKR, Degiro, Scalable Capital, eToro, Freedom24) into Spanish tax declarations (Modelo 100, 720, D-6). Browser-first, privacy-focused.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -1793,8 +1793,6 @@ footer a:hover {
 
 .splash-broker-tag {
   padding: 0.3rem 0.75rem;
-  min-width: 5.5rem;
-  text-align: center;
   background: var(--accent-subtle);
   border: 1px solid var(--tag-border);
   border-radius: 20px;
@@ -1802,6 +1800,7 @@ footer a:hover {
   font-weight: 600;
   color: var(--accent);
   letter-spacing: 0.02em;
+  white-space: nowrap;
   transition: background 0.2s, transform 0.2s;
 }
 
@@ -2073,7 +2072,6 @@ footer a:hover {
   .splash-broker-tag {
     font-size: 0.65rem;
     padding: 0.2rem 0.45rem;
-    min-width: 4.5rem;
   }
 
   .splash-features {


### PR DESCRIPTION
## Summary
- Removes `min-width` that was causing "Trade Republic" to wrap inside its tag on desktop
- Uses `white-space: nowrap` to prevent tag text from breaking across lines
- Fixes regression from v0.31.2

## Test plan
- [ ] Desktop: all broker tags on single line, no text wrapping
- [ ] Mobile: tags wrap to next row (flex-wrap: wrap) but each tag stays intact