### PR TITLE
fix: eliminate phantom FX gains when prior-year lots are missing

### DIFF
--- a/src/engine/fx-fifo.ts
+++ b/src/engine/fx-fifo.ts
@@ -259,6 +259,21 @@ export class FxFifoEngine {
 
     if (!lots || lots.length === 0) {
       this.warnings.push(`⚠ Venta de ${event.currency} sin lotes previos el ${event.date}. Posible adquisición anterior al período declarado.`);
+      // No lots = prior-year acquisition. Record with zero gain (cost = proceeds)
+      // to avoid fabricating phantom profits from missing historical data.
+      const proceedsEur = remaining.mul(event.ecbRate);
+      this.disposals.push({
+        currency: event.currency,
+        disposeDate: event.date,
+        acquireDate: event.date,
+        quantity: remaining,
+        proceedsEur,
+        costBasisEur: proceedsEur,
+        gainLossEur: new Decimal(0),
+        trigger: event.trigger,
+        holdingPeriodDays: 0,
+        lotId: "UNKNOWN",
+      });
       return;
     }
 
@@ -295,6 +310,8 @@ export class FxFifoEngine {
 
     if (remaining.greaterThan(0)) {
       this.warnings.push(`⚠ Lotes FX insuficientes: ${event.currency} × ${remaining} el ${event.date}. Coste = 0.`);
+      // Without prior-year lots we cannot determine cost basis.
+      // Use current rate as cost (zero gain) to avoid fabricating phantom profits.
       const proceedsEur = remaining.mul(event.ecbRate);
       this.disposals.push({
         currency: event.currency,
@@ -302,8 +319,8 @@ export class FxFifoEngine {
         acquireDate: event.date,
         quantity: remaining,
         proceedsEur,
-        costBasisEur: new Decimal(0),
-        gainLossEur: proceedsEur,
+        costBasisEur: proceedsEur,
+        gainLossEur: new Decimal(0),
         trigger: event.trigger,
         holdingPeriodDays: 0,
         lotId: "UNKNOWN",

--- a/tests/engine/fx-fifo.test.ts
+++ b/tests/engine/fx-fifo.test.ts
@@ -116,17 +116,22 @@ describe("FxFifoEngine", () => {
       expect(engine.getDisposals()).toHaveLength(0);
     });
 
-    it("should warn when disposing without prior lots", () => {
+    it("should warn when disposing without prior lots and record zero-gain disposal", () => {
       const engine = new FxFifoEngine();
       engine.processEvents([
-        makeEvent({ quantity: new Decimal(-500) }),
+        makeEvent({ quantity: new Decimal(-500), ecbRate: new Decimal("0.95") }),
       ]);
 
       expect(engine.warnings).toHaveLength(1);
       expect(engine.warnings[0]).toMatch(/sin lotes previos/);
+      const disposals = engine.getDisposals();
+      expect(disposals).toHaveLength(1);
+      expect(disposals[0]!.gainLossEur.toFixed(2)).toBe("0.00");
+      expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("475.00");
+      expect(disposals[0]!.proceedsEur.toFixed(2)).toBe("475.00");
     });
 
-    it("should warn and record zero-cost disposal for insufficient lots", () => {
+    it("should warn and record zero-gain disposal for insufficient lots", () => {
       const engine = new FxFifoEngine();
       engine.processEvents([
         makeEvent({ quantity: new Decimal(300), ecbRate: new Decimal("0.92") }),
@@ -135,11 +140,15 @@ describe("FxFifoEngine", () => {
 
       const disposals = engine.getDisposals();
       expect(disposals).toHaveLength(2);
-      // First: 300 from lot
+      // First: 300 from lot (real gain/loss)
       expect(disposals[0]!.quantity.toString()).toBe("300");
-      // Second: 200 with zero cost (overflow)
+      expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("276.00");
+      expect(disposals[0]!.proceedsEur.toFixed(2)).toBe("285.00");
+      // Second: 200 overflow — zero gain (cost = proceeds, no phantom profit)
       expect(disposals[1]!.quantity.toString()).toBe("200");
-      expect(disposals[1]!.costBasisEur.toFixed(2)).toBe("0.00");
+      expect(disposals[1]!.costBasisEur.toFixed(2)).toBe("190.00");
+      expect(disposals[1]!.proceedsEur.toFixed(2)).toBe("190.00");
+      expect(disposals[1]!.gainLossEur.toFixed(2)).toBe("0.00");
       expect(engine.warnings.some((w) => w.includes("insuficientes"))).toBe(true);
     });
 


### PR DESCRIPTION
## Summary
- When FX lots are insufficient or completely absent (only current year uploaded), the engine was creating disposals with `costBasisEur = 0`, fabricating phantom profits equal to the full proceeds
- For users like Armando trading USD options with IBKR auto-converting currencies, this produced ~48K EUR in fake FX gains and inflated the tax bracket estimate
- Fix: use disposal's ECB rate as both cost and proceeds when lots are missing → zero gain instead of phantom profit
- Warnings still emitted so users know prior-year data would improve accuracy

## Root cause
IBKR multi-currency accounts (FOP in USD, CASH conversions on IDEALFX without AFx markers) generate implicit FX events from securities trades. Without prior-year FX lots, every disposal had `costBasisEur = 0`, counting 100% of proceeds as taxable gain.

## Test plan
- [x] All 915 tests pass (updated 2 test expectations to match new zero-gain behavior)
- [x] Lint clean
- [ ] Verify with Armando's XML: FX gains should drop from ~48K to near-zero