### PR TITLE
fix: restore realistic bull logo for app branding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,28 @@ When adding a new section (like 721), follow this checklist:
 - Use `charset=utf-8` in MIME type for prototypes/stubs
 - For real AEAT submission (Modelo 720 fixed-width, ISO-8859-15), proper byte encoding would need a TextEncoder or library — current implementation is a known limitation
 
+### FOP/FSFOP Asset Category (Hard Trace)
+- IBKR reports futures options on MEFF (Spanish derivatives exchange) as `assetCategory="FOP"` or `"FSFOP"`
+- These must be added to `KNOWN_CATEGORIES` in fifo.ts, `WASH_SALE_EXEMPT` in wash-sale.ts, and `ASSET_LABELS` in charts.ts/operations-annex.ts
+- FOP/FSFOP are derivatives → exempt from anti-churning (Art. 33.5.f only applies to homogeneous securities)
+- They share option-like metadata (strike, expiry, putCall) — extend OPT spreads in fifo.ts to also match FOP/FSFOP
+- **Symptom**: massive false blocked losses (~22K EUR) and 75+ "categoría desconocida" warnings
+- **ISIN guard**: FOP trades on MEFF often have empty ISIN. The wash-sale matcher must skip disposals with empty ISIN to avoid false matches against unrelated securities
+
+### FX Phantom Gains from Missing Prior-Year Lots (Hard Trace)
+- Multi-currency accounts (no auto-convert) generate implicit FX events when trading non-EUR securities
+- If the user's Flex Query only covers the declaration year, prior-year FCY acquisitions are missing → no lots exist when the engine tries to consume them
+- **Old behavior**: `costBasisEur = 0` → fabricated huge phantom profits (e.g. 48K EUR)
+- **Fix**: When lots are missing (both "sin lotes previos" and "insuficientes" paths in fx-fifo.ts), set `costBasisEur = proceedsEur` → zero gain. The warning still fires so users know data is incomplete.
+- **Detection**: `detectAutoConvert()` uses 4 signals (FXCONV markers, absence of manual CASH trades, amount-correlation heuristic). If it returns false, securities trades generate FX events.
+- **User impact**: Users with auto-convert accounts (FXCONV/AFx markers) are unaffected. Only manual multi-currency accounts with incomplete history trigger this.
+
+### Logo vs Favicon (Hard Trace)
+- `src/web/public/logo.png` = the realistic bull app logo (1.9MB, 1024×1024). Used for splash screen and top-bar branding.
+- `src/web/public/favicon.svg` / `favicon-16.png` / `favicon-32.png` = small icon for browser tabs only.
+- **NEVER** use `favicon.svg` as the `src` for `.splash-logo` or `.brand-logo` in index.html. Those must reference `logo.png`.
+- `docs/images/logo.png` and `src/web/assets/logo.png` are copies of the same logo for docs/README.
+
 ### CLI Build Gotcha
 - `tsup` config produces both lib and CLI entries to `dist/` — CLI entry `dist/index.js` collides with lib entry
 - `package.json` `bin.declarenta` points to `./dist/cli.js` which doesn't exist

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -19,7 +19,7 @@
     <div class="splash-bg-grid" aria-hidden="true"></div>
     <div class="splash-content">
       <div class="splash-logo-wrap">
-        <img src="./favicon.svg" alt="DeclaRenta" class="splash-logo" width="120" height="120" />
+        <img src="./logo.png" alt="DeclaRenta" class="splash-logo" width="120" height="120" />
         <div class="splash-logo-glow" aria-hidden="true"></div>
       </div>
       <h1 class="splash-title">Decla<span class="brand-accent">Renta</span></h1>
@@ -54,7 +54,7 @@
   <nav class="top-bar" data-i18n-aria="a11y.nav_label" aria-label="Ajustes">
     <div class="top-bar-brand">
       <button class="sidebar-toggle" id="sidebar-toggle" data-i18n-aria="sidebar.toggle" aria-label="Abrir/cerrar menú">&#9776;</button>
-      <img src="./favicon.svg" alt="DeclaRenta" class="brand-logo" width="36" height="36" />
+      <img src="./logo.png" alt="DeclaRenta" class="brand-logo" width="36" height="36" />
       <h1>Decla<span class="brand-accent">Renta</span></h1>
     </div>
     <div class="top-bar-actions">


### PR DESCRIPTION
## Summary
- Splash screen and top-bar were incorrectly using `favicon.svg` (small angry bull icon) instead of `logo.png` (full realistic bull). Fixed both references.
- Added hard traces in AGENTS.md documenting:
  - FOP/FSFOP asset category handling (futures options on MEFF)
  - FX phantom gains from missing prior-year lots
  - Logo vs favicon distinction to prevent future regressions

## Test plan
- [ ] Verify splash screen shows the realistic bull logo (not the small icon)
- [ ] Verify top-bar brand logo shows the realistic bull
- [ ] Verify favicon in browser tab still shows the small icon
- [ ] TypeScript typecheck passes