### PR TITLE
feat(parsers): add Trading 212 CSV parser

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export { binanceParser } from "./parsers/binance.js";
 export { krakenParser } from "./parsers/kraken.js";
 export { revolutParser } from "./parsers/revolut.js";
 export { lightyearParser } from "./parsers/lightyear.js";
+export { trading212Parser } from "./parsers/trading212.js";
 export { detectBroker, getBroker, brokerParsers } from "./parsers/index.js";
 
 // CSV utilities

--- a/src/parsers/index.ts
+++ b/src/parsers/index.ts
@@ -17,6 +17,7 @@ import { krakenParser } from "./kraken.js";
 import { revolutParser } from "./revolut.js";
 import { lightyearParser } from "./lightyear.js";
 import { tradeRepublicParser } from "./trade-republic.js";
+import { trading212Parser } from "./trading212.js";
 
 /**
  * All registered broker parsers, checked in order for auto-detection.
@@ -31,6 +32,7 @@ export const brokerParsers: BrokerParser[] = [
   degiroParser,     // CSV with ISIN + quantity + price headers
   scalableParser,   // CSV with date;time;status;reference headers
   tradeRepublicParser, // CSV with transaction_id + asset_class + counterparty_name
+  trading212Parser, // CSV with Action + Time + No. of shares + Price / share
   binanceParser,    // CSV with Date(UTC),Pair,Side,Price headers
   coinbaseParser,   // CSV with Transaction Type + Spot Price headers
   krakenParser,     // CSV with txid + pair/ordertxid or refid/aclass headers

--- a/src/parsers/trading212.ts
+++ b/src/parsers/trading212.ts
@@ -1,0 +1,308 @@
+/**
+ * Trading 212 CSV parser.
+ *
+ * Parses Trading 212's "History → Transactions" CSV export into a normalized Statement.
+ * Trading 212 is a Bulgarian neobroker (FSC Bulgaria license) that does NOT
+ * report to AEAT — users must declare gains/dividends manually.
+ *
+ * CSV format (real export):
+ * Action,Time,ISIN,Ticker,Name,No. of shares,Price / share,Currency (Price / share),Exchange rate,Result,Currency (Result),Total,Currency (Total),Notes,ID
+ *
+ * Action types:
+ * - Market buy / Limit buy / Stop buy → BUY trade
+ * - Market sell / Limit sell / Stop sell → SELL trade
+ * - Dividend (Ordinary) / Dividend (Dividend) → cash transaction (dividend)
+ * - Dividend (Dividend tax) → cash transaction (Withholding Tax)
+ * - Interest on cash → cash transaction (interest)
+ * - Deposit / Withdrawal / Currency conversion / Card debit / Spending cashback → skipped
+ *
+ * Limitations:
+ * - No open positions in CSV — Modelo 720/D-6 cannot be generated from this alone.
+ * - Exchange rate column is Trading 212's own rate, not ECB — the FIFO engine fetches ECB rates independently.
+ * - Trading 212 is zero-commission (spread-based) — commission is always 0.
+ */
+
+import Decimal from "decimal.js";
+import type { BrokerParser, Statement } from "../types/broker.js";
+import type { Trade, CashTransaction } from "../types/ibkr.js";
+import { parseCsvLine, parseNumber, findColumn, stripBom } from "./csv-utils.js";
+
+// ---------------------------------------------------------------------------
+// Header detection
+// ---------------------------------------------------------------------------
+
+/** Trading 212 CSV required headers */
+const TRADING212_REQUIRED = ["action", "time", "isin", "ticker", "no. of shares", "price / share"];
+
+function isTrading212Csv(headerLine: string): boolean {
+  const lower = headerLine.toLowerCase();
+  return TRADING212_REQUIRED.every((h) => lower.includes(h));
+}
+
+// ---------------------------------------------------------------------------
+// Column resolution
+// ---------------------------------------------------------------------------
+
+interface Trading212Columns {
+  action: number;
+  time: number;
+  isin: number;
+  ticker: number;
+  name: number;
+  shares: number;
+  pricePerShare: number;
+  priceCurrency: number;
+  exchangeRate: number;
+  total: number;
+  totalCurrency: number;
+  id: number;
+}
+
+function resolveColumns(headers: string[]): Trading212Columns {
+  return {
+    action: findColumn(headers, ["action"]),
+    time: findColumn(headers, ["time"]),
+    isin: findColumn(headers, ["isin"]),
+    ticker: findColumn(headers, ["ticker"]),
+    name: findColumn(headers, ["name"]),
+    shares: findColumn(headers, ["no. of shares"]),
+    pricePerShare: findColumn(headers, ["price / share"]),
+    priceCurrency: findColumn(headers, ["currency (price / share)"]),
+    exchangeRate: findColumn(headers, ["exchange rate"]),
+    total: findColumn(headers, ["total"]),
+    totalCurrency: findColumn(headers, ["currency (total)"]),
+    id: findColumn(headers, ["id"]),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Date conversion
+// ---------------------------------------------------------------------------
+
+/** Convert "YYYY-MM-DD HH:MM:SS" to YYYYMMDD */
+function convertTrading212Date(dateStr: string): string {
+  const trimmed = dateStr.trim();
+  const match = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (match) return `${match[1]}${match[2]}${match[3]}`;
+  throw new Error(`Trading 212 CSV: formato de fecha no reconocido: "${trimmed}"`);
+}
+
+// ---------------------------------------------------------------------------
+// Action type classification
+// ---------------------------------------------------------------------------
+
+function isBuyAction(action: string): boolean {
+  return /buy/i.test(action);
+}
+
+function isSellAction(action: string): boolean {
+  return /sell/i.test(action);
+}
+
+function isDividendTaxAction(action: string): boolean {
+  return /dividend.*tax/i.test(action);
+}
+
+function isDividendAction(action: string): boolean {
+  return /dividend/i.test(action) && !isDividendTaxAction(action);
+}
+
+function isInterestAction(action: string): boolean {
+  return /interest on cash/i.test(action);
+}
+
+function isSkippedAction(action: string): boolean {
+  return /deposit|withdrawal|currency conversion|card debit|spending cashback/i.test(action);
+}
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+function parseTrading212Csv(lines: string[]): Statement {
+  const headers = parseCsvLine(lines[0]!, ",");
+  const cols = resolveColumns(headers);
+
+  if (cols.action < 0 || cols.time < 0) {
+    throw new Error("Trading 212 CSV: faltan columnas obligatorias (Action, Time)");
+  }
+
+  const trades: Trade[] = [];
+  const cashTransactions: CashTransaction[] = [];
+
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i]!.trim();
+    if (!line) continue;
+
+    const fields = parseCsvLine(line, ",");
+
+    const action = (fields[cols.action] ?? "").trim();
+    const timeRaw = (fields[cols.time] ?? "").trim();
+    const isin = (fields[cols.isin] ?? "").trim();
+    const ticker = (fields[cols.ticker] ?? "").trim();
+    const name = (fields[cols.name] ?? "").trim();
+    const sharesStr = parseNumber(fields[cols.shares] ?? "0");
+    const priceStr = parseNumber(fields[cols.pricePerShare] ?? "0");
+    const currency = (fields[cols.priceCurrency] ?? "").trim() || "EUR";
+    // Currency (Total) is authoritative for cash transaction amounts: in EUR-primary accounts
+    // the Total column holds the credited EUR amount, not the instrument's native currency.
+    const cashCurrency = (fields[cols.totalCurrency] ?? "").trim() || currency;
+    const totalStr = parseNumber(fields[cols.total] ?? "0");
+    const txId = (fields[cols.id] ?? "").trim();
+
+    if (!timeRaw) continue;
+    const tradeDate = convertTrading212Date(timeRaw);
+
+    if (isSkippedAction(action)) continue;
+
+    const uniqueId = txId || `${tradeDate}-${ticker || action}-${i}`;
+
+    // Withholding tax on dividend — must be checked before the generic dividend branch
+    if (isDividendTaxAction(action)) {
+      if (!ticker) continue;
+      const amountDec = new Decimal(totalStr).abs();
+      if (amountDec.isZero()) continue;
+
+      cashTransactions.push({
+        transactionID: `trading212-tax-${uniqueId}`,
+        accountId: "",
+        symbol: ticker,
+        description: `Withholding tax - ${ticker}`,
+        isin,
+        currency: cashCurrency,
+        dateTime: tradeDate,
+        settleDate: tradeDate,
+        amount: amountDec.neg().toString(),
+        fxRateToBase: "1",
+        type: "Withholding Tax",
+      });
+      continue;
+    }
+
+    // Dividends
+    if (isDividendAction(action)) {
+      if (!ticker) continue;
+      const amountDec = new Decimal(totalStr).abs();
+      if (amountDec.isZero()) continue;
+
+      cashTransactions.push({
+        transactionID: `trading212-div-${uniqueId}`,
+        accountId: "",
+        symbol: ticker,
+        description: `Dividend - ${ticker}`,
+        isin,
+        currency: cashCurrency,
+        dateTime: tradeDate,
+        settleDate: tradeDate,
+        amount: amountDec.toString(),
+        fxRateToBase: "1",
+        type: "Dividends",
+      });
+      continue;
+    }
+
+    // Interest on cash
+    if (isInterestAction(action)) {
+      const amountDec = new Decimal(totalStr).abs();
+      if (amountDec.isZero()) continue;
+
+      cashTransactions.push({
+        transactionID: `trading212-interest-${uniqueId}`,
+        accountId: "",
+        symbol: "CASH",
+        description: "Interest on cash",
+        isin: "",
+        currency: cashCurrency,
+        dateTime: tradeDate,
+        settleDate: tradeDate,
+        amount: amountDec.toString(),
+        fxRateToBase: "1",
+        type: "Broker Interest Received",
+      });
+      continue;
+    }
+
+    // Buy / Sell trades
+    const buy = isBuyAction(action);
+    const sell = isSellAction(action);
+    if (!buy && !sell) continue;
+    if (!ticker) continue;
+
+    const qtyDec = new Decimal(sharesStr).abs();
+    if (qtyDec.isZero()) continue;
+
+    const priceDec = new Decimal(priceStr);
+    const grossDec = priceDec.isZero()
+      ? new Decimal(totalStr).abs()
+      : qtyDec.times(priceDec);
+
+    trades.push({
+      tradeID: `trading212-${buy ? "buy" : "sell"}-${uniqueId}`,
+      accountId: "",
+      symbol: ticker,
+      description: name || `${buy ? "Buy" : "Sell"} ${ticker}`,
+      isin,
+      assetCategory: "STK",
+      currency,
+      tradeDate,
+      settlementDate: tradeDate,
+      quantity: sell ? qtyDec.neg().toString() : qtyDec.toString(),
+      tradePrice: priceDec.toString(),
+      tradeMoney: sell ? grossDec.toString() : grossDec.neg().toString(),
+      proceeds: sell ? grossDec.toString() : "0",
+      cost: sell ? "0" : grossDec.neg().toString(),
+      fifoPnlRealized: "0",
+      fxRateToBase: "1",
+      buySell: sell ? "SELL" : "BUY",
+      openCloseIndicator: sell ? "C" : "O",
+      exchange: "TRADING212",
+      commissionCurrency: currency,
+      commission: "0",
+      taxes: "0",
+      multiplier: "1",
+    });
+  }
+
+  return {
+    accountId: "",
+    fromDate: "",
+    toDate: "",
+    period: "",
+    trades,
+    cashTransactions,
+    corporateActions: [],
+    openPositions: [],
+    securitiesInfo: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public BrokerParser
+// ---------------------------------------------------------------------------
+
+export const trading212Parser: BrokerParser = {
+  name: "Trading 212",
+  formats: ["CSV"],
+
+  detect(input: string): boolean {
+    const lines = stripBom(input).split(/\r?\n/);
+    return lines.slice(0, 10).some((l) => isTrading212Csv(l));
+  },
+
+  parse(input: string): Statement {
+    const cleaned = stripBom(input);
+    const allLines = cleaned.split(/\r?\n/);
+    const headerIdx = allLines.findIndex((l) => isTrading212Csv(l));
+    if (headerIdx === -1) {
+      const hasContent = allLines.some((l) => l.trim());
+      throw new Error(hasContent ? "Trading 212 CSV: formato no reconocido" : "Trading 212 CSV: fichero vacío o sin datos");
+    }
+    const lines = allLines.slice(headerIdx).filter((l) => l.trim());
+    if (lines.length < 2) {
+      throw new Error("Trading 212 CSV: fichero vacío o sin datos");
+    }
+
+    return parseTrading212Csv(lines);
+  },
+};
+

--- a/src/parsers/trading212.ts
+++ b/src/parsers/trading212.ts
@@ -232,8 +232,12 @@ function parseTrading212Csv(lines: string[]): Statement {
     if (qtyDec.isZero()) continue;
 
     const priceDec = new Decimal(priceStr);
+    const totalDec = new Decimal(totalStr).abs();
+    if (priceDec.isZero() && !totalDec.isZero() && cashCurrency !== currency) {
+      continue;
+    }
     const grossDec = priceDec.isZero()
-      ? new Decimal(totalStr).abs()
+      ? totalDec
       : qtyDec.times(priceDec);
 
     trades.push({

--- a/tests/fixtures/trading212-cash-sample.csv
+++ b/tests/fixtures/trading212-cash-sample.csv
@@ -1,0 +1,12 @@
+Action,Time,ISIN,Ticker,Name,Notes,ID,No. of shares,Price / share,Currency (Price / share),Exchange rate,Result,Currency (Result),Total,Currency (Total),Currency conversion fee,Currency (Currency conversion fee),Merchant name,Merchant category
+Deposit,2025-08-01 08:00:00,,,,Transaction ID: CASH-DEP-001,cash-001,,,,,,,500.00,EUR,,,,
+Interest on cash,2025-08-02 01:15:00,,,,Daily interest payment,int-001,,,,,,,0.07,EUR,,,,
+Interest on cash,2025-08-03 01:16:00,,,,Daily interest payment,int-002,,,,,,,0.07,EUR,,,,
+Spending cashback,2025-08-03 02:01:00,,,,Card cashback,cb-101,,,,,,,0.02,EUR,,,,
+Currency conversion,2025-08-03 10:05:00,,,,Manual FX conversion,fx-001,,,,,,,150.00,USD,0.23,EUR,,
+Interest on cash,2025-08-04 01:15:00,,,,Daily interest payment,int-003,,,,,,,0.06,EUR,,,,
+Withdrawal,2025-08-04 12:30:00,,,,Bank withdrawal,wd-001,,,,,,,-100.00,EUR,,,,
+Interest on cash,2025-08-05 01:15:00,,,,Daily interest payment,int-004,,,,,,,0.08,EUR,,,,
+Card debit,2025-08-05 18:42:21,,,,Card purchase,card-101,,,,,,,-18.45,EUR,,,CAFE DEL PORT,RETAIL_STORES
+Interest on cash,2025-08-06 01:15:00,,,,Daily interest payment,int-005,,,,,,,0.09,EUR,,,,
+

--- a/tests/fixtures/trading212-dividends-sample.csv
+++ b/tests/fixtures/trading212-dividends-sample.csv
@@ -1,0 +1,14 @@
+Action,Time,ISIN,Ticker,Name,Notes,ID,No. of shares,Price / share,Currency (Price / share),Exchange rate,Result,Currency (Result),Total,Currency (Total),Currency conversion fee,Currency (Currency conversion fee),Merchant name,Merchant category
+Market buy,2025-01-10 09:00:00,XX0000000101,ORIO,"Orion Foods Inc",,div-ord-001,18.0000000000,41.2000000000,USD,1.09115000,,,679.35,EUR,0.10,EUR,,
+Dividend (Ordinary),2025-03-15 00:00:00,XX0000000101,ORIO,"Orion Foods Inc",Quarterly cash dividend,div-001,,,USD,1.08650000,,,9.71,USD,,USD,,
+Dividend (Dividend tax),2025-03-15 00:00:00,XX0000000101,ORIO,"Orion Foods Inc",US withholding tax,divtax-001,,,USD,1.08650000,,,-1.46,USD,,USD,,
+Market buy,2025-02-12 09:30:00,XX0000000102,NOVA,"Nova Medical Devices SA",,div-ord-002,25.0000000000,12.8000000000,EUR,1.00000000,,,320.00,EUR,,EUR,,
+Dividend (Ordinary),2025-04-03 00:00:00,XX0000000102,NOVA,"Nova Medical Devices SA",Semi-annual dividend (no WHT),div-002,,,EUR,1.00000000,,,5.50,EUR,,EUR,,
+Market buy,2025-02-20 15:45:17,XX0000000103,HELI,"Helios Industrials AG",,div-ord-003,14.4000000000,28.5000000000,EUR,1.00000000,,,410.40,EUR,,EUR,,
+Dividend (Ordinary),2025-05-08 00:00:00,XX0000000103,HELI,"Helios Industrials AG",German source dividend,div-003,,,EUR,1.00000000,,,11.20,EUR,,EUR,,
+Dividend (Dividend tax),2025-05-08 00:00:00,XX0000000103,HELI,"Helios Industrials AG",German withholding tax,divtax-003,,,EUR,1.00000000,,,-2.95,EUR,,EUR,,
+Market buy,2025-03-18 13:05:44,XX0000000104,VEGA,"Vega Retail Holdings",,div-ord-004,3.7500000000,96.0000000000,USD,1.08250000,,,332.56,EUR,0.05,EUR,,
+Dividend (Ordinary),2025-06-20 00:00:00,XX0000000104,VEGA,"Vega Retail Holdings",Fractional-share dividend,div-004,,,USD,1.07840000,,,1.53,USD,,USD,,
+Dividend (Dividend tax),2025-06-20 00:00:00,XX0000000104,VEGA,"Vega Retail Holdings",US withholding tax,divtax-004,,,USD,1.07840000,,,-0.23,USD,,USD,,
+Dividend (Ordinary),2025-07-05 00:00:00,XX0000000101,ORIO,"Orion Foods Inc",Special dividend no WHT,div-005,,,USD,1.07150000,,,12.98,USD,,USD,,
+

--- a/tests/fixtures/trading212-extended-sample.csv
+++ b/tests/fixtures/trading212-extended-sample.csv
@@ -1,0 +1,12 @@
+Action,Time,ISIN,Ticker,Name,Notes,ID,No. of shares,Price / share,Currency (Price / share),Exchange rate,Result,Currency (Result),Total,Currency (Total),Currency conversion fee,Currency (Currency conversion fee),Merchant name,Merchant category
+Market buy,2025-09-01 09:00:00,XX0000000201,QUOT,"Quoted ""Special"" Holdings, Inc.",,edge-001,1.2500000000,80.0000000000,USD,1.11250000,,,89.89,EUR,0.01,EUR,,
+Market sell,2025-09-02 09:05:00,XX0000000201,QUOT,"Quoted ""Special"" Holdings, Inc.",,edge-002,0.5000000000,82.4000000000,USD,1.11020000,0.79,EUR,37.11,EUR,0.01,EUR,,
+Market sell,2025-09-02 16:41:00,XX0000000201,QUOT,"Quoted ""Special"" Holdings, Inc.",Partial close,edge-003,0.7500000000,81.8000000000,USD,1.10940000,0.92,EUR,55.29,EUR,,EUR,,
+Limit buy,2025-09-08 10:11:18,XX0000000202,MICR,"Micro Grid Networks",,edge-004,0.1234567890,19.7500000000,EUR,1.00000000,,,2.44,EUR,,EUR,,
+Limit sell,2025-09-09 15:59:59,XX0000000202,MICR,"Micro Grid Networks",,edge-005,0.1234567890,20.1000000000,EUR,1.00000000,0.04,EUR,2.48,EUR,,EUR,,
+Stop buy,2025-09-20 09:00:00,XX0000000204,NORD,"Nordic Air Logistics",,edge-006,6.0000000000,14.2500000000,USD,1.09700000,,,77.94,EUR,0.01,EUR,,
+Stop sell,2025-09-24 13:37:42,XX0000000204,NORD,"Nordic Air Logistics",,edge-007,6.0000000000,13.9500000000,USD,1.10400000,-2.55,EUR,75.82,EUR,0.01,EUR,,
+Dividend (Ordinary),2025-09-15 00:00:00,XX0000000203,PAIR,"Paired Income Trust",Ordinary dividend,,,,USD,1.10100000,,,3.93,USD,,USD,,
+Dividend (Dividend tax),2025-09-15 00:00:00,XX0000000203,PAIR,"Paired Income Trust",Dividend tax with blank ID,,,,USD,1.10100000,,,-0.59,USD,,USD,,
+Interest on cash,2025-09-16 01:15:00,,,,Rounded carry release,,,,,,,,0.01,EUR,,,,
+

--- a/tests/fixtures/trading212-sample.csv
+++ b/tests/fixtures/trading212-sample.csv
@@ -1,0 +1,21 @@
+Action,Time,ISIN,Ticker,Name,No. of shares,Price / share,Currency (Price / share),Exchange rate,Result,Currency (Result),Total,Currency (Total),Notes,ID
+Market buy,2024-01-15 09:30:00,US0378331005,AAPL,Apple Inc,10,185.50,USD,0.92,,,1706.60,EUR,,trade001
+Market buy,2024-02-10 10:15:00,US5949181045,MSFT,Microsoft Corp,5,415.00,USD,0.93,,,1929.75,EUR,,trade002
+Market sell,2024-06-20 14:22:00,US0378331005,AAPL,Apple Inc,10,210.30,USD,0.93,283.00,USD,1955.79,EUR,,trade003
+Limit buy,2024-03-05 11:00:00,IE00B4L5Y983,IWDA,iShares Core MSCI World ETF,3,95.20,EUR,1.00,,,285.60,EUR,,trade004
+Limit sell,2024-09-12 15:30:00,IE00B4L5Y983,IWDA,iShares Core MSCI World ETF,3,102.50,EUR,1.00,21.90,EUR,307.50,EUR,,trade005
+Stop buy,2024-04-10 09:00:00,XX0000000301,DELT,Delta Pharma Inc,2.5,48.00,USD,0.92,,,110.40,EUR,,trade006
+Stop sell,2024-05-15 16:00:00,XX0000000301,DELT,Delta Pharma Inc,2.5,51.20,USD,0.93,8.00,USD,134.18,EUR,,trade007
+Market buy,2024-07-01 09:15:00,XX0000000302,ECHO,"Echo Digital, Inc.",1.75,120.00,USD,0.92,,,193.04,EUR,,trade008
+Market buy,2024-08-20 14:00:00,XX0000000302,ECHO,"Echo Digital, Inc.",0.50,118.50,USD,0.93,,,55.11,EUR,,
+Dividend (Ordinary),2024-03-15 00:00:00,US0378331005,AAPL,Apple Inc,,,USD,0.92,,,2.35,USD,,div001
+Dividend (Dividend tax),2024-03-15 00:00:00,US0378331005,AAPL,Apple Inc,,,USD,0.92,,,-0.47,USD,,divtax001
+Dividend (Ordinary),2024-06-15 00:00:00,US5949181045,MSFT,Microsoft Corp,,,USD,0.93,,,3.12,USD,,div002
+Dividend (Ordinary),2024-09-15 00:00:00,US0378331005,AAPL,Apple Inc,,,USD,0.91,,,2.50,USD,,div003
+Dividend (Dividend tax),2024-09-15 00:00:00,US0378331005,AAPL,Apple Inc,,,USD,0.91,,,-0.50,USD,,divtax003
+Interest on cash,2024-01-31 00:00:00,,,,,,,1.00,,,0.48,EUR,,int001
+Interest on cash,2024-02-29 00:00:00,,,,,,,1.00,,,0.37,EUR,,int002
+Deposit,2024-01-10 08:00:00,,,,,,,1.00,,,1000.00,EUR,,dep001
+Withdrawal,2024-12-01 09:00:00,,,,,,,1.00,,,-500.00,EUR,,wit001
+Currency conversion,2024-04-01 10:00:00,,,,,,USD,0.92,,,460.00,USD,,conv001
+

--- a/tests/fixtures/trading212-v2-sample.csv
+++ b/tests/fixtures/trading212-v2-sample.csv
@@ -1,0 +1,22 @@
+Action,Time,ISIN,Ticker,Name,Notes,ID,No. of shares,Price / share,Currency (Price / share),Exchange rate,Result,Currency (Result),Total,Currency (Total),Currency conversion fee,Currency (Currency conversion fee),Merchant name,Merchant category
+Spending cashback,2025-04-30 01:07:59,,,,,cb-001,,,,,,,0.41,EUR,,,,
+Card debit,2025-04-30 07:11:18,,,,,card-001,,,,,,,-32.79,EUR,,,Grover Group GmbH,BUSINESS_SERVICES
+Card debit,2025-04-30 08:56:51,,,,,card-002,,,,,,,-10.19,EUR,,,CORP ALIM GUISSONA T44,RETAIL_STORES
+Interest on cash,2025-04-30 01:15:00,,,,Daily interest,int-v2-001,,,,,,,0.11,EUR,,,,
+Deposit,2025-05-05 07:34:12,,,,Transaction ID: DEP-001,dep-001,,,,,,,34.00,EUR,,,,
+Market buy,2025-05-05 08:00:00,XX0000000001,ALFA,"Alpha Battery Systems",,ord-001,30.9760400000,1.2400000000,USD,1.13137819,,,34.00,EUR,0.05,EUR,,
+Market sell,2025-05-06 17:57:46,XX0000000001,ALFA,"Alpha Battery Systems",,ord-002,30.9760400000,1.0800000000,USD,1.13634929,-4.51,EUR,29.40,EUR,0.04,EUR,,
+Card debit,2025-05-06 18:07:51,,,,,card-003,,,,,,,-22.99,EUR,,,APPLE.COM/BILL,MISCELLANEOUS
+Spending cashback,2025-05-08 01:09:49,,,,,cb-002,,,,,,,0.12,EUR,,,,
+Deposit,2025-05-23 08:20:13,,,,Transaction ID: DEP-002,dep-002,,,,,,,131.00,EUR,,,,
+Market buy,2025-05-23 08:27:53,XX0000000001,ALFA,"Alpha Battery Systems",,ord-003,126.7577700000,1.1700000000,USD,1.13384243,,,131.00,EUR,0.20,EUR,,
+Market sell,2025-05-27 08:00:29,XX0000000001,ALFA,"Alpha Battery Systems",,ord-004,28.3955800000,1.2000000000,USD,1.13393331,0.75,EUR,30.00,EUR,0.05,EUR,,
+Limit buy,2025-06-03 10:15:11,XX0000000002,BRAV,"Bravo Water Utilities",,ord-005,12.5000000000,48.0000000000,EUR,1.00000000,,,600.00,EUR,,EUR,,
+Limit sell,2025-06-10 14:46:42,XX0000000002,BRAV,"Bravo Water Utilities",,ord-006,4.0000000000,51.5000000000,EUR,1.00000000,14.00,EUR,206.00,EUR,,EUR,,
+Card debit,2025-06-11 09:12:02,,,,,card-004,,,,,,,-4.40,EUR,,,SUPERMERCADO ST ESTEVE,RETAIL_STORES
+Interest on cash,2025-06-11 01:15:00,,,,Daily interest,int-v2-002,,,,,,,0.09,EUR,,,,
+Deposit,2025-06-12 07:00:00,,,,Transaction ID: DEP-003,dep-003,,,,,,,200.00,EUR,,,,
+Stop buy,2025-06-12 09:00:00,XX0000000003,CYGN,"Cygnus Robotics PLC",,ord-007,8.2500000000,22.0000000000,USD,1.14968152,,,158.00,EUR,0.24,EUR,,
+Stop sell,2025-06-18 16:31:10,XX0000000003,CYGN,"Cygnus Robotics PLC",,ord-008,3.0000000000,24.3000000000,USD,1.15284810,7.05,EUR,63.23,EUR,0.10,EUR,,
+Limit sell,2025-06-20 09:30:00,XX0000000002,BRAV,"Bravo Water Utilities",,ord-009,4.0000000000,52.0000000000,EUR,1.00000000,16.00,EUR,208.00,EUR,,EUR,,
+

--- a/tests/parsers/trading212.test.ts
+++ b/tests/parsers/trading212.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { trading212Parser } from "../../src/parsers/trading212.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const HEADER = "Action,Time,ISIN,Ticker,Name,No. of shares,Price / share,Currency (Price / share),Exchange rate,Result,Currency (Result),Total,Currency (Total),Notes,ID";
+
+const TRADING212_CSV = [
+  HEADER,
+  "Market buy,2024-01-15 09:30:00,US0378331005,AAPL,Apple Inc,10,185.50,USD,0.92,,,1706.60,EUR,,trade001",
+  "Market buy,2024-02-10 10:15:00,US5949181045,MSFT,Microsoft Corp,5,415.00,USD,0.93,,,1929.75,EUR,,trade002",
+  "Market sell,2024-06-20 14:22:00,US0378331005,AAPL,Apple Inc,10,210.30,USD,0.93,283.00,USD,1955.79,EUR,,trade003",
+  "Limit buy,2024-03-05 11:00:00,IE00B4L5Y983,IWDA,iShares Core MSCI World ETF,3,95.20,EUR,1.00,,,285.60,EUR,,trade004",
+  "Limit sell,2024-09-12 15:30:00,IE00B4L5Y983,IWDA,iShares Core MSCI World ETF,3,102.50,EUR,1.00,21.90,EUR,307.50,EUR,,trade005",
+  "Dividend (Ordinary),2024-03-15 00:00:00,US0378331005,AAPL,Apple Inc,,,USD,0.92,,,2.35,USD,,div001",
+  "Dividend (Dividend tax),2024-03-15 00:00:00,US0378331005,AAPL,Apple Inc,,,USD,0.92,,,-0.47,USD,,divtax001",
+  "Dividend (Ordinary),2024-06-15 00:00:00,US5949181045,MSFT,Microsoft Corp,,,USD,0.93,,,3.12,USD,,div002",
+  "Interest on cash,2024-01-31 00:00:00,,,,,,,1.00,,,0.48,EUR,,int001",
+  "Deposit,2024-01-10 08:00:00,,,,,,,1.00,,,1000.00,EUR,,dep001",
+  "Withdrawal,2024-12-01 09:00:00,,,,,,,1.00,,,-500.00,EUR,,wit001",
+  "Currency conversion,2024-04-01 10:00:00,,,,,,USD,0.92,,,460.00,USD,,conv001",
+].join("\n");
+
+const TRADING212_CSV_BOM = "﻿" + TRADING212_CSV;
+
+const TRADING212_FIXTURE = readFileSync(
+  new URL("../fixtures/trading212-sample.csv", import.meta.url),
+  "utf-8",
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("trading212Parser", () => {
+  // -------------------------------------------------------------------------
+  // Detection
+  // -------------------------------------------------------------------------
+
+  describe("detect", () => {
+    it("should detect Trading 212 CSV by header", () => {
+      expect(trading212Parser.detect(TRADING212_CSV)).toBe(true);
+    });
+
+    it("should detect CSV with BOM", () => {
+      expect(trading212Parser.detect(TRADING212_CSV_BOM)).toBe(true);
+    });
+
+    it("should not detect IBKR XML", () => {
+      expect(trading212Parser.detect("<FlexQueryResponse>")).toBe(false);
+    });
+
+    it("should not detect Lightyear CSV", () => {
+      expect(
+        trading212Parser.detect("Date,Reference,Ticker,ISIN,Type,Quantity,CCY,Price/share,Gross Amount"),
+      ).toBe(false);
+    });
+
+    it("should not detect Degiro CSV", () => {
+      expect(
+        trading212Parser.detect("Fecha,Hora,Producto,ISIN,Bolsa,Cantidad,Precio"),
+      ).toBe(false);
+    });
+
+    it("should not detect random text", () => {
+      expect(trading212Parser.detect("hello world")).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error handling
+  // -------------------------------------------------------------------------
+
+  describe("error handling", () => {
+    it("should throw on empty input", () => {
+      expect(() => trading212Parser.parse("")).toThrow(/vacío/);
+    });
+
+    it("should throw on header-only input", () => {
+      expect(() => trading212Parser.parse(HEADER)).toThrow(/vacío/);
+    });
+
+    it("should throw on unrecognized format", () => {
+      expect(() => trading212Parser.parse("Column1,Column2\nval1,val2")).toThrow(/formato/);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Buy trades
+  // -------------------------------------------------------------------------
+
+  describe("parse buy trades", () => {
+    it("should parse a Market buy (AAPL)", () => {
+      const result = trading212Parser.parse(TRADING212_CSV);
+      const buys = result.trades.filter((t) => t.buySell === "BUY" && t.symbol === "AAPL");
+      expect(buys).toHaveLength(1);
+
+      const buy = buys[0]!;
+      expect(buy.symbol).toBe("AAPL");
+      expect(buy.isin).toBe("US0378331005");
+      expect(buy.assetCategory).toBe("STK");
+      expect(buy.currency).toBe("USD");
+      expect(buy.tradeDate).toBe("20240115");
+      expect(buy.quantity).toBe("10");
+      expect(buy.tradePrice).toBe("185.5");
+      expect(buy.cost).toBe("-1855");
+      expect(buy.commission).toBe("0");
+      expect(buy.exchange).toBe("TRADING212");
+      expect(buy.openCloseIndicator).toBe("O");
+    });
+
+    it("should parse a Limit buy (IWDA in EUR)", () => {
+      const result = trading212Parser.parse(TRADING212_CSV);
+      const buys = result.trades.filter((t) => t.buySell === "BUY" && t.symbol === "IWDA");
+      expect(buys).toHaveLength(1);
+
+      const buy = buys[0]!;
+      expect(buy.isin).toBe("IE00B4L5Y983");
+      expect(buy.currency).toBe("EUR");
+      expect(buy.tradeDate).toBe("20240305");
+      expect(buy.quantity).toBe("3");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Sell trades
+  // -------------------------------------------------------------------------
+
+  describe("parse sell trades", () => {
+    it("should parse a Market sell (AAPL)", () => {
+      const result = trading212Parser.parse(TRADING212_CSV);
+      const sells = result.trades.filter((t) => t.buySell === "SELL" && t.symbol === "AAPL");
+      expect(sells).toHaveLength(1);
+
+      const sell = sells[0]!;
+      expect(sell.symbol).toBe("AAPL");
+      expect(sell.tradeDate).toBe("20240620");
+      expect(parseFloat(sell.quantity)).toBeLessThan(0);
+      expect(sell.proceeds).toBe("2103");
+      expect(sell.openCloseIndicator).toBe("C");
+    });
+
+    it("should parse a Limit sell (IWDA)", () => {
+      const result = trading212Parser.parse(TRADING212_CSV);
+      const sells = result.trades.filter((t) => t.buySell === "SELL" && t.symbol === "IWDA");
+      expect(sells).toHaveLength(1);
+
+      const sell = sells[0]!;
+      expect(sell.tradeDate).toBe("20240912");
+      expect(sell.quantity).toBe("-3");
+      expect(sell.proceeds).toBe("307.5");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Dividends
+  // -------------------------------------------------------------------------
+
+  describe("parse dividends", () => {
+    it("should parse Dividend rows as cash transactions", () => {
+      const result = trading212Parser.parse(TRADING212_CSV);
+      const divs = result.cashTransactions.filter((c) => c.type === "Dividends");
+      expect(divs).toHaveLength(2);
+    });
+
+    it("should parse AAPL dividend correctly", () => {
+      const result = trading212Parser.parse(TRADING212_CSV);
+      const div = result.cashTransactions.find((c) => c.symbol === "AAPL" && c.type === "Dividends");
+      expect(div).toBeDefined();
+      expect(div!.amount).toBe("2.35");
+      expect(div!.currency).toBe("USD");
+      expect(div!.isin).toBe("US0378331005");
+      expect(div!.dateTime).toBe("20240315");
+    });
+
+    it("should parse MSFT dividend correctly", () => {
+      const result = trading212Parser.parse(TRADING212_CSV);
+      const div = result.cashTransactions.find((c) => c.symbol === "MSFT" && c.type === "Dividends");
+      expect(div).toBeDefined();
+      expect(div!.amount).toBe("3.12");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Withholding tax
+  // -------------------------------------------------------------------------
+
+  describe("parse withholding tax", () => {
+    it("should parse Dividend (Dividend tax) as Withholding Tax", () => {
+      const result = trading212Parser.parse(TRADING212_CSV);
+      const wht = result.cashTransactions.filter((c) => c.type === "Withholding Tax");
+      expect(wht).toHaveLength(1);
+    });
+
+    it("should parse AAPL withholding correctly", () => {
+      const result = trading212Parser.parse(TRADING212_CSV);
+      const wht = result.cashTransactions.find((c) => c.type === "Withholding Tax");
+      expect(wht).toBeDefined();
+      expect(wht!.symbol).toBe("AAPL");
+      expect(wht!.isin).toBe("US0378331005");
+      expect(wht!.currency).toBe("USD");
+      expect(wht!.dateTime).toBe("20240315");
+      expect(parseFloat(wht!.amount)).toBeLessThan(0);
+      expect(wht!.amount).toBe("-0.47");
+    });
+
+    it("should not classify Dividend (Dividend tax) as a regular dividend", () => {
+      const result = trading212Parser.parse(TRADING212_CSV);
+      const divs = result.cashTransactions.filter(
+        (c) => c.type === "Dividends" && c.symbol === "AAPL",
+      );
+      expect(divs).toHaveLength(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Interest on cash
+  // -------------------------------------------------------------------------
+
+  describe("parse interest", () => {
+    it("should parse Interest on cash as cash transaction", () => {
+      const result = trading212Parser.parse(TRADING212_CSV);
+      const interest = result.cashTransactions.find((c) => c.type === "Broker Interest Received");
+      expect(interest).toBeDefined();
+      expect(interest!.amount).toBe("0.48");
+      expect(interest!.currency).toBe("EUR");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Skipped transaction types
+  // -------------------------------------------------------------------------
+
+  describe("skip non-taxable transactions", () => {
+    it("should skip Deposit rows", () => {
+      const result = trading212Parser.parse(TRADING212_CSV);
+      const allIds = [...result.trades.map((t) => t.tradeID), ...result.cashTransactions.map((c) => c.transactionID)];
+      expect(allIds.some((id) => id.toLowerCase().includes("dep001"))).toBe(false);
+    });
+
+    it("should skip Withdrawal rows", () => {
+      const result = trading212Parser.parse(TRADING212_CSV);
+      const allIds = [...result.trades.map((t) => t.tradeID), ...result.cashTransactions.map((c) => c.transactionID)];
+      expect(allIds.some((id) => id.toLowerCase().includes("wit001"))).toBe(false);
+    });
+
+    it("should skip Currency conversion rows", () => {
+      const result = trading212Parser.parse(TRADING212_CSV);
+      const allIds = [...result.trades.map((t) => t.tradeID), ...result.cashTransactions.map((c) => c.transactionID)];
+      expect(allIds.some((id) => id.toLowerCase().includes("conv001"))).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Trade counts
+  // -------------------------------------------------------------------------
+
+  describe("overall counts", () => {
+    it("should produce correct number of trades", () => {
+      const result = trading212Parser.parse(TRADING212_CSV);
+      // AAPL buy, MSFT buy, AAPL sell, IWDA buy, IWDA sell = 5
+      expect(result.trades).toHaveLength(5);
+    });
+
+    it("should produce correct number of cash transactions", () => {
+      const result = trading212Parser.parse(TRADING212_CSV);
+      // AAPL div, AAPL withholding, MSFT div, interest = 4
+      expect(result.cashTransactions).toHaveLength(4);
+    });
+
+    it("should return empty arrays for non-applicable fields", () => {
+      const result = trading212Parser.parse(TRADING212_CSV);
+      expect(result.corporateActions).toEqual([]);
+      expect(result.openPositions).toEqual([]);
+      expect(result.securitiesInfo).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Date parsing
+  // -------------------------------------------------------------------------
+
+  describe("date parsing", () => {
+    it("should convert YYYY-MM-DD HH:MM:SS to YYYYMMDD", () => {
+      const result = trading212Parser.parse(TRADING212_CSV);
+      const buy = result.trades.find((t) => t.symbol === "AAPL" && t.buySell === "BUY");
+      expect(buy!.tradeDate).toBe("20240115");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // fxRateToBase
+  // -------------------------------------------------------------------------
+
+  describe("fx rate", () => {
+    it("should set fxRateToBase to '1' (ECB fetched independently)", () => {
+      const result = trading212Parser.parse(TRADING212_CSV);
+      result.trades.forEach((t) => { expect(t.fxRateToBase).toBe("1"); });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Real fixture (trading212-sample.csv)
+  // -------------------------------------------------------------------------
+
+  describe("real fixture (trading212-sample.csv)", () => {
+    it("should detect", () => {
+      expect(trading212Parser.detect(TRADING212_FIXTURE)).toBe(true);
+    });
+
+    it("should parse 9 trades, 3 dividends, 2 WHTs, 2 interests", () => {
+      const result = trading212Parser.parse(TRADING212_FIXTURE);
+      expect(result.trades).toHaveLength(9);
+      const divs = result.cashTransactions.filter((t) => t.type === "Dividends");
+      const whts = result.cashTransactions.filter((t) => t.type === "Withholding Tax");
+      const interest = result.cashTransactions.filter((t) => t.type === "Broker Interest Received");
+      expect(divs).toHaveLength(3);
+      expect(whts).toHaveLength(2);
+      expect(interest).toHaveLength(2);
+    });
+
+    it("should handle quoted company name with comma (Echo Digital, Inc.)", () => {
+      const result = trading212Parser.parse(TRADING212_FIXTURE);
+      const echo = result.trades.filter((t) => t.symbol === "ECHO");
+      expect(echo).toHaveLength(2);
+      expect(echo[0]!.description).toContain("Echo Digital");
+    });
+
+    it("should handle fractional quantities and blank ID", () => {
+      const result = trading212Parser.parse(TRADING212_FIXTURE);
+      const fractional = result.trades.find((t) => t.symbol === "ECHO" && t.quantity === "0.5");
+      expect(fractional).toBeDefined();
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- Adds Trading 212 CSV parser (11th broker!) contributed by @AlexAlves87
- Supports buy/sell trades (Market, Limit, Stop), dividends, withholding tax, and interest on cash
- Handles both 15-col and 19-col header variants, fractional shares, quoted fields with commas, BOM
- Hardened dividend regex to prevent accidental double-counting of withholding tax as dividend
- Registered in `brokerParsers` and exported from public API

## Credits
Cherry-picked from #145 (closed due to git history rewrite incompatibility). All parser code authored by @AlexAlves87.

## Test plan
- [x] 32 unit tests pass (detection, error handling, buy/sell, dividends, WHT, interest, skipped rows, counts, dates, fixtures)
- [x] Full test suite: 947/947 pass
- [x] TypeScript typecheck clean
- [x] Security review: no vulnerabilities
- [x] Tax correctness review: WHT sign, fxRateToBase, currency handling all correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Trading 212 CSV imports with automatic format detection
  * Parses trades (buy/sell), dividends, interest payments, and withholding tax from Trading 212 exports
  * Seamlessly integrates with auto-detection system for streamlined import workflow

* **Tests**
  * Added comprehensive test coverage for Trading 212 parser including edge cases and fixture validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->