### PR TITLE
fix(engine): reduce false warnings for CMDTY, option exercises, and FX lots

### DIFF
--- a/src/engine/fifo.ts
+++ b/src/engine/fifo.ts
@@ -47,17 +47,22 @@ export class FifoEngine {
     // Process securities: STK, FUND, OPT, FUT, BOND, CFD, CRYPTO, CMDTY
     // Excluded: WAR (warrants — insufficient data), CASH (FX conversions —
     // gain/loss already embedded in securities trades via ECB rate conversion)
-    const hasOptionExercises = (optionExercises ?? []).length > 0;
+    const optionEaeKeys = new Set(
+      (optionExercises ?? []).map((ex) => ex.conid ? `conid:${ex.conid}` : ex.symbol),
+    );
     const sorted = [...trades]
       .filter((t) => {
         if (!KNOWN_CATEGORIES.has(t.assetCategory)) {
           this.warnings.push(`⚠ Categoría de activo desconocida: "${t.assetCategory}" para ${t.symbol}. Se procesará con FIFO genérico.`);
         }
-        // Skip option BookTrades for exercises/expirations when OptionEAE data is present
+        // Skip option BookTrades for exercises/expirations only when a matching OptionEAE exists
         // (IBKR generates both a BookTrade with notes="Ep"/"Ex" and an OptionEAE event)
-        if (hasOptionExercises && (t.assetCategory === "OPT" || t.assetCategory === "FOP" || t.assetCategory === "FSFOP")) {
+        if (optionEaeKeys.size > 0 && (t.assetCategory === "OPT" || t.assetCategory === "FOP" || t.assetCategory === "FSFOP")) {
           const notes = (t.notes || "").split(";");
-          if (notes.includes("Ep") || notes.includes("Ex")) return false;
+          if (notes.includes("Ep") || notes.includes("Ex")) {
+            const tradeKey = t.conid ? `conid:${t.conid}` : t.symbol;
+            if (optionEaeKeys.has(tradeKey)) return false;
+          }
         }
         return t.assetCategory !== "WAR" && t.assetCategory !== "CASH";
       })

--- a/src/engine/fifo.ts
+++ b/src/engine/fifo.ts
@@ -14,7 +14,7 @@ import { getEcbRate } from "./ecb.js";
 import { daysBetween, normalizeDate } from "./dates.js";
 
 /** Known asset categories — warn on unknown values to catch future IBKR additions */
-const KNOWN_CATEGORIES: ReadonlySet<string> = new Set(["STK", "OPT", "FUT", "FOP", "FSFOP", "CASH", "BOND", "FUND", "WAR", "CRYPTO", "CFD"]);
+const KNOWN_CATEGORIES: ReadonlySet<string> = new Set(["STK", "OPT", "FUT", "FOP", "FSFOP", "CASH", "BOND", "FUND", "WAR", "CRYPTO", "CFD", "CMDTY"]);
 
 /** Lot grouping key: ISIN when available; conid for IBKR instruments without ISIN (survives ticker renames); otherwise asset category + symbol */
 function lotKey(trade: { isin: string; symbol: string; assetCategory: string; conid?: string }): string {
@@ -44,13 +44,20 @@ export class FifoEngine {
     corporateActions?: CorporateAction[],
     optionExercises?: OptionExercise[],
   ): FifoDisposal[] {
-    // Process securities: STK, FUND, OPT, FUT, BOND, CFD, CRYPTO
+    // Process securities: STK, FUND, OPT, FUT, BOND, CFD, CRYPTO, CMDTY
     // Excluded: WAR (warrants — insufficient data), CASH (FX conversions —
     // gain/loss already embedded in securities trades via ECB rate conversion)
+    const hasOptionExercises = (optionExercises ?? []).length > 0;
     const sorted = [...trades]
       .filter((t) => {
         if (!KNOWN_CATEGORIES.has(t.assetCategory)) {
           this.warnings.push(`⚠ Categoría de activo desconocida: "${t.assetCategory}" para ${t.symbol}. Se procesará con FIFO genérico.`);
+        }
+        // Skip option BookTrades for exercises/expirations when OptionEAE data is present
+        // (IBKR generates both a BookTrade with notes="Ep"/"Ex" and an OptionEAE event)
+        if (hasOptionExercises && (t.assetCategory === "OPT" || t.assetCategory === "FOP" || t.assetCategory === "FSFOP")) {
+          const notes = (t.notes || "").split(";");
+          if (notes.includes("Ep") || notes.includes("Ex")) return false;
         }
         return t.assetCategory !== "WAR" && t.assetCategory !== "CASH";
       })

--- a/src/engine/fx-fifo.ts
+++ b/src/engine/fx-fifo.ts
@@ -28,6 +28,7 @@ export class FxFifoEngine {
   private disposals: FxDisposal[] = [];
   private nextLotId = 1;
   warnings: string[] = [];
+  private fxMissing: Map<string, { count: number; totalQty: Decimal }> = new Map();
 
   /**
    * Process FX events extracted from trades.
@@ -35,7 +36,14 @@ export class FxFifoEngine {
    * (not automatic FXCONV) generate FX lots and disposals.
    */
   processEvents(events: FxEvent[]): FxDisposal[] {
-    const sorted = [...events].sort((a, b) => a.date.localeCompare(b.date));
+    const sorted = [...events].sort((a, b) => {
+      const cmp = a.date.localeCompare(b.date);
+      if (cmp !== 0) return cmp;
+      // Same date: acquisitions (positive qty) before disposals (negative qty)
+      const aPhase = a.quantity.greaterThan(0) ? 0 : 1;
+      const bPhase = b.quantity.greaterThan(0) ? 0 : 1;
+      return aPhase - bPhase;
+    });
 
     for (const event of sorted) {
       if (event.currency === "EUR") continue;
@@ -45,6 +53,10 @@ export class FxFifoEngine {
       } else if (event.quantity.lessThan(0)) {
         this.consumeLots(event);
       }
+    }
+
+    for (const [currency, { count, totalQty }] of this.fxMissing) {
+      this.warnings.push(`⚠ ${count} disposiciones de ${currency} sin lotes previos suficientes (total: ${totalQty.toFixed(2)} ${currency}). Posible adquisición anterior al período declarado — ganancia FX asumida = 0.`);
     }
 
     return this.disposals;
@@ -258,7 +270,10 @@ export class FxFifoEngine {
     const lots = this.lots.get(event.currency);
 
     if (!lots || lots.length === 0) {
-      this.warnings.push(`⚠ Venta de ${event.currency} sin lotes previos el ${event.date}. Posible adquisición anterior al período declarado.`);
+      const entry = this.fxMissing.get(event.currency) ?? { count: 0, totalQty: new Decimal(0) };
+      entry.count++;
+      entry.totalQty = entry.totalQty.plus(remaining);
+      this.fxMissing.set(event.currency, entry);
       // No lots = prior-year acquisition. Record with zero gain (cost = proceeds)
       // to avoid fabricating phantom profits from missing historical data.
       const proceedsEur = remaining.mul(event.ecbRate);
@@ -309,7 +324,10 @@ export class FxFifoEngine {
     }
 
     if (remaining.greaterThan(0)) {
-      this.warnings.push(`⚠ Lotes FX insuficientes: ${event.currency} × ${remaining} el ${event.date}. Coste = 0.`);
+      const entry = this.fxMissing.get(event.currency) ?? { count: 0, totalQty: new Decimal(0) };
+      entry.count++;
+      entry.totalQty = entry.totalQty.plus(remaining);
+      this.fxMissing.set(event.currency, entry);
       // Without prior-year lots we cannot determine cost basis.
       // Use current rate as cost (zero gain) to avoid fabricating phantom profits.
       const proceedsEur = remaining.mul(event.ecbRate);

--- a/src/engine/fx-fifo.ts
+++ b/src/engine/fx-fifo.ts
@@ -36,6 +36,7 @@ export class FxFifoEngine {
    * (not automatic FXCONV) generate FX lots and disposals.
    */
   processEvents(events: FxEvent[]): FxDisposal[] {
+    this.fxMissing.clear();
     const sorted = [...events].sort((a, b) => {
       const cmp = a.date.localeCompare(b.date);
       if (cmp !== 0) return cmp;

--- a/tests/engine/fx-fifo.test.ts
+++ b/tests/engine/fx-fifo.test.ts
@@ -149,7 +149,7 @@ describe("FxFifoEngine", () => {
       expect(disposals[1]!.costBasisEur.toFixed(2)).toBe("190.00");
       expect(disposals[1]!.proceedsEur.toFixed(2)).toBe("190.00");
       expect(disposals[1]!.gainLossEur.toFixed(2)).toBe("0.00");
-      expect(engine.warnings.some((w) => w.includes("insuficientes"))).toBe(true);
+      expect(engine.warnings.some((w) => w.includes("sin lotes previos suficientes"))).toBe(true);
     });
 
     it("should calculate holding period days correctly", () => {


### PR DESCRIPTION
## Summary

- Add `CMDTY` to `KNOWN_CATEGORIES` — eliminates 3 false "unknown category" warnings for IBKR silver/commodity trades (XAGUSD)
- Skip option BookTrades with notes `Ep`/`Ex` when OptionEAE data is present — IBKR generates both a BookTrade and an OptionEAE event for exercises/expirations, causing duplicate lot consumption and "Venta sin lotes" false warnings (7 warnings eliminated)
- FX engine: sort same-day acquisitions before disposals to avoid false "missing lots" when settlement timing places the EUR→USD conversion after the stock purchase on the same day
- Consolidate per-event FX warnings into one summary per currency — reduces ~51 individual warnings to 1 informational message

Net effect: **61 warnings → ~1-2** for a typical multi-year IBKR portfolio with options and commodities.

## Test plan

- [x] All 947 existing tests pass
- [x] FX warning consolidation test updated to match new message format
- [x] Verified with real 3-year IBKR data (2023-2025) that previously triggered 61 warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of commodity assets to eliminate unknown category warnings
  * Corrected option exercise event processing to prevent duplicate transaction calculations
  * Improved FX trade lot consumption order for same-day transactions

* **Improvements**
  * Consolidated missing lot warnings into single summary messages per currency for clearer feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->