### PR TITLE
feat(generators): add browser-side PDF export for Modelo 100 (#64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Se pueden combinar ficheros de varios brokers en una sola ejecución para FIFO c
 
 | Modelo | Descripción | Formato |
 |---|---|---|
-| **Modelo 100** (IRPF) | Casillas 0327, 0328, 0029, 0033, 0358, 0588 | JSON, CSV, PDF (con tipos ECB) |
+| **Modelo 100** (IRPF) | Casillas 0327, 0328, 0029, 0027, 0588 (pérdidas bloqueadas: informativo) | JSON, CSV, PDF (con tipos ECB) |
 | **Modelo 720** | Declaración de bienes en el extranjero (>50.000 EUR), tipos A/M/C | Fixed-width AEAT (validado contra spec BOE) |
 | **Modelo 721** | Revisión orientativa de criptomonedas en el extranjero (>50.000 EUR) | Generación oficial pendiente: AEAT exige XML |
 | **Modelo D-6** | Guía orientativa para participaciones significativas (Banco de España / AFORIX) | JSON o guía paso a paso |
@@ -89,9 +89,9 @@ Se pueden combinar ficheros de varios brokers en una sola ejecución para FIFO c
 | 0327 | Valor de transmisión (importe total de ventas) |
 | 0328 | Valor de adquisición (coste total FIFO con tipos ECB) |
 | 0029 | Dividendos brutos de acciones extranjeras |
-| 0033 | Intereses de cuentas y depósitos |
+| 0027 | Intereses de cuentas, depósitos y activos financieros (Art. 25.2 LIRPF) |
 | — | Intereses pagados al broker (margen, no deducible — informativo) |
-| 0358 | Pérdidas patrimoniales a compensar (bloqueadas por regla anti-churning) |
+| — | Pérdidas bloqueadas por regla anti-churning (Art. 33.5.f) — informativo, no hay casilla agregada en Renta Web |
 | 0588 | Deducción por doble imposición internacional |
 
 ## Interfaz web

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "commander": "^13.1.0",
         "decimal.js": "^10.5.0",
         "fast-xml-parser": "^5.7.2",
+        "jspdf": "2.5.2",
+        "jspdf-autotable": "5.0.7",
         "pdfkit": "^0.18.0",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
       },
@@ -23,6 +25,7 @@
         "@types/node": "^22.15.0",
         "@vitest/coverage-v8": "^3.2.4",
         "eslint": "^9.25.0",
+        "jsdom": "^29.1.0",
         "tsup": "^8.4.0",
         "tsx": "^4.19.0",
         "typescript": "^5.8.0",
@@ -47,6 +50,57 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
@@ -84,6 +138,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/types": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
@@ -106,6 +169,159 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -694,6 +910,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1269,6 +1503,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
@@ -1812,12 +2053,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1838,6 +2101,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.13",
@@ -1866,6 +2139,18 @@
       "license": "MIT",
       "dependencies": {
         "pako": "~1.0.5"
+      }
+    },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/bundle-require": {
@@ -1902,6 +2187,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/chai": {
@@ -2026,6 +2331,18 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2039,6 +2356,44 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/debug": {
@@ -2088,6 +2443,13 @@
       "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
       "license": "MIT"
     },
+    "node_modules/dompurify": {
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.9.tgz",
+      "integrity": "sha512-i6mvVmWN4xo9LrhCOZrDgSs9noW6nOahbrmzjRbPF36YPyj5Ue5lgok0MHDWkG7xzpWFO2OYttXdzM7rJxHvNA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2101,6 +2463,19 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -2412,6 +2787,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -2621,12 +3002,39 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -2697,6 +3105,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2811,6 +3226,57 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "29.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.0.tgz",
+      "integrity": "sha512-YNUc7fB9QuvSSQWfrH0xF+TyABkxUwx8sswgIDaCrw4Hol8BghdZDkITtZheRJeMtzWlnTfsM3bBBusRvpO1wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -2831,6 +3297,33 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jspdf": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.2.tgz",
+      "integrity": "sha512-myeX9c+p7znDWPk0eTrujCzNjT+CXdXyk7YmJq5nD5V7uLLKmSXnlQ/Jn/kuo3X09Op70Apm0rQSnFWyGK8uEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.5.4",
+        "html2canvas": "^1.0.0-rc.5"
+      }
+    },
+    "node_modules/jspdf-autotable": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/jspdf-autotable/-/jspdf-autotable-5.0.7.tgz",
+      "integrity": "sha512-2wr7H6liNDBYNwt25hMQwXkEWFOEopgKIvR1Eukuw6Zmprm/ZcnmLTQEjW7Xx3FCbD3v7pflLcnMAv/h1jFDQw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jspdf": "^2 || ^3 || ^4"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -2979,6 +3472,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -3147,6 +3647,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3229,6 +3742,13 @@
         "linebreak": "^1.1.0",
         "png-js": "^1.0.0"
       }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3372,6 +3892,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -3384,6 +3914,23 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -3411,6 +3958,16 @@
       "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
       "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
       "license": "MIT"
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
     },
     "node_modules/rollup": {
       "version": "4.60.1",
@@ -3455,6 +4012,19 @@
         "@rollup/rollup-win32-x64-gnu": "4.60.1",
         "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/semver": {
@@ -3539,6 +4109,16 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
     },
     "node_modules/std-env": {
       "version": "3.10.0",
@@ -3735,6 +4315,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/test-exclude": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
@@ -3787,6 +4384,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/thenify": {
@@ -3877,6 +4484,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.29.tgz",
+      "integrity": "sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.29"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.29.tgz",
+      "integrity": "sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tree-kill": {
@@ -4056,6 +4709,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -4096,6 +4759,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vite": {
@@ -4753,6 +5426,54 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4902,6 +5623,23 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
     "commander": "^13.1.0",
     "decimal.js": "^10.5.0",
     "fast-xml-parser": "^5.7.2",
+    "jspdf": "2.5.2",
+    "jspdf-autotable": "5.0.7",
     "pdfkit": "^0.18.0",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
   },
@@ -82,6 +84,7 @@
     "@types/node": "^22.15.0",
     "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.25.0",
+    "jsdom": "^29.1.0",
     "tsup": "^8.4.0",
     "tsx": "^4.19.0",
     "typescript": "^5.8.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "type": "git",
     "url": "https://github.com/GeiserX/DeclaRenta.git"
   },
-  "homepage": "https://declarenta.es",
+  "homepage": "https://declarenta.com",
   "bugs": {
     "url": "https://github.com/GeiserX/DeclaRenta/issues"
   },

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -408,7 +408,7 @@ function formatReport(report: ReturnType<typeof generateTaxReport>) {
     casillas: {
       "0029_dividendos_brutos": report.dividends.grossIncome.toFixed(2),
       "intereses_margen_no_deducible_informativo": report.interest.paid.toFixed(2),
-      "0033_intereses_cuentas": report.interest.earned.toFixed(2),
+      "0027_intereses_cuentas": report.interest.earned.toFixed(2),
       "0327_valor_transmision": report.capitalGains.transmissionValue.toFixed(2),
       "0328_valor_adquisicion": report.capitalGains.acquisitionValue.toFixed(2),
       "1626_valor_transmision_fx": report.fxGains.transmissionValue.toFixed(2),
@@ -493,7 +493,7 @@ function printSummary(report: ReturnType<typeof generateTaxReport>) {
   console.error("");
   console.error("  RENDIMIENTOS CAPITAL MOBILIARIO");
   console.error(`    Casilla 0029 (Dividendos brutos):  ${report.dividends.grossIncome.toFixed(2)} EUR`);
-  console.error(`    Casilla 0033 (Intereses ganados):  ${report.interest.earned.toFixed(2)} EUR`);
+  console.error(`    Casilla 0027 (Intereses ganados):  ${report.interest.earned.toFixed(2)} EUR`);
   console.error(`    Intereses margen (no deducible, informativo):   ${report.interest.paid.toFixed(2)} EUR`);
   console.error("");
   console.error("  DOBLE IMPOSICIÓN INTERNACIONAL");

--- a/src/generators/csv.ts
+++ b/src/generators/csv.ts
@@ -76,7 +76,7 @@ export function formatCsv(report: TaxSummary): string {
   lines.push(`1631,Valor de adquisicion FX,${report.fxGains.acquisitionValue.toFixed(2)}`);
   lines.push(`0029,Dividendos brutos,${report.dividends.grossIncome.toFixed(2)}`);
   lines.push(`—,Intereses pagados al broker (margen no deducible — informativo),${report.interest.paid.toFixed(2)}`);
-  lines.push(`0033,Intereses de cuentas,${report.interest.earned.toFixed(2)}`);
+  lines.push(`0027,Intereses de cuentas,${report.interest.earned.toFixed(2)}`);
   lines.push(`0588,Deduccion doble imposicion,${report.doubleTaxation.deduction.toFixed(2)}`);
 
   return lines.join("\n") + "\n";

--- a/src/generators/pdf-web.ts
+++ b/src/generators/pdf-web.ts
@@ -1,0 +1,319 @@
+import type { TaxSummary } from "../types/tax.js";
+
+export type TranslationFn = (key: string) => string;
+
+// Injected by Vite at build time; vitest.config.ts provides "dev" fallback
+declare const __APP_VERSION__: string;
+
+// ---------------------------------------------------------------------------
+// Layout constants (A4 mm)
+// ---------------------------------------------------------------------------
+
+const MARGIN = 14;
+const PAGE_W = 210;
+const PAGE_H = 297;
+const CONTENT_W = PAGE_W - 2 * MARGIN;
+
+const C = {
+  primary:   "#1a365d",
+  header:    "#2b6cb0",
+  muted:     "#718096",
+  danger:    "#e53e3e",
+  headerBg:  [43, 108, 176]  as [number, number, number],
+  textRgb:   [26, 32, 44]    as [number, number, number],
+  mutedRgb:  [113, 128, 150] as [number, number, number],
+  dangerRgb: [229, 62, 62]   as [number, number, number],
+  successRgb:[56, 161, 105]  as [number, number, number],
+  rowAlt:    [247, 250, 252] as [number, number, number],
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatDate(d: string): string {
+  if (d.length === 8) return `${d.slice(6, 8)}/${d.slice(4, 6)}/${d.slice(0, 4)}`;
+  return d;
+}
+
+function eur(d: { toFixed: (n: number) => string }): string {
+  return d.toFixed(2) + " EUR";
+}
+
+function lastTableY(doc: unknown, fallback: number): number {
+  return (doc as { lastAutoTable?: { finalY?: number } }).lastAutoTable?.finalY ?? fallback;
+}
+
+// ---------------------------------------------------------------------------
+// Browser-side PDF report generator
+// ---------------------------------------------------------------------------
+
+/**
+ * Generates a Modelo 100 PDF report entirely in-browser.
+ * Lazy-loads jsPDF + jspdf-autotable on first call (~125 KB gz, never on initial page load).
+ */
+export async function generatePdfWebReport(
+  report: TaxSummary,
+  t: TranslationFn,
+  locale: string = "es",
+): Promise<Blob> {
+  const { jsPDF } = await import("jspdf");
+  const { default: autoTable } = await import("jspdf-autotable");
+
+  const doc = new jsPDF({ orientation: "p", unit: "mm", format: "a4" });
+  const version = typeof __APP_VERSION__ !== "undefined" ? __APP_VERSION__ : "dev";
+
+  // --- Header ---
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(18);
+  doc.setTextColor(C.primary);
+  doc.text("DECLARENTA", MARGIN, MARGIN + 5);
+
+  doc.setFont("helvetica", "normal");
+  doc.setFontSize(8);
+  doc.setTextColor(C.muted);
+  doc.text(`${t("pdf.subtitle")} ${report.year}`, MARGIN, MARGIN + 11);
+  doc.text(
+    `${t("pdf.generated")} ${new Date().toLocaleDateString(locale)} — v${version}`,
+    MARGIN,
+    MARGIN + 16,
+  );
+
+  doc.setDrawColor(226, 232, 240);
+  doc.setLineWidth(0.3);
+  doc.line(MARGIN, MARGIN + 20, MARGIN + CONTENT_W, MARGIN + 20);
+
+  // --- Section 1: Casillas ---
+  doc.setFont("helvetica", "bold");
+  doc.setFontSize(11);
+  doc.setTextColor(C.header);
+  doc.text(t("pdf.section_casillas"), MARGIN, MARGIN + 27);
+
+  const casillasBody: string[][] = [
+    ["0327", t("casilla.transmission_value"), eur(report.capitalGains.transmissionValue)],
+    ["0328", t("casilla.acquisition_value"),  eur(report.capitalGains.acquisitionValue)],
+    ["",     t("casilla.net_gain_loss"),       eur(report.capitalGains.netGainLoss)],
+    ["0029", t("casilla.gross_dividends"),     eur(report.dividends.grossIncome)],
+    ["0033", t("casilla.interest_earned"),     eur(report.interest.earned)],
+    [t("pdf.informative"), t("pdf.interest_margin"), eur(report.interest.paid)],
+    ["0588", t("casilla.double_taxation"),     eur(report.doubleTaxation.deduction)],
+  ];
+
+  if (report.capitalGains.blockedLosses.greaterThan(0)) {
+    casillasBody.push(["0358", t("pdf.blocked_losses"), eur(report.capitalGains.blockedLosses)]);
+  }
+
+  autoTable(doc, {
+    startY: MARGIN + 30,
+    head: [[t("table.casilla"), t("table.concept"), t("table.amount_eur")]],
+    body: casillasBody,
+    theme: "striped",
+    headStyles: { fillColor: C.headerBg, fontSize: 8, textColor: [255, 255, 255] as [number, number, number] },
+    bodyStyles: { fontSize: 8, textColor: C.textRgb },
+    alternateRowStyles: { fillColor: C.rowAlt },
+    columnStyles: {
+      0: { cellWidth: 22 },
+      2: { cellWidth: 42, halign: "right" },
+    },
+    margin: { left: MARGIN, right: MARGIN },
+  });
+
+  // contentEndY tracks the real bottom of all rendered content across the whole document.
+  // Sections using autoTable update it via lastTableY(); the warnings section updates it
+  // directly from the manual-text cursor so the ECB footnote never overlaps either.
+  let contentEndY = lastTableY(doc, MARGIN + 30);
+
+  // --- Section 2: Operaciones ---
+  if (report.capitalGains.disposals.length > 0) {
+    const y2 = contentEndY + 10;
+
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(11);
+    doc.setTextColor(C.header);
+    doc.text(t("pdf.section_operations"), MARGIN, y2);
+
+    const opsColors: [number, number, number][] = report.capitalGains.disposals.map((d) =>
+      d.gainLossEur.greaterThanOrEqualTo(0) ? C.successRgb : C.dangerRgb,
+    );
+
+    const opsBody = report.capitalGains.disposals.map((d) => {
+      const scenarioTag =
+        d.optionScenario === "expiration" ? "EXP"
+        : d.optionScenario === "exercise" ? "EJ"
+        : null;
+      const symbol = scenarioTag
+        ? `${(d.underlyingSymbol ?? d.symbol).slice(0, 6)}${d.putCall ?? ""} [${scenarioTag}]`
+        : d.symbol.slice(0, 12);
+      const sign = d.gainLossEur.greaterThanOrEqualTo(0) ? "+" : "";
+      return [
+        d.isin,
+        symbol,
+        formatDate(d.acquireDate),
+        formatDate(d.sellDate),
+        d.quantity.toFixed(4),
+        d.costBasisEur.toFixed(2),
+        d.proceedsEur.toFixed(2),
+        sign + d.gainLossEur.toFixed(2),
+        d.sellEcbRate.toFixed(4),
+      ];
+    });
+
+    autoTable(doc, {
+      startY: y2 + 4,
+      head: [[
+        t("table.isin"), t("table.symbol"),
+        t("table.buy_date"), t("table.sell_date"),
+        t("table.units"), t("table.cost_eur"),
+        t("table.proceeds_eur"), t("table.gain_loss_eur"), "ECB",
+      ]],
+      body: opsBody,
+      theme: "striped",
+      headStyles: { fillColor: C.headerBg, fontSize: 6.5, textColor: [255, 255, 255] as [number, number, number] },
+      bodyStyles: { fontSize: 6.5, textColor: C.textRgb },
+      alternateRowStyles: { fillColor: C.rowAlt },
+      tableWidth: CONTENT_W,
+      columnStyles: {
+        0: { cellWidth: 24 },
+        1: { cellWidth: 20 },
+        2: { cellWidth: 17 },
+        3: { cellWidth: 17 },
+        4: { cellWidth: 14, halign: "right" },
+        5: { cellWidth: 22, halign: "right" },
+        6: { cellWidth: 22, halign: "right" },
+        7: { cellWidth: 20, halign: "right" },
+        8: { cellWidth: 26, halign: "right" },
+      },
+      margin: { left: MARGIN, right: MARGIN },
+      didParseCell: (data: unknown) => {
+        const d = data as { section: string; column: { index: number }; row: { index: number }; cell: { styles: { textColor: unknown } } };
+        if (d.section === "body" && d.column.index === 7) {
+          d.cell.styles.textColor = opsColors[d.row.index] ?? C.textRgb;
+        }
+      },
+    });
+
+    contentEndY = lastTableY(doc, contentEndY);
+  }
+
+  // --- Section 3: Dividendos ---
+  if (report.dividends.entries.length > 0) {
+    const y3 = contentEndY + 10;
+
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(11);
+    doc.setTextColor(C.header);
+    doc.text(t("pdf.section_dividends"), MARGIN, y3);
+
+    autoTable(doc, {
+      startY: y3 + 4,
+      head: [[
+        t("table.date"), t("table.isin"), t("table.symbol"),
+        t("table.gross_eur"), t("table.withholding_eur"), t("table.country"), "ECB",
+      ]],
+      body: report.dividends.entries.map((d) => [
+        formatDate(d.payDate),
+        d.isin,
+        d.symbol.slice(0, 10),
+        d.grossAmountEur.toFixed(2),
+        d.withholdingTaxEur.toFixed(2),
+        d.withholdingCountry,
+        d.ecbRate.toFixed(4),
+      ]),
+      theme: "striped",
+      headStyles: { fillColor: C.headerBg, fontSize: 7, textColor: [255, 255, 255] as [number, number, number] },
+      bodyStyles: { fontSize: 7, textColor: C.textRgb },
+      alternateRowStyles: { fillColor: C.rowAlt },
+      columnStyles: { 3: { halign: "right" }, 4: { halign: "right" }, 6: { halign: "right" } },
+      margin: { left: MARGIN, right: MARGIN },
+    });
+
+    contentEndY = lastTableY(doc, contentEndY);
+  }
+
+  // --- Section 4: Doble imposición ---
+  const dtEntries = Object.entries(report.doubleTaxation.byCountry);
+  if (dtEntries.length > 0) {
+    const y4 = contentEndY + 10;
+
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(11);
+    doc.setTextColor(C.header);
+    doc.text(t("pdf.section_dt"), MARGIN, y4);
+
+    autoTable(doc, {
+      startY: y4 + 4,
+      head: [[t("table.country"), t("pdf.dt_paid"), t("pdf.dt_allowed")]],
+      body: dtEntries.map(([country, data]) => [
+        country,
+        data.taxPaid.toFixed(2) + " EUR",
+        data.deductionAllowed.toFixed(2) + " EUR",
+      ]),
+      theme: "striped",
+      headStyles: { fillColor: C.headerBg, fontSize: 8, textColor: [255, 255, 255] as [number, number, number] },
+      bodyStyles: { fontSize: 8, textColor: C.textRgb },
+      alternateRowStyles: { fillColor: C.rowAlt },
+      columnStyles: { 1: { halign: "right" }, 2: { halign: "right" } },
+      margin: { left: MARGIN, right: MARGIN },
+    });
+
+    contentEndY = lastTableY(doc, contentEndY);
+  }
+
+  // --- Section 5: Warnings ---
+  if (report.warnings.length > 0) {
+    const y5 = contentEndY + 10;
+
+    doc.setFont("helvetica", "bold");
+    doc.setFontSize(11);
+    doc.setTextColor(C.header);
+    doc.text(t("pdf.section_warnings"), MARGIN, y5);
+
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(7);
+    doc.setTextColor(C.danger);
+    let wy = y5 + 6;
+    for (const w of report.warnings.slice(0, 20)) {
+      const lines = doc.splitTextToSize(w, CONTENT_W) as string[];
+      doc.text(lines, MARGIN, wy);
+      wy += lines.length * 4;
+      if (wy > PAGE_H - MARGIN - 20) {
+        doc.addPage();
+        wy = MARGIN + 10;
+      }
+    }
+
+    // Warnings use manual text — update contentEndY from the text cursor, not lastAutoTable
+    contentEndY = wy;
+  }
+
+  // --- ECB footnote ---
+  // Always render the footnote; add a page if the content leaves insufficient room.
+  let footnoteY = contentEndY + 10;
+  if (footnoteY > PAGE_H - MARGIN - 35) {
+    doc.addPage();
+    footnoteY = MARGIN + 10;
+  }
+  doc.setFont("helvetica", "normal");
+  doc.setFontSize(6.5);
+  doc.setTextColor(C.muted);
+  doc.text(t("pdf.ecb_note"), MARGIN, footnoteY, { maxWidth: CONTENT_W });
+
+  // --- Page numbers (looped after all content) ---
+  const totalPages = doc.getNumberOfPages();
+  for (let i = 1; i <= totalPages; i++) {
+    doc.setPage(i);
+    doc.setFont("helvetica", "normal");
+    doc.setFontSize(7);
+    doc.setTextColor(C.muted);
+    doc.text(`${i} / ${totalPages}`, PAGE_W / 2, PAGE_H - 8, { align: "center" });
+  }
+
+  // --- Footer disclaimer (last page) ---
+  doc.setPage(totalPages);
+  doc.setFont("helvetica", "normal");
+  doc.setFontSize(6.5);
+  doc.setTextColor(C.muted);
+  doc.text(t("pdf.footer"), MARGIN, PAGE_H - MARGIN, { maxWidth: CONTENT_W, align: "center" });
+
+  return doc.output("blob");
+}

--- a/src/generators/pdf-web.ts
+++ b/src/generators/pdf-web.ts
@@ -272,14 +272,15 @@ export async function generatePdfWebReport(
     doc.setFontSize(7);
     doc.setTextColor(C.danger);
     let wy = y5 + 6;
-    for (const w of report.warnings.slice(0, 20)) {
+    for (const w of report.warnings) {
       const lines = doc.splitTextToSize(w, CONTENT_W) as string[];
-      doc.text(lines, MARGIN, wy);
-      wy += lines.length * 4;
-      if (wy > PAGE_H - MARGIN - 20) {
+      const blockH = lines.length * 4;
+      if (wy + blockH > PAGE_H - MARGIN - 20) {
         doc.addPage();
         wy = MARGIN + 10;
       }
+      doc.text(lines, MARGIN, wy);
+      wy += blockH;
     }
 
     // Warnings use manual text — update contentEndY from the text cursor, not lastAutoTable

--- a/src/generators/pdf-web.ts
+++ b/src/generators/pdf-web.ts
@@ -1,6 +1,9 @@
 import type { TaxSummary } from "../types/tax.js";
+import type Decimal from "decimal.js";
+import type { CellHookData } from "jspdf-autotable";
+import type { TranslationKey } from "../i18n/index.js";
 
-export type TranslationFn = (key: string) => string;
+export type TranslationFn = (key: TranslationKey) => string;
 
 // Injected by Vite at build time; vitest.config.ts provides "dev" fallback
 declare const __APP_VERSION__: string;
@@ -36,7 +39,7 @@ function formatDate(d: string): string {
   return d;
 }
 
-function eur(d: { toFixed: (n: number) => string }): string {
+function eur(d: Decimal): string {
   return d.toFixed(2) + " EUR";
 }
 
@@ -94,13 +97,22 @@ export async function generatePdfWebReport(
     ["0328", t("casilla.acquisition_value"),  eur(report.capitalGains.acquisitionValue)],
     ["",     t("casilla.net_gain_loss"),       eur(report.capitalGains.netGainLoss)],
     ["0029", t("casilla.gross_dividends"),     eur(report.dividends.grossIncome)],
-    ["0033", t("casilla.interest_earned"),     eur(report.interest.earned)],
+    // Casilla 0027: Intereses de cuentas, depósitos y activos financieros (Art. 25.2 LIRPF)
+    ["0027", t("casilla.interest_earned"),     eur(report.interest.earned)],
     [t("pdf.informative"), t("pdf.interest_margin"), eur(report.interest.paid)],
     ["0588", t("casilla.double_taxation"),     eur(report.doubleTaxation.deduction)],
   ];
 
+  // FX gains (Casillas 1626/1631) — only shown when multi-currency FX events exist
+  if (report.fxGains.disposals.length > 0) {
+    casillasBody.push(["1626", t("casilla.fx_transmission_value"), eur(report.fxGains.transmissionValue)]);
+    casillasBody.push(["1631", t("casilla.fx_acquisition_value"),  eur(report.fxGains.acquisitionValue)]);
+    casillasBody.push(["",     t("casilla.fx_net_gain_loss"),       eur(report.fxGains.netGainLoss)]);
+  }
+
+  // Blocked losses: informative only — Renta Web handles Art. 33.5.f per-disposal, no aggregate casilla
   if (report.capitalGains.blockedLosses.greaterThan(0)) {
-    casillasBody.push(["0358", t("pdf.blocked_losses"), eur(report.capitalGains.blockedLosses)]);
+    casillasBody.push([t("pdf.informative"), t("pdf.blocked_losses"), eur(report.capitalGains.blockedLosses)]);
   }
 
   autoTable(doc, {
@@ -140,6 +152,7 @@ export async function generatePdfWebReport(
       const scenarioTag =
         d.optionScenario === "expiration" ? "EXP"
         : d.optionScenario === "exercise" ? "EJ"
+        : d.optionScenario === "close" ? "CL"
         : null;
       const symbol = scenarioTag
         ? `${(d.underlyingSymbol ?? d.symbol).slice(0, 6)}${d.putCall ?? ""} [${scenarioTag}]`
@@ -184,10 +197,9 @@ export async function generatePdfWebReport(
         8: { cellWidth: 26, halign: "right" },
       },
       margin: { left: MARGIN, right: MARGIN },
-      didParseCell: (data: unknown) => {
-        const d = data as { section: string; column: { index: number }; row: { index: number }; cell: { styles: { textColor: unknown } } };
-        if (d.section === "body" && d.column.index === 7) {
-          d.cell.styles.textColor = opsColors[d.row.index] ?? C.textRgb;
+      didParseCell: (data: CellHookData) => {
+        if (data.section === "body" && data.column.index === 7) {
+          data.cell.styles.textColor = opsColors[data.row.index] ?? C.textRgb;
         }
       },
     });

--- a/src/generators/pdf.ts
+++ b/src/generators/pdf.ts
@@ -112,7 +112,7 @@ export function generatePdfReport(report: TaxSummary): Promise<Buffer> {
         ["Casilla 0328", "Valor de adquisición", formatEur(report.capitalGains.acquisitionValue)],
         ["", "Ganancia/Pérdida neta", formatEur(report.capitalGains.netGainLoss)],
         ["Casilla 0029", "Dividendos brutos", formatEur(report.dividends.grossIncome)],
-        ["Casilla 0033", "Intereses ganados", formatEur(report.interest.earned)],
+        ["Casilla 0027", "Intereses ganados", formatEur(report.interest.earned)],
         ["Informativo", "Intereses margen (no deducible)", formatEur(report.interest.paid)],
         ["Casilla 0588", "Deducción doble imposición", formatEur(report.doubleTaxation.deduction)],
       ];
@@ -258,7 +258,7 @@ export function generatePdfReport(report: TaxSummary): Promise<Buffer> {
       // --- Footer ---
       doc.fontSize(FONT_SIZE.small).fillColor(COLORS.muted)
         .text(
-          `DeclaRenta v${VERSION} — https://declarenta.es — Este informe es orientativo y no sustituye al asesoramiento fiscal profesional.`,
+          `DeclaRenta v${VERSION} — https://declarenta.com — Este informe es orientativo y no sustituye al asesoramiento fiscal profesional.`,
           MARGIN,
           doc.page.height - MARGIN - 20,
           { width: CONTENT_WIDTH, align: "center" },

--- a/src/i18n/locales/ca.ts
+++ b/src/i18n/locales/ca.ts
@@ -30,6 +30,7 @@ const ca: TranslationKeys = {
   "results.filter_losses": "Pèrdues",
   "results.export_json": "Exportar JSON",
   "results.export_csv": "Exportar CSV",
+  "results.export_pdf": "Exportar PDF",
   "results.operations_count": "{{count}} operació(ns)",
   "results.dividends_count": "{{count}} dividend(s)",
   "results.year_mismatch": "El fitxer conté dades dels exercicis {{available}}, però l'exercici seleccionat és {{year}}. Selecciona un altre any al desplegable superior.",
@@ -373,6 +374,22 @@ const ca: TranslationKeys = {
   "tax.breakdown_dividends": "Dividends",
   "tax.breakdown_interest": "Interessos",
   "tax.breakdown_blocked_losses": "Pèrdues bloquejades (diferides)",
+
+  // PDF report
+  "pdf.subtitle": "Informe fiscal — Exercici",
+  "pdf.generated": "Generat el",
+  "pdf.informative": "Informatiu",
+  "pdf.blocked_losses": "Pèrdues bloquejades anti-churning (Casella 0358)",
+  "pdf.interest_margin": "Interessos marge (no deduïble)",
+  "pdf.section_casillas": "1. Resum de Caselles — Model 100",
+  "pdf.section_operations": "2. Detall d'Operacions",
+  "pdf.section_dividends": "3. Dividends",
+  "pdf.section_dt": "4. Deducció per Doble Imposició Internacional",
+  "pdf.section_warnings": "Advertències",
+  "pdf.dt_paid": "Impost pagat",
+  "pdf.dt_allowed": "Deducció permesa",
+  "pdf.ecb_note": "Tipus ECB: tipus de canvi oficial del Banc Central Europeu (EUR per 1 unitat de divisa estrangera) en la data de l'operació. Font: ECB SDMX API.",
+  "pdf.footer": "DeclaRenta — https://declarenta.es — Aquest informe és orientatiu i no substitueix l'assessorament fiscal professional.",
 };
 
 export default ca;

--- a/src/i18n/locales/ca.ts
+++ b/src/i18n/locales/ca.ts
@@ -379,7 +379,7 @@ const ca: TranslationKeys = {
   "pdf.subtitle": "Informe fiscal — Exercici",
   "pdf.generated": "Generat el",
   "pdf.informative": "Informatiu",
-  "pdf.blocked_losses": "Pèrdues bloquejades anti-churning (Casella 0358)",
+  "pdf.blocked_losses": "Pèrdues bloquejades anti-churning",
   "pdf.interest_margin": "Interessos marge (no deduïble)",
   "pdf.section_casillas": "1. Resum de Caselles — Model 100",
   "pdf.section_operations": "2. Detall d'Operacions",
@@ -389,7 +389,7 @@ const ca: TranslationKeys = {
   "pdf.dt_paid": "Impost pagat",
   "pdf.dt_allowed": "Deducció permesa",
   "pdf.ecb_note": "Tipus ECB: tipus de canvi oficial del Banc Central Europeu (EUR per 1 unitat de divisa estrangera) en la data de l'operació. Font: ECB SDMX API.",
-  "pdf.footer": "DeclaRenta — https://declarenta.es — Aquest informe és orientatiu i no substitueix l'assessorament fiscal professional.",
+  "pdf.footer": "DeclaRenta — https://declarenta.com — Aquest informe és orientatiu i no substitueix l'assessorament fiscal professional.",
 };
 
 export default ca;

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -383,7 +383,7 @@ const en: TranslationKeys = {
   "pdf.subtitle": "Tax report — Year",
   "pdf.generated": "Generated on",
   "pdf.informative": "Info",
-  "pdf.blocked_losses": "Anti-churning blocked losses (Box 0358)",
+  "pdf.blocked_losses": "Anti-churning blocked losses",
   "pdf.interest_margin": "Margin interest (non-deductible)",
   "pdf.section_casillas": "1. Tax Boxes Summary — Modelo 100",
   "pdf.section_operations": "2. Transactions Detail",
@@ -393,7 +393,7 @@ const en: TranslationKeys = {
   "pdf.dt_paid": "Tax paid",
   "pdf.dt_allowed": "Deduction allowed",
   "pdf.ecb_note": "ECB rate: official European Central Bank exchange rate (EUR per 1 unit of foreign currency) on the transaction date. Source: ECB SDMX API.",
-  "pdf.footer": "DeclaRenta — https://declarenta.es — This report is informational only and does not replace professional tax advice.",
+  "pdf.footer": "DeclaRenta — https://declarenta.com — This report is informational only and does not replace professional tax advice.",
 };
 
 export default en;

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -29,6 +29,7 @@ const en: TranslationKeys = {
   "results.filter_losses": "Losses",
   "results.export_json": "Export JSON",
   "results.export_csv": "Export CSV",
+  "results.export_pdf": "Export PDF",
   "results.operations_count": "{{count}} transaction(s)",
   "results.dividends_count": "{{count}} dividend(s)",
   "results.year_mismatch": "The file contains data for tax years {{available}}, but the selected year is {{year}}. Select another year from the dropdown above.",
@@ -377,6 +378,22 @@ const en: TranslationKeys = {
   "tax.breakdown_dividends": "Dividends",
   "tax.breakdown_interest": "Interest",
   "tax.breakdown_blocked_losses": "Blocked losses (deferred)",
+
+  // PDF report
+  "pdf.subtitle": "Tax report — Year",
+  "pdf.generated": "Generated on",
+  "pdf.informative": "Info",
+  "pdf.blocked_losses": "Anti-churning blocked losses (Box 0358)",
+  "pdf.interest_margin": "Margin interest (non-deductible)",
+  "pdf.section_casillas": "1. Tax Boxes Summary — Modelo 100",
+  "pdf.section_operations": "2. Transactions Detail",
+  "pdf.section_dividends": "3. Dividends",
+  "pdf.section_dt": "4. International Double Taxation Deduction",
+  "pdf.section_warnings": "Warnings",
+  "pdf.dt_paid": "Tax paid",
+  "pdf.dt_allowed": "Deduction allowed",
+  "pdf.ecb_note": "ECB rate: official European Central Bank exchange rate (EUR per 1 unit of foreign currency) on the transaction date. Source: ECB SDMX API.",
+  "pdf.footer": "DeclaRenta — https://declarenta.es — This report is informational only and does not replace professional tax advice.",
 };
 
 export default en;

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -412,7 +412,7 @@ const es = {
   "pdf.subtitle": "Informe fiscal — Ejercicio",
   "pdf.generated": "Generado el",
   "pdf.informative": "Informativo",
-  "pdf.blocked_losses": "Pérdidas bloqueadas anti-churning (Casilla 0358)",
+  "pdf.blocked_losses": "Pérdidas bloqueadas anti-churning",
   "pdf.interest_margin": "Intereses margen (no deducible)",
   "pdf.section_casillas": "1. Resumen de Casillas — Modelo 100",
   "pdf.section_operations": "2. Detalle de Operaciones",
@@ -422,7 +422,7 @@ const es = {
   "pdf.dt_paid": "Impuesto pagado",
   "pdf.dt_allowed": "Deducción permitida",
   "pdf.ecb_note": "Tipo ECB: tipo de cambio oficial del Banco Central Europeo (EUR por 1 unidad de divisa extranjera) en la fecha de la operación. Fuente: ECB SDMX API.",
-  "pdf.footer": "DeclaRenta — https://declarenta.es — Este informe es orientativo y no sustituye al asesoramiento fiscal profesional.",
+  "pdf.footer": "DeclaRenta — https://declarenta.com — Este informe es orientativo y no sustituye al asesoramiento fiscal profesional.",
 } as const;
 
 export type TranslationKeys = Record<keyof typeof es, string>;

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -31,6 +31,7 @@ const es = {
   "results.filter_losses": "Pérdidas",
   "results.export_json": "Exportar JSON",
   "results.export_csv": "Exportar CSV",
+  "results.export_pdf": "Exportar PDF",
   "results.operations_count": "{{count}} operación(es)",
   "results.dividends_count": "{{count}} dividendo(s)",
   "results.year_mismatch": "El fichero contiene datos de los ejercicios {{available}}, pero el ejercicio seleccionado es {{year}}. Selecciona otro año en el desplegable superior.",
@@ -406,6 +407,22 @@ const es = {
   "tax.breakdown_dividends": "Dividendos",
   "tax.breakdown_interest": "Intereses",
   "tax.breakdown_blocked_losses": "Pérdidas bloqueadas (diferidas)",
+
+  // PDF report
+  "pdf.subtitle": "Informe fiscal — Ejercicio",
+  "pdf.generated": "Generado el",
+  "pdf.informative": "Informativo",
+  "pdf.blocked_losses": "Pérdidas bloqueadas anti-churning (Casilla 0358)",
+  "pdf.interest_margin": "Intereses margen (no deducible)",
+  "pdf.section_casillas": "1. Resumen de Casillas — Modelo 100",
+  "pdf.section_operations": "2. Detalle de Operaciones",
+  "pdf.section_dividends": "3. Dividendos",
+  "pdf.section_dt": "4. Deducción por Doble Imposición Internacional",
+  "pdf.section_warnings": "Advertencias",
+  "pdf.dt_paid": "Impuesto pagado",
+  "pdf.dt_allowed": "Deducción permitida",
+  "pdf.ecb_note": "Tipo ECB: tipo de cambio oficial del Banco Central Europeo (EUR por 1 unidad de divisa extranjera) en la fecha de la operación. Fuente: ECB SDMX API.",
+  "pdf.footer": "DeclaRenta — https://declarenta.es — Este informe es orientativo y no sustituye al asesoramiento fiscal profesional.",
 } as const;
 
 export type TranslationKeys = Record<keyof typeof es, string>;

--- a/src/i18n/locales/eu.ts
+++ b/src/i18n/locales/eu.ts
@@ -30,6 +30,7 @@ const eu: TranslationKeys = {
   "results.filter_losses": "Galerak",
   "results.export_json": "Esportatu JSON",
   "results.export_csv": "Esportatu CSV",
+  "results.export_pdf": "Esportatu PDF",
   "results.operations_count": "{{count}} eragiketa",
   "results.dividends_count": "{{count}} dibidendu",
   "results.year_mismatch": "Fitxategiak {{available}} ekitaldietako datuak ditu, baina hautatutako ekitaldia {{year}} da. Hautatu beste urte bat goiko zerrendan.",
@@ -373,6 +374,22 @@ const eu: TranslationKeys = {
   "tax.breakdown_dividends": "Dibidenduak",
   "tax.breakdown_interest": "Interesak",
   "tax.breakdown_blocked_losses": "Blokeatutako galerak (atzeratuak)",
+
+  // PDF report
+  "pdf.subtitle": "Zerga txostena — Ekitaldia",
+  "pdf.generated": "Sortua",
+  "pdf.informative": "Informatibo",
+  "pdf.blocked_losses": "Anti-churning blokatutako galerak (0358 laukia)",
+  "pdf.interest_margin": "Marjina interesak (kengarria ez)",
+  "pdf.section_casillas": "1. Laukien Laburpena — 100 Eredua",
+  "pdf.section_operations": "2. Eragiketen Xehetasuna",
+  "pdf.section_dividends": "3. Dibidenduak",
+  "pdf.section_dt": "4. Nazioarteko Zerga Bikoitzaren Kenkaria",
+  "pdf.section_warnings": "Abisuak",
+  "pdf.dt_paid": "Ordaindutako zerga",
+  "pdf.dt_allowed": "Baimendutako kenkaria",
+  "pdf.ecb_note": "ECB tasa: Europako Banku Zentralaren truke-tasa ofiziala (EUR 1 atzerriko moneta-unitate bakoitzeko) eragiketa-datan. Iturria: ECB SDMX API.",
+  "pdf.footer": "DeclaRenta — https://declarenta.es — Txosten hau informatiboa da eta ez du zerga-aholkularitza profesionala ordezten.",
 };
 
 export default eu;

--- a/src/i18n/locales/eu.ts
+++ b/src/i18n/locales/eu.ts
@@ -379,8 +379,8 @@ const eu: TranslationKeys = {
   "pdf.subtitle": "Zerga txostena — Ekitaldia",
   "pdf.generated": "Sortua",
   "pdf.informative": "Informatibo",
-  "pdf.blocked_losses": "Anti-churning blokatutako galerak (0358 laukia)",
-  "pdf.interest_margin": "Marjina interesak (kengarria ez)",
+  "pdf.blocked_losses": "Anti-churning blokeatutako galerak",
+  "pdf.interest_margin": "Marjina interesak (ez kengarria)",
   "pdf.section_casillas": "1. Laukien Laburpena — 100 Eredua",
   "pdf.section_operations": "2. Eragiketen Xehetasuna",
   "pdf.section_dividends": "3. Dibidenduak",
@@ -389,7 +389,7 @@ const eu: TranslationKeys = {
   "pdf.dt_paid": "Ordaindutako zerga",
   "pdf.dt_allowed": "Baimendutako kenkaria",
   "pdf.ecb_note": "ECB tasa: Europako Banku Zentralaren truke-tasa ofiziala (EUR 1 atzerriko moneta-unitate bakoitzeko) eragiketa-datan. Iturria: ECB SDMX API.",
-  "pdf.footer": "DeclaRenta — https://declarenta.es — Txosten hau informatiboa da eta ez du zerga-aholkularitza profesionala ordezten.",
+  "pdf.footer": "DeclaRenta — https://declarenta.com — Txosten hau informatiboa da eta ez du zerga-aholkularitza profesionala ordezten.",
 };
 
 export default eu;

--- a/src/i18n/locales/gl.ts
+++ b/src/i18n/locales/gl.ts
@@ -30,6 +30,7 @@ const gl: TranslationKeys = {
   "results.filter_losses": "Perdas",
   "results.export_json": "Exportar JSON",
   "results.export_csv": "Exportar CSV",
+  "results.export_pdf": "Exportar PDF",
   "results.operations_count": "{{count}} operación(s)",
   "results.dividends_count": "{{count}} dividendo(s)",
   "results.year_mismatch": "O ficheiro contén datos dos exercicios {{available}}, pero o exercicio seleccionado é {{year}}. Selecciona outro ano no despregable superior.",
@@ -373,6 +374,22 @@ const gl: TranslationKeys = {
   "tax.breakdown_dividends": "Dividendos",
   "tax.breakdown_interest": "Xuros",
   "tax.breakdown_blocked_losses": "Perdas bloqueadas (diferidas)",
+
+  // PDF report
+  "pdf.subtitle": "Informe fiscal — Exercicio",
+  "pdf.generated": "Xerado o",
+  "pdf.informative": "Informativo",
+  "pdf.blocked_losses": "Perdas bloqueadas anti-churning (Caixa 0358)",
+  "pdf.interest_margin": "Xuros marxe (non deducible)",
+  "pdf.section_casillas": "1. Resumo de Caixas — Modelo 100",
+  "pdf.section_operations": "2. Detalle de Operacións",
+  "pdf.section_dividends": "3. Dividendos",
+  "pdf.section_dt": "4. Dedución por Dobre Imposición Internacional",
+  "pdf.section_warnings": "Advertencias",
+  "pdf.dt_paid": "Imposto pagado",
+  "pdf.dt_allowed": "Dedución permitida",
+  "pdf.ecb_note": "Tipo ECB: tipo de cambio oficial do Banco Central Europeo (EUR por 1 unidade de divisa estranxeira) na data da operación. Fonte: ECB SDMX API.",
+  "pdf.footer": "DeclaRenta — https://declarenta.es — Este informe é orientativo e non substitúe o asesoramento fiscal profesional.",
 };
 
 export default gl;

--- a/src/i18n/locales/gl.ts
+++ b/src/i18n/locales/gl.ts
@@ -379,7 +379,7 @@ const gl: TranslationKeys = {
   "pdf.subtitle": "Informe fiscal — Exercicio",
   "pdf.generated": "Xerado o",
   "pdf.informative": "Informativo",
-  "pdf.blocked_losses": "Perdas bloqueadas anti-churning (Caixa 0358)",
+  "pdf.blocked_losses": "Perdas bloqueadas anti-churning",
   "pdf.interest_margin": "Xuros marxe (non deducible)",
   "pdf.section_casillas": "1. Resumo de Caixas — Modelo 100",
   "pdf.section_operations": "2. Detalle de Operacións",
@@ -389,7 +389,7 @@ const gl: TranslationKeys = {
   "pdf.dt_paid": "Imposto pagado",
   "pdf.dt_allowed": "Dedución permitida",
   "pdf.ecb_note": "Tipo ECB: tipo de cambio oficial do Banco Central Europeo (EUR por 1 unidade de divisa estranxeira) na data da operación. Fonte: ECB SDMX API.",
-  "pdf.footer": "DeclaRenta — https://declarenta.es — Este informe é orientativo e non substitúe o asesoramento fiscal profesional.",
+  "pdf.footer": "DeclaRenta — https://declarenta.com — Este informe é orientativo e non substitúe o asesoramento fiscal profesional.",
 };
 
 export default gl;

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -127,7 +127,7 @@ export interface TaxSummary {
 
   /** Interest income */
   interest: {
-    /** Casilla 0033: Intereses de cuentas y depósitos */
+    /** Casilla 0027: Intereses de cuentas, depósitos y activos financieros (Art. 25.2 LIRPF) */
     earned: Decimal;
     /** Intereses pagados al broker (margen) — informativo, NO deducible (Art. 26.1.a LIRPF) */
     paid: Decimal;

--- a/src/web/casilla-detail.ts
+++ b/src/web/casilla-detail.ts
@@ -182,7 +182,7 @@ const CASILLAS: CasillaConfig[] = [
     getDetail: (r) => renderDividendsDetail(r.dividends.entries),
   },
   {
-    code: "0033",
+    code: "0027",
     i18nKey: "casilla.interest_earned",
     getValue: (r) => r.interest.earned.toFixed(2),
     getClass: () => "",

--- a/src/web/docs.html
+++ b/src/web/docs.html
@@ -574,10 +574,10 @@ declarenta d6 --input informe.xml --year 2025 --nif 12345678A --name "Apellidos,
         </div>
 
         <div class="casilla-ref">
-          <span class="casilla-num">0358</span>
-          <h4>Pérdidas patrimoniales a compensar</h4>
-          <p>Pérdidas bloqueadas por la norma anti-churning (Art. 33.5.f LIRPF). Son las pérdidas en las que se ha recomprado el mismo valor en los 2 meses anteriores o posteriores a la venta.</p>
-          <p class="muted">Estas pérdidas no se pierden: se integran en el coste de adquisición de los nuevos títulos adquiridos.</p>
+          <span class="casilla-num">Info</span>
+          <h4>Pérdidas patrimoniales bloqueadas (anti-churning) — Informativo</h4>
+          <p>Pérdidas bloqueadas por la norma anti-churning (Art. 33.5.f LIRPF). Son las pérdidas en las que se ha recomprado el mismo valor en los 2 meses anteriores o posteriores a la venta (cotizados) o en 1 año (no cotizados).</p>
+          <p class="muted">No existe una casilla agregada en Renta Web: estas pérdidas se gestionan a nivel de operación individual mediante «Integración diferida» (checkbox «no imputación por recompra de valores homogéneos»). DeclaRenta las muestra como informativo para que el contribuyente las localice en sus disposiciones.</p>
         </div>
 
         <div class="casilla-ref">
@@ -589,10 +589,10 @@ declarenta d6 --input informe.xml --year 2025 --nif 12345678A --name "Apellidos,
         </div>
 
         <div class="casilla-ref">
-          <span class="casilla-num">0033</span>
+          <span class="casilla-num">0027</span>
           <h4>Intereses de cuentas y depósitos</h4>
           <p>Intereses recibidos por saldos en efectivo en el broker, depósitos o bonos. Convertidos a EUR al tipo ECB del día del cobro.</p>
-          <p class="muted">Base legal: Art. 25.2 LIRPF. En Renta Web: Rendimientos del capital mobiliario &gt; Intereses de cuentas y depósitos.</p>
+          <p class="muted">Base legal: Art. 25.2 LIRPF. En Renta Web: Rendimientos del capital mobiliario &gt; Intereses de cuentas, depósitos y activos financieros en general.</p>
         </div>
 
         <div class="casilla-ref">
@@ -908,7 +908,7 @@ declarenta d6 --input informe.xml --year 2025 --nif 12345678A --name "Apellidos,
         <p class="muted">La regla anti-churning no se aplica a operaciones forex.</p>
 
         <h3>Bonos y renta fija (BOND)</h3>
-        <p>La compraventa de bonos tributa como ganancia o pérdida patrimonial, procesada con FIFO. Los cupones (intereses de bonos) se declaran como rendimiento del capital mobiliario en la Casilla 0033, al igual que los intereses de cuentas.</p>
+        <p>La compraventa de bonos tributa como ganancia o pérdida patrimonial, procesada con FIFO. Los cupones (intereses de bonos) se declaran como rendimiento del capital mobiliario en la Casilla 0027, al igual que los intereses de cuentas.</p>
         <p>Las letras del Tesoro extranjeras reciben el mismo tratamiento fiscal que los bonos corporativos.</p>
         <p class="muted">La regla anti-churning sí se aplica a bonos (son valores homogéneos).</p>
 

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -196,6 +196,7 @@
             <div class="export-buttons">
               <button id="export-json-btn" data-i18n="results.export_json">Exportar JSON</button>
               <button id="export-csv-btn" data-i18n="results.export_csv">Exportar CSV</button>
+              <button id="export-pdf-btn" data-i18n="results.export_pdf">Exportar PDF</button>
             </div>
 
             <!-- Year comparison -->

--- a/src/web/main.ts
+++ b/src/web/main.ts
@@ -168,6 +168,7 @@ const opsTable = document.getElementById("operations-table")!;
 const divsTable = document.getElementById("dividends-table")!;
 const exportJsonBtn = document.getElementById("export-json-btn")!;
 const exportCsvBtn = document.getElementById("export-csv-btn")!;
+const exportPdfBtn = document.getElementById("export-pdf-btn") as HTMLButtonElement;
 const brokerSelect = document.getElementById("broker-select") as HTMLSelectElement;
 const fileListDiv = document.getElementById("file-list")!;
 const opsSearch = document.getElementById("ops-search") as HTMLInputElement;
@@ -524,6 +525,22 @@ exportCsvBtn.addEventListener("click", () => {
   const csv = formatCsv(currentReport);
   const blob = new Blob([csv], { type: "text/csv" });
   downloadBlob(blob, `declarenta_${currentReport.year}.csv`);
+});
+
+exportPdfBtn.addEventListener("click", () => {
+  if (!currentReport) return;
+  exportPdfBtn.disabled = true;
+  const report = currentReport;
+  void import("../generators/pdf-web.js").then(({ generatePdfWebReport }) =>
+    generatePdfWebReport(report, t as (key: string) => string, getCurrentLocale())
+  ).then((blob) => {
+    downloadBlob(blob, `declarenta_${report.year}.pdf`);
+  }).catch((err: unknown) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    reviewContent.innerHTML = `<p class="warning">${t("error.prefix")}${esc(msg)}</p>`;
+  }).finally(() => {
+    exportPdfBtn.disabled = false;
+  });
 });
 
 function downloadBlob(blob: Blob, filename: string) {

--- a/tests/generators/pdf-web.test.ts
+++ b/tests/generators/pdf-web.test.ts
@@ -168,4 +168,102 @@ describe("generatePdfWebReport", () => {
     );
     expect(withOps.size).toBeGreaterThan(withoutOps.size);
   });
+
+  it("renders option disposals with expiration and exercise scenarios", async () => {
+    const report = makeReport({
+      capitalGains: {
+        transmissionValue: new Decimal("500"),
+        acquisitionValue: new Decimal("600"),
+        netGainLoss: new Decimal("-100"),
+        blockedLosses: new Decimal(0),
+        disposals: [
+          {
+            isin: "US0231351067",
+            symbol: "AAPL250117P00150000",
+            description: "AAPL Jan 2025 150P",
+            sellDate: "20250117",
+            acquireDate: "20241201",
+            quantity: new Decimal("1"),
+            proceedsEur: new Decimal("0"),
+            costBasisEur: new Decimal("300"),
+            gainLossEur: new Decimal("-300"),
+            holdingPeriodDays: 47,
+            currency: "USD",
+            sellEcbRate: new Decimal("0.92"),
+            acquireEcbRate: new Decimal("0.91"),
+            washSaleBlocked: false,
+            assetCategory: "OPT",
+            optionScenario: "expiration",
+            underlyingSymbol: "AAPL",
+            putCall: "P",
+          },
+          {
+            isin: "US0231351067",
+            symbol: "AAPL250117C00200000",
+            description: "AAPL Jan 2025 200C",
+            sellDate: "20250117",
+            acquireDate: "20241101",
+            quantity: new Decimal("2"),
+            proceedsEur: new Decimal("500"),
+            costBasisEur: new Decimal("300"),
+            gainLossEur: new Decimal("200"),
+            holdingPeriodDays: 77,
+            currency: "USD",
+            sellEcbRate: new Decimal("0.92"),
+            acquireEcbRate: new Decimal("0.91"),
+            washSaleBlocked: false,
+            assetCategory: "OPT",
+            optionScenario: "exercise",
+            underlyingSymbol: "AAPL",
+            putCall: "C",
+          },
+        ],
+      },
+    });
+    const blob = await generatePdfWebReport(report, t);
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.size).toBeGreaterThan(10_000);
+  });
+
+  it("handles warnings long enough to overflow onto a new page", async () => {
+    // 20 warnings of 300 chars each force multi-line wrapping at 7pt that
+    // fills beyond PAGE_H - MARGIN - 20, triggering doc.addPage() in the warnings loop
+    const longWarning = "Warning: missing acquisition cost data for ticker ".padEnd(300, "X");
+    const report = makeReport({
+      capitalGains: {
+        transmissionValue: new Decimal(0),
+        acquisitionValue: new Decimal(0),
+        netGainLoss: new Decimal(0),
+        blockedLosses: new Decimal(0),
+        disposals: [],
+      },
+      dividends: { grossIncome: new Decimal(0), deductibleExpenses: new Decimal(0), entries: [] },
+      doubleTaxation: { deduction: new Decimal(0), byCountry: {} },
+      warnings: Array.from({ length: 20 }, (_, i) => `${i + 1}: ${longWarning}`),
+    });
+    const blob = await generatePdfWebReport(report, t);
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.size).toBeGreaterThan(10_000);
+  });
+
+  it("pushes ECB footnote to a new page when warnings fill the page near the bottom", async () => {
+    // 18 medium-length warnings push contentEndY past the footnote threshold (PAGE_H - MARGIN - 35)
+    // without triggering the warnings page-break themselves (which resets the cursor)
+    const mediumWarning = "Warning: ECB rate not found, using fallback rate for ".padEnd(200, "X");
+    const report = makeReport({
+      capitalGains: {
+        transmissionValue: new Decimal(0),
+        acquisitionValue: new Decimal(0),
+        netGainLoss: new Decimal(0),
+        blockedLosses: new Decimal(0),
+        disposals: [],
+      },
+      dividends: { grossIncome: new Decimal(0), deductibleExpenses: new Decimal(0), entries: [] },
+      doubleTaxation: { deduction: new Decimal(0), byCountry: {} },
+      warnings: Array.from({ length: 18 }, (_, i) => `${i + 1}: ${mediumWarning}`),
+    });
+    const blob = await generatePdfWebReport(report, t);
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.size).toBeGreaterThan(10_000);
+  });
 });

--- a/tests/generators/pdf-web.test.ts
+++ b/tests/generators/pdf-web.test.ts
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import Decimal from "decimal.js";
+import { generatePdfWebReport } from "../../src/generators/pdf-web.js";
+import type { TaxSummary } from "../../src/types/tax.js";
+
+const t = (key: string) => key;
+
+function makeReport(overrides: Partial<TaxSummary> = {}): TaxSummary {
+  return {
+    year: 2025,
+    warnings: [],
+    capitalGains: {
+      transmissionValue: new Decimal("10000"),
+      acquisitionValue: new Decimal("8000"),
+      netGainLoss: new Decimal("2000"),
+      blockedLosses: new Decimal("0"),
+      disposals: [
+        {
+          isin: "US78462F1030",
+          symbol: "SPY",
+          description: "SPDR S&P 500",
+          sellDate: "20250915",
+          acquireDate: "20240301",
+          quantity: new Decimal("10"),
+          proceedsEur: new Decimal("5000"),
+          costBasisEur: new Decimal("4000"),
+          gainLossEur: new Decimal("1000"),
+          holdingPeriodDays: 198,
+          currency: "USD",
+          sellEcbRate: new Decimal("0.92"),
+          acquireEcbRate: new Decimal("0.91"),
+          washSaleBlocked: false,
+          assetCategory: "STK",
+        },
+        {
+          isin: "IE00BK5BQT80",
+          symbol: "VWCE",
+          description: "Vanguard FTSE All-World",
+          sellDate: "20251020",
+          acquireDate: "20230615",
+          quantity: new Decimal("5"),
+          proceedsEur: new Decimal("5000"),
+          costBasisEur: new Decimal("4000"),
+          gainLossEur: new Decimal("-500"),
+          holdingPeriodDays: 858,
+          currency: "EUR",
+          sellEcbRate: new Decimal("1"),
+          acquireEcbRate: new Decimal("1"),
+          washSaleBlocked: false,
+          assetCategory: "FUND",
+        },
+      ],
+    },
+    dividends: {
+      grossIncome: new Decimal("500"),
+      deductibleExpenses: new Decimal("75"),
+      entries: [
+        {
+          isin: "US78462F1030",
+          symbol: "SPY",
+          description: "US Dividend - SPY",
+          payDate: "20250620",
+          grossAmountEur: new Decimal("500"),
+          withholdingTaxEur: new Decimal("75"),
+          withholdingCountry: "US",
+          currency: "USD",
+          ecbRate: new Decimal("0.92"),
+        },
+      ],
+    },
+    interest: {
+      earned: new Decimal("10"),
+      paid: new Decimal("5"),
+      entries: [],
+    },
+    doubleTaxation: {
+      deduction: new Decimal("75"),
+      byCountry: {
+        US: { taxPaid: new Decimal("75"), deductionAllowed: new Decimal("75") },
+      },
+    },
+    fxGains: {
+      transmissionValue: new Decimal(0),
+      acquisitionValue: new Decimal(0),
+      netGainLoss: new Decimal(0),
+      disposals: [],
+    },
+    ...overrides,
+  };
+}
+
+describe("generatePdfWebReport", () => {
+  it("returns a Blob with application/pdf type", async () => {
+    const blob = await generatePdfWebReport(makeReport(), t);
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe("application/pdf");
+  });
+
+  it("generates a non-trivial PDF (> 10 KB)", async () => {
+    const blob = await generatePdfWebReport(makeReport(), t);
+    expect(blob.size).toBeGreaterThan(10_000);
+  });
+
+  it("starts with PDF magic bytes (%PDF)", async () => {
+    const blob = await generatePdfWebReport(makeReport(), t);
+    const buf = await blob.arrayBuffer();
+    const header = new TextDecoder().decode(new Uint8Array(buf).slice(0, 4));
+    expect(header).toBe("%PDF");
+  });
+
+  it("handles empty disposals without throwing", async () => {
+    const report = makeReport({
+      capitalGains: {
+        transmissionValue: new Decimal(0),
+        acquisitionValue: new Decimal(0),
+        netGainLoss: new Decimal(0),
+        blockedLosses: new Decimal(0),
+        disposals: [],
+      },
+    });
+    await expect(generatePdfWebReport(report, t)).resolves.toBeInstanceOf(Blob);
+  });
+
+  it("handles empty dividends without throwing", async () => {
+    const report = makeReport({
+      dividends: {
+        grossIncome: new Decimal(0),
+        deductibleExpenses: new Decimal(0),
+        entries: [],
+      },
+    });
+    await expect(generatePdfWebReport(report, t)).resolves.toBeInstanceOf(Blob);
+  });
+
+  it("handles warnings section without throwing", async () => {
+    const report = makeReport({ warnings: ["Short sale detected: TSLA", "Missing lot: NVDA"] });
+    await expect(generatePdfWebReport(report, t)).resolves.toBeInstanceOf(Blob);
+  });
+
+  it("includes blocked losses row when blockedLosses > 0", async () => {
+    const report = makeReport({
+      capitalGains: {
+        transmissionValue: new Decimal("10000"),
+        acquisitionValue: new Decimal("8000"),
+        netGainLoss: new Decimal("2000"),
+        blockedLosses: new Decimal("300"),
+        disposals: [],
+      },
+    });
+    const blob = await generatePdfWebReport(report, t);
+    expect(blob.size).toBeGreaterThan(10_000);
+  });
+
+  it("generates a larger PDF with operations than without", async () => {
+    const withOps = await generatePdfWebReport(makeReport(), t);
+    const withoutOps = await generatePdfWebReport(
+      makeReport({
+        capitalGains: {
+          transmissionValue: new Decimal(0),
+          acquisitionValue: new Decimal(0),
+          netGainLoss: new Decimal(0),
+          blockedLosses: new Decimal(0),
+          disposals: [],
+        },
+      }),
+      t,
+    );
+    expect(withOps.size).toBeGreaterThan(withoutOps.size);
+  });
+});

--- a/tests/generators/pdf-web.test.ts
+++ b/tests/generators/pdf-web.test.ts
@@ -97,7 +97,7 @@ describe("generatePdfWebReport", () => {
     expect(blob.type).toBe("application/pdf");
   });
 
-  it("generates a non-trivial PDF (> 10 KB)", async () => {
+  it("generates a non-trivial PDF (smoke: > 10 KB)", async () => {
     const blob = await generatePdfWebReport(makeReport(), t);
     expect(blob.size).toBeGreaterThan(10_000);
   });
@@ -148,8 +148,7 @@ describe("generatePdfWebReport", () => {
         disposals: [],
       },
     });
-    const blob = await generatePdfWebReport(report, t);
-    expect(blob.size).toBeGreaterThan(10_000);
+    await expect(generatePdfWebReport(report, t)).resolves.toBeInstanceOf(Blob);
   });
 
   it("generates a larger PDF with operations than without", async () => {
@@ -220,14 +219,10 @@ describe("generatePdfWebReport", () => {
         ],
       },
     });
-    const blob = await generatePdfWebReport(report, t);
-    expect(blob).toBeInstanceOf(Blob);
-    expect(blob.size).toBeGreaterThan(10_000);
+    await expect(generatePdfWebReport(report, t)).resolves.toBeInstanceOf(Blob);
   });
 
   it("handles warnings long enough to overflow onto a new page", async () => {
-    // 20 warnings of 300 chars each force multi-line wrapping at 7pt that
-    // fills beyond PAGE_H - MARGIN - 20, triggering doc.addPage() in the warnings loop
     const longWarning = "Warning: missing acquisition cost data for ticker ".padEnd(300, "X");
     const report = makeReport({
       capitalGains: {
@@ -241,14 +236,10 @@ describe("generatePdfWebReport", () => {
       doubleTaxation: { deduction: new Decimal(0), byCountry: {} },
       warnings: Array.from({ length: 20 }, (_, i) => `${i + 1}: ${longWarning}`),
     });
-    const blob = await generatePdfWebReport(report, t);
-    expect(blob).toBeInstanceOf(Blob);
-    expect(blob.size).toBeGreaterThan(10_000);
+    await expect(generatePdfWebReport(report, t)).resolves.toBeInstanceOf(Blob);
   });
 
   it("pushes ECB footnote to a new page when warnings fill the page near the bottom", async () => {
-    // 18 medium-length warnings push contentEndY past the footnote threshold (PAGE_H - MARGIN - 35)
-    // without triggering the warnings page-break themselves (which resets the cursor)
     const mediumWarning = "Warning: ECB rate not found, using fallback rate for ".padEnd(200, "X");
     const report = makeReport({
       capitalGains: {
@@ -262,8 +253,6 @@ describe("generatePdfWebReport", () => {
       doubleTaxation: { deduction: new Decimal(0), byCountry: {} },
       warnings: Array.from({ length: 18 }, (_, i) => `${i + 1}: ${mediumWarning}`),
     });
-    const blob = await generatePdfWebReport(report, t);
-    expect(blob).toBeInstanceOf(Blob);
-    expect(blob.size).toBeGreaterThan(10_000);
+    await expect(generatePdfWebReport(report, t)).resolves.toBeInstanceOf(Blob);
   });
 });

--- a/tests/generators/pdf-web.test.ts
+++ b/tests/generators/pdf-web.test.ts
@@ -168,7 +168,7 @@ describe("generatePdfWebReport", () => {
     expect(withOps.size).toBeGreaterThan(withoutOps.size);
   });
 
-  it("renders option disposals with expiration and exercise scenarios", async () => {
+  it("renders option disposals with expiration, exercise, and close scenarios", async () => {
     const report = makeReport({
       capitalGains: {
         transmissionValue: new Decimal("500"),
@@ -216,10 +216,72 @@ describe("generatePdfWebReport", () => {
             underlyingSymbol: "AAPL",
             putCall: "C",
           },
+          {
+            isin: "US0231351067",
+            symbol: "AAPL250320C00180000",
+            description: "AAPL Mar 2025 180C",
+            sellDate: "20250320",
+            acquireDate: "20250101",
+            quantity: new Decimal("3"),
+            proceedsEur: new Decimal("600"),
+            costBasisEur: new Decimal("400"),
+            gainLossEur: new Decimal("200"),
+            holdingPeriodDays: 78,
+            currency: "USD",
+            sellEcbRate: new Decimal("0.91"),
+            acquireEcbRate: new Decimal("0.90"),
+            washSaleBlocked: false,
+            assetCategory: "OPT",
+            optionScenario: "close",
+            underlyingSymbol: "AAPL",
+            putCall: "C",
+          },
         ],
       },
     });
     await expect(generatePdfWebReport(report, t)).resolves.toBeInstanceOf(Blob);
+  });
+
+  it("includes key casilla numbers in PDF content", async () => {
+    const blob = await generatePdfWebReport(makeReport(), t);
+    const buf = await blob.arrayBuffer();
+    const text = new TextDecoder("latin1").decode(new Uint8Array(buf));
+    expect(text).toContain("0327");
+    expect(text).toContain("0029");
+    expect(text).toContain("0027");
+    expect(text).toContain("0588");
+  });
+
+  it("handles 50+ disposals without throwing (pagination stress)", async () => {
+    const disposals = Array.from({ length: 55 }, (_, i) => ({
+      isin: `US${String(i).padStart(10, "0")}`,
+      symbol: `SYM${i}`,
+      description: `Security ${i}`,
+      sellDate: "20251201",
+      acquireDate: "20240101",
+      quantity: new Decimal("10"),
+      proceedsEur: new Decimal("1000"),
+      costBasisEur: new Decimal("800"),
+      gainLossEur: new Decimal("200"),
+      holdingPeriodDays: 334,
+      currency: "USD",
+      sellEcbRate: new Decimal("0.92"),
+      acquireEcbRate: new Decimal("0.91"),
+      washSaleBlocked: false,
+      assetCategory: "STK",
+    }));
+    const report = makeReport({
+      capitalGains: {
+        transmissionValue: new Decimal("55000"),
+        acquisitionValue: new Decimal("44000"),
+        netGainLoss: new Decimal("11000"),
+        blockedLosses: new Decimal(0),
+        disposals,
+      },
+    });
+    const blob = await generatePdfWebReport(report, t);
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.size).toBeGreaterThan(20_000);
   });
 
   it("handles warnings long enough to overflow onto a new page", async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,10 @@ export default defineConfig({
   test: {
     include: ["tests/**/*.test.ts"],
     globals: false,
+    define: {
+      __APP_VERSION__: JSON.stringify("test"),
+      __COMMIT_HASH__: JSON.stringify("test"),
+    },
     coverage: {
       provider: "v8",
       include: ["src/engine/**", "src/generators/**", "src/parsers/**", "src/i18n/**"],


### PR DESCRIPTION
## Summary

Adds browser-side PDF export for Modelo 100 results using jsPDF 2.5.2 and jspdf-autotable 5.0.7.

- New `Exportar PDF` button in the results section
- PDF generation is fully client-side, so no financial data leaves the browser
- jsPDF and jspdf-autotable are lazy-loaded via `dynamic import()` on first click
- Included sections: casillas summary, trade operations with gain/loss color coding, dividends, double taxation by country, warnings, ECB exchange-rate footnote, and page numbers

## Technical details

- `jsPDF` pinned at `2.5.2`
- `jspdf-autotable` pinned at `5.0.7`
- PDF path is lazy-loaded and kept out of `main.js`
- `contentEndY` tracking prevents the ECB footnote from overlapping with warnings
- Export errors surface in the review panel, following the existing app pattern
- The PDF header date follows the active locale

## Bundle note

The lazy PDF path loads approximately:
- `jsPDF`: ~118 KB gz
- `jspdf-autotable`: ~9.9 KB gz

Total: ~128 KB gz.

This exceeds the 100 KB target mentioned in `#64`, but the trade-off is accepted because:
- it has no effect on initial page load
- it is only downloaded on explicit user action
- `html2canvas` and `dompurify` appear in the Vite build graph but are not fetched in practice, because this implementation does not use `doc.html()`

## Validation

- `npm test -- --run tests/generators/pdf-web.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run build`

All green.

Closes #64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export tax reports as formatted, multi-page PDF with a download button in results and year-based filenames

* **Localization**
  * PDF UI and report strings added across supported locales (en, es, ca, eu, gl)

* **Content Updates**
  * Modelo 100 documentation, UI labels and exports now reference Casilla 0027 (interest) instead of 0033
  * PDF/footer now shows declarenta.com

* **Tests / Chores**
  * End-to-end PDF generation tests added; PDF generation libraries included
<!-- end of auto-generated comment: release notes by coderabbit.ai -->