### PR TITLE
Fix (Lightyear) Error in commission calculation. Error in discounting the stock sale commission.

### DIFF
--- a/src/parsers/lightyear.ts
+++ b/src/parsers/lightyear.ts
@@ -191,7 +191,10 @@ function parseLightyearCsv(lines: string[]): Statement {
 
     // Interest and Reward → cash transactions (income)
     if (INCOME_TYPES.has(txType)) {
-      const amountDec = new Decimal(netAmount || grossAmount).abs();
+
+      const amuntRaw = new Decimal(netAmount);
+      const amountDec = amuntRaw.isZero() ? new Decimal(grossAmount) : amuntRaw;
+
       if (amountDec.isZero()) continue;
       cashTransactions.push({
         transactionID: `lightyear-${txType}-${reference || `${tradeDate}-${i}`}`,
@@ -213,7 +216,9 @@ function parseLightyearCsv(lines: string[]): Statement {
     // Lightyear emits a pair: one leg per currency (e.g. USD +64.50, EUR -59.24).
     // Positive gross = acquiring that currency (BUY), negative = spending it (SELL).
     if (txType === "conversion") {
-      const netDec = new Decimal(netAmount || grossAmount);
+      const netRaw = new Decimal(netAmount);
+      const netDec = netRaw.isZero() ? new Decimal(grossAmount) : netRaw;
+
       if (netDec.isZero() || currency === "EUR") continue;
 
       const absDec = netDec.abs();

--- a/src/parsers/lightyear.ts
+++ b/src/parsers/lightyear.ts
@@ -32,6 +32,7 @@ import {
   findColumn,
   stripBom,
 } from "./csv-utils.js";
+import { freedom24Parser } from "./freedom24.js";
 
 // ---------------------------------------------------------------------------
 // Header detection
@@ -185,11 +186,12 @@ function parseLightyearCsv(lines: string[]): Statement {
         });
       }
       continue;
+
     }
 
     // Interest and Reward → cash transactions (income)
     if (INCOME_TYPES.has(txType)) {
-      const amountDec = new Decimal(netAmount || grossAmount).abs();
+      const amountDec = new Decimal(netAmount).abs();
       if (amountDec.isZero()) continue;
       cashTransactions.push({
         transactionID: `lightyear-${txType}-${reference || `${tradeDate}-${i}`}`,
@@ -211,11 +213,11 @@ function parseLightyearCsv(lines: string[]): Statement {
     // Lightyear emits a pair: one leg per currency (e.g. USD +64.50, EUR -59.24).
     // Positive gross = acquiring that currency (BUY), negative = spending it (SELL).
     if (txType === "conversion") {
-      const grossDec = new Decimal(grossAmount);
-      if (grossDec.isZero() || currency === "EUR") continue;
+      const netDec = new Decimal(netAmount);
+      if (netDec.isZero() || currency === "EUR") continue;
 
-      const absDec = grossDec.abs();
-      const isFxBuy = grossDec.greaterThan(0);
+      const absDec = netDec.abs();
+      const isFxBuy = netDec.greaterThan(0);
 
       trades.push({
         tradeID: `lightyear-fx-${reference || `${tradeDate}-${currency}-${i}`}`,
@@ -254,9 +256,9 @@ function parseLightyearCsv(lines: string[]): Statement {
     const qtyDec = new Decimal(quantityStr).abs();
     if (qtyDec.isZero()) continue;
 
-    const feeDec = new Decimal(fee);
-    const grossDec = new Decimal(grossAmount).abs();
-    const price = pricePerShare || (qtyDec.isZero() ? "0" : grossDec.div(qtyDec).toString());
+    const feeDec = new Decimal(fee).abs();
+    const netDec = new Decimal(netAmount).abs();
+    const price = pricePerShare || (qtyDec.isZero() ? "0" : netDec.div(qtyDec).toString());
 
     trades.push({
       tradeID: `lightyear-${txType}-${reference || `${tradeDate}-${ticker}-${i}`}`,
@@ -270,16 +272,16 @@ function parseLightyearCsv(lines: string[]): Statement {
       settlementDate: tradeDate,
       quantity: isSell ? qtyDec.neg().toString() : qtyDec.toString(),
       tradePrice: price,
-      tradeMoney: isSell ? grossDec.toString() : grossDec.neg().toString(),
-      proceeds: isSell ? grossDec.toString() : "0",
-      cost: isSell ? "0" : grossDec.neg().toString(),
+      tradeMoney: isSell ? netDec.toString() : netDec.neg().toString(),
+      proceeds: isSell ? netDec.toString() : "0",
+      cost: isSell ? "0" : netDec.neg().toString(),
       fifoPnlRealized: "0",
       fxRateToBase: "1",
       buySell: isSell ? "SELL" : "BUY",
       openCloseIndicator: isSell ? "C" : "O",
       exchange: "LIGHTYEAR",
       commissionCurrency: currency,
-      commission: feeDec.isZero() ? "0" : feeDec.abs().neg().toString(),
+      commission: (feeDec.isZero() || isSell) ? "0" : feeDec.neg().toString(),
       taxes: "0",
       multiplier: "1",
     });

--- a/src/parsers/lightyear.ts
+++ b/src/parsers/lightyear.ts
@@ -257,8 +257,9 @@ function parseLightyearCsv(lines: string[]): Statement {
     if (qtyDec.isZero()) continue;
 
     const feeDec = new Decimal(fee).abs();
+    const grossDec = new Decimal(grossAmount).abs();
     const netDec = new Decimal(netAmount).abs();
-    const price = pricePerShare || (qtyDec.isZero() ? "0" : netDec.div(qtyDec).toString());
+    const price = pricePerShare || (qtyDec.isZero() ? "0" : grossDec.div(qtyDec).toString());
 
     trades.push({
       tradeID: `lightyear-${txType}-${reference || `${tradeDate}-${ticker}-${i}`}`,

--- a/src/parsers/lightyear.ts
+++ b/src/parsers/lightyear.ts
@@ -32,7 +32,7 @@ import {
   findColumn,
   stripBom,
 } from "./csv-utils.js";
-import { freedom24Parser } from "./freedom24.js";
+
 
 // ---------------------------------------------------------------------------
 // Header detection

--- a/src/parsers/lightyear.ts
+++ b/src/parsers/lightyear.ts
@@ -191,7 +191,7 @@ function parseLightyearCsv(lines: string[]): Statement {
 
     // Interest and Reward → cash transactions (income)
     if (INCOME_TYPES.has(txType)) {
-      const amountDec = new Decimal(netAmount).abs();
+      const amountDec = new Decimal(netAmount || grossAmount).abs();
       if (amountDec.isZero()) continue;
       cashTransactions.push({
         transactionID: `lightyear-${txType}-${reference || `${tradeDate}-${i}`}`,
@@ -213,7 +213,7 @@ function parseLightyearCsv(lines: string[]): Statement {
     // Lightyear emits a pair: one leg per currency (e.g. USD +64.50, EUR -59.24).
     // Positive gross = acquiring that currency (BUY), negative = spending it (SELL).
     if (txType === "conversion") {
-      const netDec = new Decimal(netAmount);
+      const netDec = new Decimal(netAmount || grossAmount);
       if (netDec.isZero() || currency === "EUR") continue;
 
       const absDec = netDec.abs();


### PR DESCRIPTION
Se han corregido varios aspectos que hacían que los cash FX no cuadraran.

1. En algunas operaciones se usaba GrossAmount en vez de NetAmount.  En lightyear GrossAmoun incluye el importe total con comisiones incluidas. NetAmount es importe neto.  
2. En las operaciones de venta no es necesario crear una operación de Comisión ya que viene descontado del total que recibimos.

Dejo un csv para que se compruebe que con el sistema anterior los lotes_Fx no cuadran.
[Lightyear Test Fallos FX comisiones 4.csv](https://github.com/user-attachments/files/27968885/Lightyear.Test.Fallos.FX.comisiones.4.csv)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized monetary normalization to prefer net amounts and fall back to gross only when net is zero, reducing zero-value noise.
  * Improved income handling to better reflect interest/rewards using net values.
  * FX conversions now derive direction and quantities from net values and skip base-currency or zero-value legs.
  * Buy/sell trades compute money, proceeds, costs, and fees from net amounts; commissions properly recorded (zero for zero-fee or sell).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/DeclaRenta/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->