### PR TITLE
ADD Implement FX lot julian day nomenclature

### DIFF
--- a/src/engine/dates.ts
+++ b/src/engine/dates.ts
@@ -27,3 +27,12 @@ export function daysBetween(from: string, to: string): number {
     (parseDate(to).getTime() - parseDate(from).getTime()) / (1000 * 60 * 60 * 24),
   );
 }
+
+/** Calculate day of year (1-366) for a date string (YYYYMMDD or YYYY-MM-DD) */
+export function getDayOfYear(date: string): number {
+  const parsed = parseDate(date);
+  const year = parsed.getFullYear();
+  const start = new Date(year, 0, 1);
+  const diff = parsed.getTime() - start.getTime();
+  return Math.floor(diff / (1000 * 60 * 60 * 24)) + 1;
+}

--- a/src/engine/fx-fifo.ts
+++ b/src/engine/fx-fifo.ts
@@ -11,7 +11,7 @@ import type { FxLot, FxDisposal, FxTrigger } from "../types/tax.js";
 import type { Trade, CashTransaction } from "../types/ibkr.js";
 import type { EcbRateMap } from "../types/ecb.js";
 import { getEcbRate } from "./ecb.js";
-import { daysBetween, normalizeDate } from "./dates.js";
+import { daysBetween, normalizeDate, getDayOfYear } from "./dates.js";
 
 export interface FxEvent {
   date: string;
@@ -26,7 +26,6 @@ export interface FxEvent {
 export class FxFifoEngine {
   private lots: Map<string, FxLot[]> = new Map();
   private disposals: FxDisposal[] = [];
-  private nextLotId = 1;
   warnings: string[] = [];
   private fxMissing: Map<string, { count: number; totalQty: Decimal }> = new Map();
 
@@ -254,8 +253,11 @@ export class FxFifoEngine {
   }
 
   private addLot(event: FxEvent): void {
+    const date = new Date(normalizeDate(event.date));
+    const yearYY = String(date.getFullYear() % 100).padStart(2, "0");
+    const dayOfYear = String(getDayOfYear(event.date)).padStart(3, "0");
     const lot: FxLot = {
-      id: `FX-${this.nextLotId++}`,
+      id: `FX${yearYY}${dayOfYear}`,
       currency: event.currency,
       acquireDate: event.date,
       quantity: event.quantity,

--- a/src/parsers/lightyear.ts
+++ b/src/parsers/lightyear.ts
@@ -192,8 +192,8 @@ function parseLightyearCsv(lines: string[]): Statement {
     // Interest and Reward → cash transactions (income)
     if (INCOME_TYPES.has(txType)) {
 
-      const amuntRaw = new Decimal(netAmount);
-      const amountDec = amuntRaw.isZero() ? new Decimal(grossAmount) : amuntRaw;
+      const amountRaw = new Decimal(netAmount);
+      const amountDec = amountRaw.isZero() ? new Decimal(grossAmount) : amountRaw;
 
       if (amountDec.isZero()) continue;
       cashTransactions.push({

--- a/src/parsers/lightyear.ts
+++ b/src/parsers/lightyear.ts
@@ -191,7 +191,10 @@ function parseLightyearCsv(lines: string[]): Statement {
 
     // Interest and Reward → cash transactions (income)
     if (INCOME_TYPES.has(txType)) {
-      const amountDec = new Decimal(netAmount || grossAmount).abs();
+
+      const amuntRaw = new Decimal(netAmount);
+      const amountDec = amuntRaw.isZero() ? new Decimal(grossAmount) : amuntRaw;
+
       if (amountDec.isZero()) continue;
       cashTransactions.push({
         transactionID: `lightyear-${txType}-${reference || `${tradeDate}-${i}`}`,
@@ -213,7 +216,9 @@ function parseLightyearCsv(lines: string[]): Statement {
     // Lightyear emits a pair: one leg per currency (e.g. USD +64.50, EUR -59.24).
     // Positive gross = acquiring that currency (BUY), negative = spending it (SELL).
     if (txType === "conversion") {
-      const netDec = new Decimal(netAmount || grossAmount);
+      const netRaw = new Decimal(netAmount);
+      const netDec = netRaw.isZero() ? new Decimal(grossAmount) : netRaw;
+
       if (netDec.isZero() || currency === "EUR") continue;
 
       const absDec = netDec.abs();

--- a/src/parsers/lightyear.ts
+++ b/src/parsers/lightyear.ts
@@ -32,6 +32,7 @@ import {
   findColumn,
   stripBom,
 } from "./csv-utils.js";
+import { freedom24Parser } from "./freedom24.js";
 
 // ---------------------------------------------------------------------------
 // Header detection
@@ -185,11 +186,12 @@ function parseLightyearCsv(lines: string[]): Statement {
         });
       }
       continue;
+
     }
 
     // Interest and Reward → cash transactions (income)
     if (INCOME_TYPES.has(txType)) {
-      const amountDec = new Decimal(netAmount || grossAmount).abs();
+      const amountDec = new Decimal(netAmount).abs();
       if (amountDec.isZero()) continue;
       cashTransactions.push({
         transactionID: `lightyear-${txType}-${reference || `${tradeDate}-${i}`}`,
@@ -211,11 +213,11 @@ function parseLightyearCsv(lines: string[]): Statement {
     // Lightyear emits a pair: one leg per currency (e.g. USD +64.50, EUR -59.24).
     // Positive gross = acquiring that currency (BUY), negative = spending it (SELL).
     if (txType === "conversion") {
-      const grossDec = new Decimal(grossAmount);
-      if (grossDec.isZero() || currency === "EUR") continue;
+      const netDec = new Decimal(netAmount);
+      if (netDec.isZero() || currency === "EUR") continue;
 
-      const absDec = grossDec.abs();
-      const isFxBuy = grossDec.greaterThan(0);
+      const absDec = netDec.abs();
+      const isFxBuy = netDec.greaterThan(0);
 
       trades.push({
         tradeID: `lightyear-fx-${reference || `${tradeDate}-${currency}-${i}`}`,
@@ -254,9 +256,9 @@ function parseLightyearCsv(lines: string[]): Statement {
     const qtyDec = new Decimal(quantityStr).abs();
     if (qtyDec.isZero()) continue;
 
-    const feeDec = new Decimal(fee);
-    const grossDec = new Decimal(grossAmount).abs();
-    const price = pricePerShare || (qtyDec.isZero() ? "0" : grossDec.div(qtyDec).toString());
+    const feeDec = new Decimal(fee).abs();
+    const netDec = new Decimal(netAmount).abs();
+    const price = pricePerShare || (qtyDec.isZero() ? "0" : netDec.div(qtyDec).toString());
 
     trades.push({
       tradeID: `lightyear-${txType}-${reference || `${tradeDate}-${ticker}-${i}`}`,
@@ -270,16 +272,16 @@ function parseLightyearCsv(lines: string[]): Statement {
       settlementDate: tradeDate,
       quantity: isSell ? qtyDec.neg().toString() : qtyDec.toString(),
       tradePrice: price,
-      tradeMoney: isSell ? grossDec.toString() : grossDec.neg().toString(),
-      proceeds: isSell ? grossDec.toString() : "0",
-      cost: isSell ? "0" : grossDec.neg().toString(),
+      tradeMoney: isSell ? netDec.toString() : netDec.neg().toString(),
+      proceeds: isSell ? netDec.toString() : "0",
+      cost: isSell ? "0" : netDec.neg().toString(),
       fifoPnlRealized: "0",
       fxRateToBase: "1",
       buySell: isSell ? "SELL" : "BUY",
       openCloseIndicator: isSell ? "C" : "O",
       exchange: "LIGHTYEAR",
       commissionCurrency: currency,
-      commission: feeDec.isZero() ? "0" : feeDec.abs().neg().toString(),
+      commission: (feeDec.isZero() || isSell) ? "0" : feeDec.neg().toString(),
       taxes: "0",
       multiplier: "1",
     });

--- a/src/parsers/lightyear.ts
+++ b/src/parsers/lightyear.ts
@@ -257,8 +257,9 @@ function parseLightyearCsv(lines: string[]): Statement {
     if (qtyDec.isZero()) continue;
 
     const feeDec = new Decimal(fee).abs();
+    const grossDec = new Decimal(grossAmount).abs();
     const netDec = new Decimal(netAmount).abs();
-    const price = pricePerShare || (qtyDec.isZero() ? "0" : netDec.div(qtyDec).toString());
+    const price = pricePerShare || (qtyDec.isZero() ? "0" : grossDec.div(qtyDec).toString());
 
     trades.push({
       tradeID: `lightyear-${txType}-${reference || `${tradeDate}-${ticker}-${i}`}`,

--- a/src/parsers/lightyear.ts
+++ b/src/parsers/lightyear.ts
@@ -32,7 +32,7 @@ import {
   findColumn,
   stripBom,
 } from "./csv-utils.js";
-import { freedom24Parser } from "./freedom24.js";
+
 
 // ---------------------------------------------------------------------------
 // Header detection

--- a/src/parsers/lightyear.ts
+++ b/src/parsers/lightyear.ts
@@ -191,7 +191,7 @@ function parseLightyearCsv(lines: string[]): Statement {
 
     // Interest and Reward → cash transactions (income)
     if (INCOME_TYPES.has(txType)) {
-      const amountDec = new Decimal(netAmount).abs();
+      const amountDec = new Decimal(netAmount || grossAmount).abs();
       if (amountDec.isZero()) continue;
       cashTransactions.push({
         transactionID: `lightyear-${txType}-${reference || `${tradeDate}-${i}`}`,
@@ -213,7 +213,7 @@ function parseLightyearCsv(lines: string[]): Statement {
     // Lightyear emits a pair: one leg per currency (e.g. USD +64.50, EUR -59.24).
     // Positive gross = acquiring that currency (BUY), negative = spending it (SELL).
     if (txType === "conversion") {
-      const netDec = new Decimal(netAmount);
+      const netDec = new Decimal(netAmount || grossAmount);
       if (netDec.isZero() || currency === "EUR") continue;
 
       const absDec = netDec.abs();

--- a/tests/engine/fx-fifo.test.ts
+++ b/tests/engine/fx-fifo.test.ts
@@ -295,8 +295,8 @@ describe("FxFifoEngine", () => {
       expect(remaining![0]!.quantity.toString()).toBe("1200");
       expect(remaining![0]!.costPerUnit.toString()).toBe("0.9");
 
-      // Verify lotId traceability
-      expect(disposals[0]!.lotId).toBe("FX-1");
+      // Verify lotId traceability (FX + YY + DayOfYear: 2025-01-01 = day 1)
+      expect(disposals[0]!.lotId).toBe("FX25001");
     });
   });
 
@@ -382,8 +382,8 @@ describe("FxFifoEngine", () => {
       ]);
 
       const disposals = engine.getDisposals();
-      expect(disposals[0]!.lotId).toBe("FX-1");
-      expect(disposals[1]!.lotId).toBe("FX-2");
+      expect(disposals[0]!.lotId).toBe("FX25074"); // 2025-03-15 = day 74
+      expect(disposals[1]!.lotId).toBe("FX25166"); // 2025-06-15 = day 166
     });
   });
 


### PR DESCRIPTION
Me gustaría sugerir un cambio en la forma de nomenglatura de los lotes FX. 

Dado que se requiere que los lotes FX se tranformen al tipo ECB  y es un dato diario todos los lotes que se generen en el mismo día se agrupan en el mismo lote. Se podría simplificar y ayudar al entendimiento que el dato estuviera relacionado con el día del año en el que se crean. 

La sugerencia sería cambiar FX-01 a FX25-001 al FX25-366 FXAño-Julianday.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * FX lot identifiers now use date-based generation in the format FX{YY}{DDD}, replacing sequential numbering for more consistent tracking.

* **Bug Fixes**
  * Enhanced transaction amount handling in financial statement parsing, improving accuracy for income, foreign exchange conversions, and equity trades.

* **Tests**
  * Updated FX lot ID test cases to validate the new date-based identifier format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/DeclaRenta/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->