### PR TITLE
fix(fx): skip all CASH trades in auto-convert accounts

### DIFF
--- a/src/engine/fx-fifo.ts
+++ b/src/engine/fx-fifo.ts
@@ -179,7 +179,10 @@ export class FxFifoEngine {
       const ecbRate = getEcbRate(rateMap, date, trade.currency);
 
       if (trade.assetCategory === "CASH") {
-        // Direct forex trade — skip FXCONV (automatic conversions)
+        // Skip all CASH trades in auto-convert accounts: the underlying FCY was
+        // created/consumed by the auto-convert mechanism (AFx), so manual
+        // conversions are just cleanup moves with no independent FX exposure.
+        if (autoConvert) continue;
         if (FxFifoEngine.isFxconv(trade)) continue;
 
         const quantity = new Decimal(trade.quantity).abs();

--- a/tests/engine/fx-fifo.test.ts
+++ b/tests/engine/fx-fifo.test.ts
@@ -449,16 +449,14 @@ describe("FxFifoEngine", () => {
       expect(events).toHaveLength(0);
     });
 
-    it("should still allow manual conversions in auto-convert accounts", () => {
+    it("should skip all CASH trades (including manual) in auto-convert accounts", () => {
       const trades = [
         makeTrade({ assetCategory: "CASH", description: "FXCONV", currency: "USD" }),
         makeTrade({ assetCategory: "CASH", description: "EUR.USD", buySell: "BUY", quantity: "1000", currency: "USD" }),
       ];
       const events = FxFifoEngine.extractFxEvents(trades, rateMap);
-      // FXCONV skipped, manual conversion preserved
-      expect(events).toHaveLength(1);
-      expect(events[0]!.trigger).toBe("conversion");
-      expect(events[0]!.quantity.toString()).toBe("1000");
+      // Auto-convert detected (FXCONV) → all CASH trades skipped, no orphan disposals
+      expect(events).toHaveLength(0);
     });
 
     it("should detect auto-convert when notes contains AFx", () => {
@@ -531,18 +529,16 @@ describe("FxFifoEngine", () => {
       const trades = [
         // Auto FX conversion (AFx note)
         makeTrade({ tradeID: "1", assetCategory: "CASH", description: "EUR.USD", notes: "AFx", buySell: "BUY", quantity: "500", currency: "USD" }),
-        // Manual conversion (no AFx)
+        // Manual conversion (no AFx) — still skipped because account is auto-convert
         makeTrade({ tradeID: "2", assetCategory: "CASH", description: "EUR.USD", buySell: "BUY", quantity: "1000", currency: "USD" }),
         // Stock trade
         makeTrade({ tradeID: "3", assetCategory: "STK", symbol: "AAPL", buySell: "BUY", tradeMoney: "800", currency: "USD" }),
       ];
-      // AFx triggers auto-convert -> stock events suppressed, AFx CASH skipped, manual CASH preserved
+      // AFx triggers auto-convert → all CASH and stock events suppressed
       expect(FxFifoEngine.detectAutoConvert(trades)).toBe(true);
       const events = FxFifoEngine.extractFxEvents(trades, rateMap);
-      // Only the manual conversion (trade 2) should generate an event
-      expect(events).toHaveLength(1);
-      expect(events[0]!.trigger).toBe("conversion");
-      expect(events[0]!.quantity.toString()).toBe("1000");
+      // All CASH skipped in auto-convert mode, stock also skipped → zero events
+      expect(events).toHaveLength(0);
     });
 
     it("should detect auto-convert via amount correlation (Signal 4, missing Notes field)", () => {


### PR DESCRIPTION
## Summary
- In auto-convert accounts (AFx/FXCONV markers detected), manual CASH trades on IDEALFX are cleanup conversions of leftover USD — not independent FX events
- Previously these created orphan disposals with `UNKNOWN` lot IDs and gain=0, confusing users (showed "1146.90 EUR" FX transmission value with zero net gain)
- Now ALL CASH-category trades are skipped when `detectAutoConvert()` returns true, eliminating UNKNOWN lots entirely

## Context
User `elmasvital` reported that monodivisa toggle had no effect and UNKNOWN lot IDs appeared. Their account is a hybrid: auto-convert for stock purchases (AFx markers) but they also manually sold USD back on IDEALFX. The manual sells found no lots (the corresponding buys were all AFx, which we correctly skip), producing confusing zero-gain entries.

## Test plan
- [x] Verified with real user XML (hybrid account): FX disposals → 0, no UNKNOWN
- [x] 1047 tests pass, including the non-autoconvert FX gains test (manual-only accounts still produce correct FX events)
- [x] Type check clean, lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed foreign exchange event generation in auto-convert accounts to skip all cash-related trades when auto-conversion is detected, preventing duplicate FX events from automatic currency conversions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/DeclaRenta/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->