### PR TITLE
fix(fx): remove detectAutoConvert, use per-trade FXCONV filtering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,12 +204,11 @@ When adding a new section (like 721), follow this checklist:
 - **ISIN guard**: FOP trades on MEFF often have empty ISIN. The wash-sale matcher must skip disposals with empty ISIN to avoid false matches against unrelated securities
 
 ### FX Phantom Gains from Missing Prior-Year Lots (Hard Trace)
-- Multi-currency accounts (no auto-convert) generate implicit FX events when trading non-EUR securities
-- If the user's Flex Query only covers the declaration year, prior-year FCY acquisitions are missing → no lots exist when the engine tries to consume them
+- If a user's Flex Query only covers the declaration year, prior-year FCY acquisitions are missing → no lots exist when the engine tries to consume them
 - **Old behavior**: `costBasisEur = 0` → fabricated huge phantom profits (e.g. 48K EUR)
 - **Fix**: When lots are missing (both "sin lotes previos" and "insuficientes" paths in fx-fifo.ts), set `costBasisEur = proceedsEur` → zero gain. The warning still fires so users know data is incomplete.
-- **Detection**: `detectAutoConvert()` uses 4 signals (FXCONV markers, absence of manual CASH trades, amount-correlation heuristic). If it returns false, securities trades generate FX events.
-- **User impact**: Users with auto-convert accounts (FXCONV/AFx markers) are unaffected. Only manual multi-currency accounts with incomplete history trigger this.
+- **FX event sources**: Only explicit CASH trades (non-FXCONV/AFx) generate FX events. Securities trades do NOT generate implicit FX events — this avoids double-counting and phantom gains entirely.
+- FXCONV/AFx trades are filtered per-trade by `isFxconv()`. No global auto-convert detection.
 
 ### Logo vs Favicon (Hard Trace)
 - `src/web/public/logo.png` = the realistic bull app logo (1.9MB, 1024×1024). Used for splash screen and top-bar branding.
@@ -238,11 +237,13 @@ When adding a new section (like 721), follow this checklist:
 - Art. 80 double taxation deduction is subtly affected (lower `totalSavingsBase` when FX gains are skipped) — accepted known limitation matching competitors
 - DGT V2324-10 is the specific consulta vinculante confirming FIFO for currency — cite specifically, not generic "consultas vinculantes"
 
-### Auto-Convert Detection Limitations
-- `detectAutoConvert()` returns true when AFx markers exist, preventing securities trades from generating implicit FX events
-- **USD deposits** (`type="Deposits/Withdrawals"` in cashTransactions) do NOT create FX acquisition lots in auto-convert accounts because `extractCashFxEvents()` returns `[]` when `autoConvert=true`
-- This means a user who deposits USD directly, then converts it manually, will get "UNKNOWN" lot IDs with gain=0 — correct conservative treatment but confusing UX
-- **Future enhancement**: USD deposits should always create FX acquisition lots regardless of auto-convert status
+### FX Engine Simplification (Hard Trace — v0.39.2)
+- `detectAutoConvert()` was REMOVED — it produced false positives on hybrid accounts (mix of manual + AFx trades), causing ALL operations to disappear
+- **Root cause**: A binary global flag can't represent accounts that mix manual conversions and auto-convert. One AFx trade anywhere → entire account classified as auto-convert → all manual CASH trades skipped
+- **New approach**: Per-trade filtering only. `isFxconv()` skips FXCONV/AFx-marked trades individually. Manual CASH trades always generate FX events regardless of what other trades exist.
+- Securities trades (STK, OPT, etc.) NEVER generate implicit FX events — this matches competitor behavior and avoids phantom gains from missing prior-year lots
+- `extractCashFxEvents()` always processes dividends/interest (no `autoConvert` param) — FCY income creates acquisition lots
+- **Impact**: Pure auto-convert accounts still correct (all CASH trades have AFx → all skipped). Hybrid accounts now correct (manual conversions processed, AFx skipped). The only "loss" is theoretical implicit FX from holding FCY across stock trades — but that was phantom gains anyway due to missing lots.
 
 ## Project Philosophy
 

--- a/src/engine/fx-fifo.ts
+++ b/src/engine/fx-fifo.ts
@@ -72,142 +72,36 @@ export class FxFifoEngine {
   }
 
   /**
-   * Detect whether the account uses automatic currency conversion.
-   * If FXCONV trades exist, the broker converts FCY instantly on each trade —
-   * the user never holds FCY between operations, so securities trades
-   * don't generate independent FX exposure.
-   *
-   * Detection uses multiple signals (any one triggers auto-convert):
-   * 1. FXCONV/CASH RECEIPTS/DISBURSEMENTS in trade descriptions
-   * 2. exchange="FXCONV" on CASH-category trades
-   * 3. Heuristic: non-EUR securities trades exist but zero manual CASH trades
-   *    (user never converted manually → broker does it automatically)
-   * 4. Amount-correlation: all CASH trades on IDEALFX with amounts matching
-   *    same-day securities tradeMoney within 2% (broker converts exact amounts
-   *    needed for settlement). Requires ≥3 CASH trades and 90%+ matches.
-   */
-  static detectAutoConvert(trades: Trade[]): boolean {
-    // Signal 1+2: Explicit FXCONV markers in trade data
-    if (trades.some((t) => t.assetCategory === "CASH" && FxFifoEngine.isFxconv(t))) {
-      return true;
-    }
-
-    // Signal 3: Heuristic — non-EUR stock trades exist but no manual CASH trades at all
-    const hasNonEurSecurities = trades.some(
-      (t) => t.currency !== "EUR" && t.assetCategory !== "CASH" && t.assetCategory !== "WAR",
-    );
-    const hasManualCashTrades = trades.some(
-      (t) => t.assetCategory === "CASH" && !FxFifoEngine.isFxconv(t),
-    );
-
-    if (hasNonEurSecurities && !hasManualCashTrades) {
-      return true;
-    }
-
-    // Signal 4: Amount-correlation heuristic for missing Notes/AFx marker.
-    // Auto-convert CASH trades have amounts that closely match same-day
-    // securities tradeMoney (broker converts exactly what's needed).
-    // Manual conversions are typically bulk round amounts unrelated to trades.
-    if (hasNonEurSecurities && hasManualCashTrades) {
-      const cashTrades = trades.filter(
-        (t) => t.assetCategory === "CASH" && !FxFifoEngine.isFxconv(t) && t.currency !== "EUR",
-      );
-      const allOnIdealfx = cashTrades.every(
-        (t) => (t.exchange || "").toUpperCase() === "IDEALFX",
-      );
-
-      if (allOnIdealfx && cashTrades.length >= 3) {
-        const nonEurStk = trades.filter(
-          (t) => t.assetCategory !== "CASH" && t.assetCategory !== "WAR" && t.currency !== "EUR",
-        );
-        let matchedCount = 0;
-        const usedStkIds = new Set<string>();
-
-        for (const cash of cashTrades) {
-          const cashDate = normalizeDate(cash.tradeDate);
-          const cashQty = new Decimal(cash.quantity).abs();
-
-          for (const stk of nonEurStk) {
-            if (usedStkIds.has(stk.tradeID)) continue;
-            if (normalizeDate(stk.tradeDate) !== cashDate) continue;
-            const stkMoney = new Decimal(stk.tradeMoney).abs();
-            if (stkMoney.isZero()) continue;
-
-            const ratio = cashQty.div(stkMoney);
-            if (ratio.gte("0.98") && ratio.lte("1.02")) {
-              matchedCount++;
-              usedStkIds.add(stk.tradeID);
-              break;
-            }
-          }
-        }
-
-        if (matchedCount / cashTrades.length >= 0.90) {
-          return true;
-        }
-      }
-    }
-
-    return false;
-  }
-
-  /**
    * Extract FX events from trades.
    *
-   * Two sources of FX events:
-   * 1. CASH trades (assetCategory=CASH): direct forex conversions
-   *    - BUY CASH in USD = acquiring USD (add lot)
-   *    - SELL CASH in USD = disposing USD (consume lots)
-   * 2. Securities trades in non-EUR (ONLY in multi-currency accounts):
-   *    - BUY stock in USD = spending USD (dispose FCY lots)
-   *    - SELL stock in USD = receiving USD (add FCY lot)
+   * Only explicit CASH trades generate FX events:
+   *   - BUY CASH in USD = acquiring USD (add lot)
+   *   - SELL CASH in USD = disposing USD (consume lots)
    *
-   * Auto-convert accounts: only manual CASH conversions generate FX events.
-   * Stock trades are settled instantly via FXCONV — no FX exposure.
+   * FXCONV/AFx-marked trades (automatic broker conversions for settlement)
+   * are skipped per-trade via isFxconv(). No global auto-convert detection —
+   * accounts can mix manual and automatic conversions freely.
+   *
+   * Securities trades do NOT generate implicit FX events. This avoids
+   * double-counting (the broker's AFx conversion already covers settlement)
+   * and eliminates phantom gains from missing prior-year lots.
    */
   static extractFxEvents(trades: Trade[], rateMap: EcbRateMap): FxEvent[] {
-    const autoConvert = FxFifoEngine.detectAutoConvert(trades);
     const events: FxEvent[] = [];
 
     for (const trade of trades) {
       if (trade.currency === "EUR") continue;
+      if (trade.assetCategory !== "CASH") continue;
+      if (FxFifoEngine.isFxconv(trade)) continue;
 
-      // Use settlement date for FX events: stock purchases and their corresponding
-      // forex conversions settle on the same date (T+2/T+1), eliminating false
-      // "missing lots" warnings caused by trade-date ordering mismatches.
       const date = normalizeDate(trade.settlementDate || trade.tradeDate);
       const ecbRate = getEcbRate(rateMap, date, trade.currency);
+      const quantity = new Decimal(trade.quantity).abs();
 
-      if (trade.assetCategory === "CASH") {
-        // Skip all CASH trades in auto-convert accounts: the underlying FCY was
-        // created/consumed by the auto-convert mechanism (AFx), so manual
-        // conversions are just cleanup moves with no independent FX exposure.
-        if (autoConvert) continue;
-        if (FxFifoEngine.isFxconv(trade)) continue;
-
-        const quantity = new Decimal(trade.quantity).abs();
-        if (trade.buySell === "BUY") {
-          events.push({ date, currency: trade.currency, quantity, ecbRate, trigger: "conversion" });
-        } else {
-          events.push({ date, currency: trade.currency, quantity: quantity.negated(), ecbRate, trigger: "conversion" });
-        }
-      } else if (!autoConvert && trade.assetCategory !== "WAR") {
-        // Multi-currency account: securities trade = implicit FX event
-        const tradeMoney = new Decimal(trade.tradeMoney).abs();
-        if (tradeMoney.isZero()) continue;
-
-        if (trade.buySell === "BUY") {
-          events.push({ date, currency: trade.currency, quantity: tradeMoney.negated(), ecbRate, trigger: "stock_purchase" });
-        } else {
-          events.push({ date, currency: trade.currency, quantity: tradeMoney, ecbRate, trigger: "stock_sale" });
-        }
-
-        // Commission also consumes FCY (paid in commissionCurrency)
-        const commission = new Decimal(trade.commission).abs();
-        if (commission.greaterThan(0) && trade.commissionCurrency !== "EUR") {
-          const commRate = getEcbRate(rateMap, date, trade.commissionCurrency);
-          events.push({ date, currency: trade.commissionCurrency, quantity: commission.negated(), ecbRate: commRate, trigger: "commission" });
-        }
+      if (trade.buySell === "BUY") {
+        events.push({ date, currency: trade.currency, quantity, ecbRate, trigger: "conversion" });
+      } else {
+        events.push({ date, currency: trade.currency, quantity: quantity.negated(), ecbRate, trigger: "conversion" });
       }
     }
 
@@ -217,12 +111,10 @@ export class FxFifoEngine {
   /**
    * Extract FX events from cash transactions (dividends, interest).
    *
-   * Only relevant for multi-currency accounts where FCY is held.
-   * Auto-convert accounts don't hold FCY — dividends/interest are
-   * converted instantly, so no FX lots are created.
+   * Dividends/interest received in FCY create acquisition lots;
+   * withholding tax and fees paid in FCY consume lots.
    */
-  static extractCashFxEvents(cashTransactions: CashTransaction[], rateMap: EcbRateMap, autoConvert: boolean): FxEvent[] {
-    if (autoConvert) return [];
+  static extractCashFxEvents(cashTransactions: CashTransaction[], rateMap: EcbRateMap): FxEvent[] {
 
     const events: FxEvent[] = [];
 

--- a/src/generators/report.ts
+++ b/src/generators/report.ts
@@ -115,7 +115,7 @@ export function generateTaxReport(
   });
 
   // 4. FX gains (Art. 37.1.l LIRPF — currency conversions as taxable events)
-  // Auto-convert accounts (FXCONV present) don't hold FCY — no implicit FX events from trades
+  // FXCONV/AFx trades filtered per-trade by isFxconv(); securities trades don't generate FX events
   // skipFx: monodivisa mode — treat all as EUR, no separate FX saldo (like Autodeclaro/Taxdown)
   let fxDisposals: ReturnType<FxFifoEngine["processEvents"]> = [];
   let fxTransmissionValue = new Decimal(0);

--- a/src/generators/report.ts
+++ b/src/generators/report.ts
@@ -125,9 +125,8 @@ export function generateTaxReport(
 
   if (!options?.skipFx) {
     const fxEngine = new FxFifoEngine();
-    const autoConvert = FxFifoEngine.detectAutoConvert(statement.trades);
     const tradeFxEvents = FxFifoEngine.extractFxEvents(statement.trades, rateMap);
-    const cashFxEvents = FxFifoEngine.extractCashFxEvents(statement.cashTransactions, rateMap, autoConvert);
+    const cashFxEvents = FxFifoEngine.extractCashFxEvents(statement.cashTransactions, rateMap);
     const allFxDisposals = fxEngine.processEvents([...tradeFxEvents, ...cashFxEvents]);
     fxDisposals = allFxDisposals.filter((d) => d.disposeDate.startsWith(yearStr));
 

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -180,7 +180,7 @@ export interface FxLot {
 }
 
 /** What triggered an FX disposal */
-export type FxTrigger = "conversion" | "stock_purchase" | "stock_sale" | "dividend" | "interest" | "commission";
+export type FxTrigger = "conversion" | "dividend" | "interest" | "commission";
 
 /** Result of consuming FX lots via FIFO for a currency disposal */
 export interface FxDisposal {

--- a/tests/engine/fx-fifo.test.ts
+++ b/tests/engine/fx-fifo.test.ts
@@ -237,29 +237,29 @@ describe("FxFifoEngine", () => {
     });
   });
 
-  describe("integration: two-event model", () => {
-    it("should produce correct FX gain for a stock round-trip in USD", () => {
-      // Day 1: Convert EUR 1000 → USD 1100 (rate 0.92 EUR/USD)
-      // Day 30: Buy 10 AAPL @ $110 using USD 1100 (rate 0.95 EUR/USD)
-      // Day 60: Sell 10 AAPL @ $120 = USD 1200 (rate 0.90 EUR/USD)
+  describe("integration: acquire and dispose", () => {
+    it("should produce correct FX gain for a conversion round-trip in USD", () => {
+      // Day 1: Convert EUR → USD 1100 (rate 0.92 EUR/USD)
+      // Day 30: Convert USD 1100 back (rate 0.95 EUR/USD) — FX gain
+      // Day 60: Convert EUR → USD 1200 (rate 0.90 EUR/USD) — new lot
       const engine = new FxFifoEngine();
       engine.processEvents([
         { date: "2025-01-01", currency: "USD", quantity: new Decimal(1100), ecbRate: new Decimal("0.92"), trigger: "conversion" },
-        { date: "2025-01-31", currency: "USD", quantity: new Decimal(-1100), ecbRate: new Decimal("0.95"), trigger: "stock_purchase" },
-        { date: "2025-03-01", currency: "USD", quantity: new Decimal(1200), ecbRate: new Decimal("0.90"), trigger: "stock_sale" },
+        { date: "2025-01-31", currency: "USD", quantity: new Decimal(-1100), ecbRate: new Decimal("0.95"), trigger: "conversion" },
+        { date: "2025-03-01", currency: "USD", quantity: new Decimal(1200), ecbRate: new Decimal("0.90"), trigger: "conversion" },
       ]);
 
       const disposals = engine.getDisposals();
       expect(disposals).toHaveLength(1);
 
-      // FX gain on the stock purchase:
+      // FX gain on the disposal:
       // Acquired 1100 USD at 0.92 = cost 1012 EUR
       // Disposed at 0.95 = proceeds 1045 EUR
       // FX gain = 1045 - 1012 = 33 EUR
       expect(disposals[0]!.gainLossEur.toFixed(2)).toBe("33.00");
-      expect(disposals[0]!.trigger).toBe("stock_purchase");
+      expect(disposals[0]!.trigger).toBe("conversion");
 
-      // Remaining: 1200 USD lot from stock_sale at rate 0.90
+      // Remaining: 1200 USD lot from second acquisition at rate 0.90
       const remaining = engine.getRemainingLots().get("USD");
       expect(remaining).toHaveLength(1);
       expect(remaining![0]!.quantity.toString()).toBe("1200");

--- a/tests/engine/fx-fifo.test.ts
+++ b/tests/engine/fx-fifo.test.ts
@@ -203,9 +203,28 @@ describe("FxFifoEngine", () => {
       const trades = [
         makeTrade({ description: "FXCONV" }),
         makeTrade({ description: "CASH RECEIPTS / DISBURSEMENTS" }),
+        makeTrade({ description: "CASH DISBURSEMENTS" }),
       ];
       const events = FxFifoEngine.extractFxEvents(trades, rateMap);
       expect(events).toHaveLength(0);
+    });
+
+    it("should fall back to tradeDate when settlementDate is empty", () => {
+      const trades = [
+        makeTrade({ buySell: "BUY", quantity: "1000", settlementDate: "", tradeDate: "20250315" }),
+      ];
+      const events = FxFifoEngine.extractFxEvents(trades, rateMap);
+      expect(events).toHaveLength(1);
+      expect(events[0]!.date).toBe("2025-03-15");
+    });
+
+    it("should handle negative quantity on BUY via .abs() normalization", () => {
+      const trades = [
+        makeTrade({ buySell: "BUY", quantity: "-500" }),
+      ];
+      const events = FxFifoEngine.extractFxEvents(trades, rateMap);
+      expect(events).toHaveLength(1);
+      expect(events[0]!.quantity.toString()).toBe("500");
     });
 
     it("should only extract CASH trades, ignoring STK trades entirely", () => {

--- a/tests/engine/fx-fifo.test.ts
+++ b/tests/engine/fx-fifo.test.ts
@@ -208,60 +208,30 @@ describe("FxFifoEngine", () => {
       expect(events).toHaveLength(0);
     });
 
-    it("should extract stock BUY as negative FX event (spending FCY) + commission", () => {
+    it("should only extract CASH trades, ignoring STK trades entirely", () => {
       const trades = [
         makeTrade({ assetCategory: "CASH", description: "EUR.USD", buySell: "BUY", quantity: "10000", currency: "USD" }),
-        makeTrade({
-          assetCategory: "STK",
-          symbol: "AAPL",
-          isin: "US0378331005",
-          buySell: "BUY",
-          tradeMoney: "5000",
-          currency: "USD",
-        }),
+        makeTrade({ assetCategory: "STK", symbol: "AAPL", buySell: "BUY", tradeMoney: "5000", currency: "USD" }),
       ];
       const events = FxFifoEngine.extractFxEvents(trades, rateMap);
 
-      // Manual CASH conversion + stock BUY (negative) + commission
-      expect(events).toHaveLength(3);
+      expect(events).toHaveLength(1);
       expect(events[0]!.trigger).toBe("conversion");
-      expect(events[1]!.quantity.toString()).toBe("-5000");
-      expect(events[1]!.trigger).toBe("stock_purchase");
-      expect(events[2]!.quantity.toString()).toBe("-2");
-      expect(events[2]!.trigger).toBe("commission");
-    });
-
-    it("should extract stock SELL as positive FX event (receiving FCY) + commission", () => {
-      const trades = [
-        makeTrade({ assetCategory: "CASH", description: "EUR.USD", buySell: "BUY", quantity: "10000", currency: "USD" }),
-        makeTrade({
-          assetCategory: "STK",
-          symbol: "AAPL",
-          isin: "US0378331005",
-          buySell: "SELL",
-          tradeMoney: "6000",
-          currency: "USD",
-        }),
-      ];
-      const events = FxFifoEngine.extractFxEvents(trades, rateMap);
-
-      // Manual CASH conversion + stock SELL (positive) + commission
-      expect(events).toHaveLength(3);
-      expect(events[0]!.trigger).toBe("conversion");
-      expect(events[1]!.quantity.toString()).toBe("6000");
-      expect(events[1]!.trigger).toBe("stock_sale");
-      expect(events[2]!.quantity.toString()).toBe("-2");
-      expect(events[2]!.trigger).toBe("commission");
+      expect(events[0]!.quantity.toString()).toBe("10000");
     });
 
     it("should skip EUR trades", () => {
-      const trades = [makeTrade({ currency: "EUR", assetCategory: "STK", tradeMoney: "5000" })];
+      const trades = [makeTrade({ currency: "EUR" })];
       const events = FxFifoEngine.extractFxEvents(trades, rateMap);
       expect(events).toHaveLength(0);
     });
 
-    it("should skip WAR asset category", () => {
-      const trades = [makeTrade({ assetCategory: "WAR", currency: "USD", tradeMoney: "1000" })];
+    it("should skip non-CASH asset categories", () => {
+      const trades = [
+        makeTrade({ assetCategory: "STK", currency: "USD", tradeMoney: "5000" }),
+        makeTrade({ assetCategory: "WAR", currency: "USD", tradeMoney: "1000" }),
+        makeTrade({ assetCategory: "OPT", currency: "USD", tradeMoney: "2000" }),
+      ];
       const events = FxFifoEngine.extractFxEvents(trades, rateMap);
       expect(events).toHaveLength(0);
     });
@@ -307,7 +277,7 @@ describe("FxFifoEngine", () => {
         isin: "US0378331005", currency: "USD", dateTime: "20250315",
         settleDate: "20250317", amount: "100", fxRateToBase: "0.92", type: "Dividends" as const,
       }];
-      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap, false);
+      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap);
       expect(events).toHaveLength(1);
       expect(events[0]!.quantity.toString()).toBe("100");
       expect(events[0]!.trigger).toBe("dividend");
@@ -319,7 +289,7 @@ describe("FxFifoEngine", () => {
         isin: "US0378331005", currency: "USD", dateTime: "20250315",
         settleDate: "20250317", amount: "-15", fxRateToBase: "0.92", type: "Withholding Tax" as const,
       }];
-      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap, false);
+      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap);
       expect(events).toHaveLength(1);
       expect(events[0]!.quantity.toString()).toBe("-15");
       expect(events[0]!.trigger).toBe("dividend");
@@ -331,7 +301,7 @@ describe("FxFifoEngine", () => {
         isin: "", currency: "USD", dateTime: "20250315",
         settleDate: "20250317", amount: "25", fxRateToBase: "0.92", type: "Broker Interest Received" as const,
       }];
-      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap, false);
+      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap);
       expect(events).toHaveLength(1);
       expect(events[0]!.quantity.toString()).toBe("25");
       expect(events[0]!.trigger).toBe("interest");
@@ -343,7 +313,7 @@ describe("FxFifoEngine", () => {
         isin: "", currency: "USD", dateTime: "20250315",
         settleDate: "20250317", amount: "-10", fxRateToBase: "0.92", type: "Broker Interest Paid" as const,
       }];
-      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap, false);
+      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap);
       expect(events).toHaveLength(1);
       expect(events[0]!.quantity.toString()).toBe("-10");
       expect(events[0]!.trigger).toBe("interest");
@@ -355,7 +325,7 @@ describe("FxFifoEngine", () => {
         isin: "IE00BK5BQT80", currency: "EUR", dateTime: "20250315",
         settleDate: "20250317", amount: "50", fxRateToBase: "1", type: "Dividends" as const,
       }];
-      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap, false);
+      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap);
       expect(events).toHaveLength(0);
     });
 
@@ -365,7 +335,7 @@ describe("FxFifoEngine", () => {
         isin: "", currency: "USD", dateTime: "20250315",
         settleDate: "20250317", amount: "-5", fxRateToBase: "0.92", type: "Other Fees" as const,
       }];
-      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap, false);
+      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap);
       expect(events).toHaveLength(1);
       expect(events[0]!.quantity.toString()).toBe("-5");
       expect(events[0]!.trigger).toBe("commission");
@@ -387,109 +357,26 @@ describe("FxFifoEngine", () => {
     });
   });
 
-  describe("auto-convert detection", () => {
-    it("should detect auto-convert when FXCONV trades exist", () => {
-      const trades = [
-        makeTrade({ assetCategory: "CASH", description: "FXCONV", currency: "USD" }),
-        makeTrade({ assetCategory: "STK", symbol: "AAPL", currency: "USD" }),
-      ];
-      expect(FxFifoEngine.detectAutoConvert(trades)).toBe(true);
-    });
-
-    it("should detect auto-convert when CASH RECEIPTS trades exist", () => {
-      const trades = [
-        makeTrade({ assetCategory: "CASH", description: "CASH RECEIPTS / DISBURSEMENTS", currency: "USD" }),
-      ];
-      expect(FxFifoEngine.detectAutoConvert(trades)).toBe(true);
-    });
-
-    it("should NOT detect auto-convert when only manual CASH trades exist", () => {
-      const trades = [
-        makeTrade({ assetCategory: "CASH", description: "EUR.USD", buySell: "BUY", currency: "USD" }),
-      ];
-      expect(FxFifoEngine.detectAutoConvert(trades)).toBe(false);
-    });
-
-    it("should skip stock FX events in auto-convert mode", () => {
-      const trades = [
-        makeTrade({ assetCategory: "CASH", description: "FXCONV", currency: "USD" }),
-        makeTrade({ assetCategory: "STK", symbol: "AAPL", buySell: "BUY", tradeMoney: "5000", currency: "USD" }),
-      ];
-      const events = FxFifoEngine.extractFxEvents(trades, rateMap);
-      // Only the FXCONV is detected (and skipped) — no stock event generated
-      expect(events).toHaveLength(0);
-    });
-
-    it("should generate stock FX events in multi-currency mode (manual CASH trade present)", () => {
-      const trades = [
-        makeTrade({ assetCategory: "CASH", description: "EUR.USD", buySell: "BUY", quantity: "10000", currency: "USD" }),
-        makeTrade({ assetCategory: "STK", symbol: "AAPL", buySell: "BUY", tradeMoney: "5000", currency: "USD" }),
-      ];
-      const events = FxFifoEngine.extractFxEvents(trades, rateMap);
-      const stockEvents = events.filter((e) => e.trigger === "stock_purchase");
-      expect(stockEvents.length).toBeGreaterThan(0);
-      expect(stockEvents[0]!.trigger).toBe("stock_purchase");
-    });
-
-    it("should NOT generate stock FX events when no CASH trades (auto-convert heuristic)", () => {
-      const trades = [
-        makeTrade({ assetCategory: "STK", symbol: "AAPL", buySell: "BUY", tradeMoney: "5000", currency: "USD" }),
-      ];
-      const events = FxFifoEngine.extractFxEvents(trades, rateMap);
-      expect(events).toHaveLength(0);
-    });
-
-    it("should return empty cash events in auto-convert mode", () => {
-      const txs = [{
-        transactionID: "1", accountId: "U1", symbol: "AAPL", description: "AAPL dividend",
-        isin: "US0378331005", currency: "USD", dateTime: "20250315",
-        settleDate: "20250317", amount: "100", fxRateToBase: "0.92", type: "Dividends" as const,
-      }];
-      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap, true);
-      expect(events).toHaveLength(0);
-    });
-
-    it("should skip all CASH trades (including manual) in auto-convert accounts", () => {
+  describe("FXCONV/AFx per-trade filtering", () => {
+    it("should skip FXCONV-described CASH trades", () => {
       const trades = [
         makeTrade({ assetCategory: "CASH", description: "FXCONV", currency: "USD" }),
         makeTrade({ assetCategory: "CASH", description: "EUR.USD", buySell: "BUY", quantity: "1000", currency: "USD" }),
       ];
       const events = FxFifoEngine.extractFxEvents(trades, rateMap);
-      // Auto-convert detected (FXCONV) → all CASH trades skipped, no orphan disposals
-      expect(events).toHaveLength(0);
+      expect(events).toHaveLength(1);
+      expect(events[0]!.quantity.toString()).toBe("1000");
     });
 
-    it("should detect auto-convert when notes contains AFx", () => {
-      const trades = [
-        makeTrade({ assetCategory: "CASH", description: "EUR.USD", notes: "AFx", currency: "USD" }),
-      ];
-      expect(FxFifoEngine.detectAutoConvert(trades)).toBe(true);
-    });
-
-    it("should detect auto-convert when notes contains AFx in semicolon-separated values", () => {
-      const trades = [
-        makeTrade({ assetCategory: "CASH", description: "EUR.USD", notes: "AFx;P", currency: "USD" }),
-      ];
-      expect(FxFifoEngine.detectAutoConvert(trades)).toBe(true);
-    });
-
-    it("should detect auto-convert when notes contains AFx with mixed case", () => {
-      const trades = [
-        makeTrade({ assetCategory: "CASH", description: "EUR.USD", notes: "afx", currency: "USD" }),
-      ];
-      expect(FxFifoEngine.detectAutoConvert(trades)).toBe(true);
-    });
-
-    it("should skip AFx-noted CASH trades in extractFxEvents", () => {
+    it("should skip AFx-noted CASH trades", () => {
       const trades = [
         makeTrade({ assetCategory: "CASH", description: "EUR.USD", notes: "AFx", buySell: "BUY", quantity: "1000", currency: "USD" }),
       ];
       const events = FxFifoEngine.extractFxEvents(trades, rateMap);
-      // AFx trade is recognized as FXCONV, skipped; also triggers auto-convert so no stock events
       expect(events).toHaveLength(0);
     });
 
-    it("should skip AFx;P-noted CASH trades in extractFxEvents", () => {
+    it("should skip AFx;P-noted CASH trades", () => {
       const trades = [
         makeTrade({ assetCategory: "CASH", description: "EUR.USD", notes: "AFx;P", buySell: "BUY", quantity: "500", currency: "USD" }),
       ];
@@ -497,108 +384,68 @@ describe("FxFifoEngine", () => {
       expect(events).toHaveLength(0);
     });
 
-    it("should detect auto-convert when exchange is FXCONV", () => {
+    it("should skip exchange=FXCONV CASH trades", () => {
       const trades = [
         makeTrade({ assetCategory: "CASH", description: "EUR.USD", exchange: "FXCONV", currency: "USD" }),
       ];
-      expect(FxFifoEngine.detectAutoConvert(trades)).toBe(true);
-    });
-
-    it("should NOT detect auto-convert when notes field is undefined", () => {
-      const trades = [
-        makeTrade({ assetCategory: "CASH", description: "EUR.USD", buySell: "BUY", notes: undefined, currency: "USD" }),
-      ];
-      expect(FxFifoEngine.detectAutoConvert(trades)).toBe(false);
-    });
-
-    it("should NOT detect auto-convert when notes is empty string", () => {
-      const trades = [
-        makeTrade({ assetCategory: "CASH", description: "EUR.USD", buySell: "BUY", notes: "", currency: "USD" }),
-      ];
-      expect(FxFifoEngine.detectAutoConvert(trades)).toBe(false);
-    });
-
-    it("should NOT detect auto-convert when notes contains unrelated values like P", () => {
-      const trades = [
-        makeTrade({ assetCategory: "CASH", description: "EUR.USD", buySell: "BUY", notes: "P", currency: "USD" }),
-      ];
-      expect(FxFifoEngine.detectAutoConvert(trades)).toBe(false);
-    });
-
-    it("should handle mixed scenario: AFx trades and manual trades in same account", () => {
-      const trades = [
-        // Auto FX conversion (AFx note)
-        makeTrade({ tradeID: "1", assetCategory: "CASH", description: "EUR.USD", notes: "AFx", buySell: "BUY", quantity: "500", currency: "USD" }),
-        // Manual conversion (no AFx) — still skipped because account is auto-convert
-        makeTrade({ tradeID: "2", assetCategory: "CASH", description: "EUR.USD", buySell: "BUY", quantity: "1000", currency: "USD" }),
-        // Stock trade
-        makeTrade({ tradeID: "3", assetCategory: "STK", symbol: "AAPL", buySell: "BUY", tradeMoney: "800", currency: "USD" }),
-      ];
-      // AFx triggers auto-convert → all CASH and stock events suppressed
-      expect(FxFifoEngine.detectAutoConvert(trades)).toBe(true);
       const events = FxFifoEngine.extractFxEvents(trades, rateMap);
-      // All CASH skipped in auto-convert mode, stock also skipped → zero events
       expect(events).toHaveLength(0);
     });
 
-    it("should detect auto-convert via amount correlation (Signal 4, missing Notes field)", () => {
-      // Simulates Armando's case: EUR-base account, Notes not exported, but CASH amounts
-      // closely match securities tradeMoney on the same date
+    it("should NOT skip when notes is empty or undefined", () => {
       const trades = [
-        makeTrade({ tradeID: "c1", assetCategory: "CASH", description: "EUR.USD", buySell: "BUY", quantity: "5002", tradeMoney: "5002", currency: "USD", tradeDate: "20250410" }),
-        makeTrade({ tradeID: "c2", assetCategory: "CASH", description: "EUR.USD", buySell: "BUY", quantity: "3251", tradeMoney: "3251", currency: "USD", tradeDate: "20250411" }),
-        makeTrade({ tradeID: "c3", assetCategory: "CASH", description: "EUR.USD", buySell: "SELL", quantity: "6001", tradeMoney: "6001", currency: "USD", tradeDate: "20250415" }),
-        makeTrade({ tradeID: "s1", assetCategory: "STK", symbol: "AAPL", buySell: "BUY", tradeMoney: "5000", currency: "USD", tradeDate: "20250410" }),
-        makeTrade({ tradeID: "s2", assetCategory: "STK", symbol: "MSFT", buySell: "BUY", tradeMoney: "3250", currency: "USD", tradeDate: "20250411" }),
-        makeTrade({ tradeID: "s3", assetCategory: "STK", symbol: "AAPL", buySell: "SELL", tradeMoney: "6000", currency: "USD", tradeDate: "20250415" }),
+        makeTrade({ assetCategory: "CASH", description: "EUR.USD", buySell: "BUY", notes: "", quantity: "1000", currency: "USD" }),
+        makeTrade({ assetCategory: "CASH", description: "EUR.USD", buySell: "BUY", notes: undefined, quantity: "2000", currency: "USD" }),
       ];
-      // All CASH on IDEALFX (default), amounts within 2% of STK tradeMoney → auto-convert
-      expect(FxFifoEngine.detectAutoConvert(trades)).toBe(true);
+      const events = FxFifoEngine.extractFxEvents(trades, rateMap);
+      expect(events).toHaveLength(2);
     });
 
-    it("should NOT detect auto-convert when CASH amounts don't correlate with securities", () => {
-      // Manual bulk conversion: user converts 20000 USD, then trades over multiple days
+    it("should NOT skip when notes contains unrelated values like P", () => {
       const trades = [
-        makeTrade({ tradeID: "c1", assetCategory: "CASH", description: "EUR.USD", buySell: "BUY", quantity: "20000", tradeMoney: "20000", currency: "USD", tradeDate: "20250401" }),
-        makeTrade({ tradeID: "c2", assetCategory: "CASH", description: "EUR.USD", buySell: "BUY", quantity: "15000", tradeMoney: "15000", currency: "USD", tradeDate: "20250410" }),
-        makeTrade({ tradeID: "c3", assetCategory: "CASH", description: "EUR.USD", buySell: "BUY", quantity: "10000", tradeMoney: "10000", currency: "USD", tradeDate: "20250420" }),
-        makeTrade({ tradeID: "s1", assetCategory: "STK", symbol: "AAPL", buySell: "BUY", tradeMoney: "5000", currency: "USD", tradeDate: "20250401" }),
-        makeTrade({ tradeID: "s2", assetCategory: "STK", symbol: "MSFT", buySell: "BUY", tradeMoney: "3000", currency: "USD", tradeDate: "20250410" }),
-        makeTrade({ tradeID: "s3", assetCategory: "STK", symbol: "GOOG", buySell: "BUY", tradeMoney: "4000", currency: "USD", tradeDate: "20250420" }),
+        makeTrade({ assetCategory: "CASH", description: "EUR.USD", buySell: "BUY", notes: "P", quantity: "1000", currency: "USD" }),
       ];
-      // CASH amounts are 4x, 5x, 2.5x the stock amounts → NOT auto-convert
-      expect(FxFifoEngine.detectAutoConvert(trades)).toBe(false);
+      const events = FxFifoEngine.extractFxEvents(trades, rateMap);
+      expect(events).toHaveLength(1);
     });
 
-    it("should NOT trigger Signal 4 with fewer than 3 CASH trades", () => {
+    it("should handle hybrid account: manual conversions processed, AFx skipped", () => {
       const trades = [
-        makeTrade({ tradeID: "c1", assetCategory: "CASH", description: "EUR.USD", buySell: "BUY", quantity: "5000", tradeMoney: "5000", currency: "USD", tradeDate: "20250410" }),
-        makeTrade({ tradeID: "c2", assetCategory: "CASH", description: "EUR.USD", buySell: "BUY", quantity: "3250", tradeMoney: "3250", currency: "USD", tradeDate: "20250411" }),
-        makeTrade({ tradeID: "s1", assetCategory: "STK", symbol: "AAPL", buySell: "BUY", tradeMoney: "5000", currency: "USD", tradeDate: "20250410" }),
-        makeTrade({ tradeID: "s2", assetCategory: "STK", symbol: "MSFT", buySell: "BUY", tradeMoney: "3250", currency: "USD", tradeDate: "20250411" }),
+        makeTrade({ tradeID: "1", assetCategory: "CASH", description: "EUR.USD", notes: "AFx", buySell: "BUY", quantity: "500", currency: "USD" }),
+        makeTrade({ tradeID: "2", assetCategory: "CASH", description: "EUR.USD", buySell: "BUY", quantity: "1000", currency: "USD" }),
+        makeTrade({ tradeID: "3", assetCategory: "STK", symbol: "AAPL", buySell: "BUY", tradeMoney: "800", currency: "USD" }),
       ];
-      // Only 2 CASH trades — below minimum 3 threshold
-      expect(FxFifoEngine.detectAutoConvert(trades)).toBe(false);
+      const events = FxFifoEngine.extractFxEvents(trades, rateMap);
+      // Only the manual CASH BUY (tradeID 2) generates an event; AFx skipped, STK ignored
+      expect(events).toHaveLength(1);
+      expect(events[0]!.quantity.toString()).toBe("1000");
+      expect(events[0]!.trigger).toBe("conversion");
     });
 
-    it("should produce zero FX gains when auto-convert account has only AFx trades", () => {
+    it("should produce zero FX events when all CASH trades are AFx", () => {
       const trades = [
         makeTrade({ assetCategory: "CASH", description: "EUR.USD", notes: "AFx", buySell: "BUY", quantity: "5000", currency: "USD" }),
         makeTrade({ assetCategory: "STK", symbol: "AAPL", buySell: "BUY", tradeMoney: "3000", currency: "USD" }),
         makeTrade({ assetCategory: "STK", symbol: "AAPL", buySell: "SELL", tradeMoney: "3500", currency: "USD" }),
       ];
       const events = FxFifoEngine.extractFxEvents(trades, rateMap);
-      // All CASH trades are AFx (skipped), auto-convert detected so stock events suppressed
       expect(events).toHaveLength(0);
 
       const engine = new FxFifoEngine();
       engine.processEvents(events);
       expect(engine.getDisposals()).toHaveLength(0);
-      // Net FX gain = 0
-      const totalGain = engine.getDisposals().reduce(
-        (sum, d) => sum.plus(d.gainLossEur), new Decimal(0),
-      );
-      expect(totalGain.toFixed(2)).toBe("0.00");
+    });
+
+    it("should always process cash transactions (dividends create FX lots)", () => {
+      const txs = [{
+        transactionID: "1", accountId: "U1", symbol: "AAPL", description: "AAPL dividend",
+        isin: "US0378331005", currency: "USD", dateTime: "20250315",
+        settleDate: "20250317", amount: "100", fxRateToBase: "0.92", type: "Dividends" as const,
+      }];
+      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap);
+      expect(events).toHaveLength(1);
+      expect(events[0]!.quantity.toString()).toBe("100");
+      expect(events[0]!.trigger).toBe("dividend");
     });
   });
 });

--- a/tests/parsers/fixtures.test.ts
+++ b/tests/parsers/fixtures.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "fs";
 import { parseIbkrFlexXml } from "../../src/parsers/ibkr.js";
 import { FxFifoEngine } from "../../src/engine/fx-fifo.js";
+import type { EcbRateMap } from "../../src/types/ecb.js";
 import { degiroParser } from "../../src/parsers/degiro.js";
 import { binanceParser } from "../../src/parsers/binance.js";
 import { coinbaseParser } from "../../src/parsers/coinbase.js";
@@ -202,9 +203,12 @@ describe("fixture file integration", () => {
       expect(afxTrades.every((t) => t.exchange === "IDEALFX")).toBe(true);
     });
 
-    it("should detect auto-convert via AFx notes", () => {
+    it("should skip AFx trades and produce zero FX events from CASH", () => {
       const r = parseIbkrFlexXml(xml);
-      expect(FxFifoEngine.detectAutoConvert(r.trades)).toBe(true);
+      const rateMap: EcbRateMap = new Map([["2025-03-17", new Map([["USD", "0.92"]])]]);
+      const events = FxFifoEngine.extractFxEvents(r.trades, rateMap);
+      // All CASH trades have AFx notes → all skipped by isFxconv
+      expect(events).toHaveLength(0);
     });
 
     it("should have 5 STK trades across EUR and USD", () => {
@@ -267,10 +271,12 @@ describe("fixture file integration", () => {
       expect(usd).toHaveLength(5);
     });
 
-    it("should detect auto-convert via heuristic (non-EUR trades, no manual CASH)", () => {
+    it("should produce zero FX events (no manual CASH trades present)", () => {
       const r = parseIbkrFlexXml(xml);
-      // Heuristic: has non-EUR securities but no manual CASH trades → auto-convert
-      expect(FxFifoEngine.detectAutoConvert(r.trades)).toBe(true);
+      const rateMap: EcbRateMap = new Map([["2025-03-17", new Map([["CAD", "0.68"], ["USD", "0.92"]])]]);
+      const events = FxFifoEngine.extractFxEvents(r.trades, rateMap);
+      // No CASH trades at all in this fixture → zero FX events
+      expect(events).toHaveLength(0);
     });
 
     it("should have buy+sell pairs for FIFO testing", () => {

--- a/tests/parsers/lightyear.test.ts
+++ b/tests/parsers/lightyear.test.ts
@@ -399,7 +399,7 @@ describe("lightyearParser", () => {
       expect(fx.quantity).toBe("-500");
     });
 
-    it("should enable FX FIFO detection (autoConvert=false when CASH trades exist)", () => {
+    it("should have CASH trades that generate FX events alongside STK trades", () => {
       const result = lightyearParser.parse(LIGHTYEAR_CSV);
       const hasCash = result.trades.some((t) => t.assetCategory === "CASH");
       const hasNonEurStk = result.trades.some((t) => t.assetCategory === "STK" && t.currency !== "EUR");


### PR DESCRIPTION
## Summary

- Removes `detectAutoConvert()` entirely — it produced false positives on hybrid accounts (mix of manual + AFx trades), causing all FX operations to disappear (reported by elmasvital)
- FX events now only come from explicit CASH trades, filtered per-trade by `isFxconv()` (AFx/FXCONV skipped individually)
- Securities trades no longer generate implicit FX events — eliminates phantom gains from missing prior-year lots and matches competitor behavior
- `extractCashFxEvents()` always processes dividends/interest (no `autoConvert` gate)

## Rationale

The old approach used a binary global flag for the entire account. One AFx trade anywhere → entire account classified as auto-convert → all manual CASH trades skipped. Real IBKR accounts commonly mix both: users convert manually once, then later the broker does it automatically for stock purchases. A single boolean can't represent this.

## Test plan

- [x] All 1033 tests pass
- [x] TypeScript strict check passes
- [x] Hybrid account (manual + AFx trades): manual conversions processed, AFx skipped
- [x] Pure auto-convert (all AFx): zero FX events (correct)
- [x] Pure manual: explicit CASH BUY/SELL processed as FX events (correct)
- [ ] Verify with elmasvital's anonymized XML that operations no longer disappear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified FX engine: Removed automatic auto-convert detection. FX events are now generated only from explicit manual currency trades; securities trades no longer implicitly generate FX events. Per-trade filtering replaces global detection for clearer, more predictable behavior in multi-currency portfolios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/DeclaRenta/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->