### PR TITLE
fix(fx): include commission in FX FIFO cost basis and proceeds

### DIFF
--- a/src/engine/fx-fifo.ts
+++ b/src/engine/fx-fifo.ts
@@ -21,6 +21,8 @@ export interface FxEvent {
   /** EUR rate at event time (EUR per 1 FCY) */
   ecbRate: Decimal;
   trigger: FxTrigger;
+  /** Commission in EUR (positive = cost paid). Increases cost basis on BUY, reduces proceeds on SELL. */
+  commissionEur?: Decimal;
 }
 
 export class FxFifoEngine {
@@ -98,10 +100,23 @@ export class FxFifoEngine {
       const ecbRate = getEcbRate(rateMap, date, trade.currency);
       const quantity = new Decimal(trade.quantity).abs();
 
+      // Commission increases cost basis (BUY) or reduces proceeds (SELL)
+      let commissionEur: Decimal | undefined;
+      const commAbs = new Decimal(trade.commission).abs();
+      if (commAbs.greaterThan(0)) {
+        const commCcy = trade.commissionCurrency || trade.currency;
+        if (commCcy === "EUR") {
+          commissionEur = commAbs;
+        } else {
+          const commRate = getEcbRate(rateMap, date, commCcy);
+          commissionEur = commAbs.mul(commRate);
+        }
+      }
+
       if (trade.buySell === "BUY") {
-        events.push({ date, currency: trade.currency, quantity, ecbRate, trigger: "conversion" });
+        events.push({ date, currency: trade.currency, quantity, ecbRate, trigger: "conversion", commissionEur });
       } else {
-        events.push({ date, currency: trade.currency, quantity: quantity.negated(), ecbRate, trigger: "conversion" });
+        events.push({ date, currency: trade.currency, quantity: quantity.negated(), ecbRate, trigger: "conversion", commissionEur });
       }
     }
 
@@ -157,13 +172,18 @@ export class FxFifoEngine {
   }
 
   private addLot(event: FxEvent): void {
+    // Commission increases the EUR cost of acquiring the lot
+    const baseCost = event.quantity.mul(event.ecbRate);
+    const totalCost = event.commissionEur ? baseCost.plus(event.commissionEur) : baseCost;
+    const costPerUnit = totalCost.div(event.quantity);
+
     const lot: FxLot = {
       id: `FX-${this.nextLotId++}`,
       currency: event.currency,
       acquireDate: event.date,
       quantity: event.quantity,
-      costPerUnit: event.ecbRate,
-      costInEur: event.quantity.mul(event.ecbRate),
+      costPerUnit,
+      costInEur: totalCost,
     };
 
     if (!this.lots.has(event.currency)) {
@@ -174,6 +194,7 @@ export class FxFifoEngine {
 
   private consumeLots(event: FxEvent): void {
     let remaining = event.quantity.abs();
+    const totalQty = remaining;
     const lots = this.lots.get(event.currency);
 
     if (!lots || lots.length === 0) {
@@ -181,16 +202,15 @@ export class FxFifoEngine {
       entry.count++;
       entry.totalQty = entry.totalQty.plus(remaining);
       this.fxMissing.set(event.currency, entry);
-      // No lots = prior-year acquisition. Record with zero gain (cost = proceeds)
-      // to avoid fabricating phantom profits from missing historical data.
       const proceedsEur = remaining.mul(event.ecbRate);
+      const netProceeds = event.commissionEur ? proceedsEur.minus(event.commissionEur) : proceedsEur;
       this.disposals.push({
         currency: event.currency,
         disposeDate: event.date,
         acquireDate: event.date,
         quantity: remaining,
-        proceedsEur,
-        costBasisEur: proceedsEur,
+        proceedsEur: netProceeds,
+        costBasisEur: netProceeds,
         gainLossEur: new Decimal(0),
         trigger: event.trigger,
         holdingPeriodDays: 0,
@@ -203,7 +223,12 @@ export class FxFifoEngine {
       const lot = lots[0]!;
       const consumed = Decimal.min(remaining, lot.quantity);
 
-      const proceedsEur = consumed.mul(event.ecbRate);
+      // Commission reduces proceeds, distributed proportionally across consumed lots
+      let proceedsEur = consumed.mul(event.ecbRate);
+      if (event.commissionEur) {
+        const proportion = consumed.div(totalQty);
+        proceedsEur = proceedsEur.minus(event.commissionEur.mul(proportion));
+      }
       const costBasisEur = consumed.mul(lot.costPerUnit);
       const holdingDays = daysBetween(lot.acquireDate, event.date);
 
@@ -235,9 +260,11 @@ export class FxFifoEngine {
       entry.count++;
       entry.totalQty = entry.totalQty.plus(remaining);
       this.fxMissing.set(event.currency, entry);
-      // Without prior-year lots we cannot determine cost basis.
-      // Use current rate as cost (zero gain) to avoid fabricating phantom profits.
-      const proceedsEur = remaining.mul(event.ecbRate);
+      let proceedsEur = remaining.mul(event.ecbRate);
+      if (event.commissionEur) {
+        const proportion = remaining.div(totalQty);
+        proceedsEur = proceedsEur.minus(event.commissionEur.mul(proportion));
+      }
       this.disposals.push({
         currency: event.currency,
         disposeDate: event.date,

--- a/src/parsers/lightyear.ts
+++ b/src/parsers/lightyear.ts
@@ -123,6 +123,28 @@ function parseLightyearCsv(lines: string[]): Statement {
   const trades: Trade[] = [];
   const cashTransactions: CashTransaction[] = [];
 
+  // Pre-scan: collect FX conversion fees by timestamp.
+  // Lightyear emits conversion pairs (one leg per currency). The fee can appear
+  // on either leg (often on the EUR leg, which we skip). Group by timestamp
+  // and extract the fee so it can be applied to the non-EUR trade.
+  const conversionFees = new Map<string, { fee: string; currency: string }>();
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i]!.trim();
+    if (!line) continue;
+    const fields = parseCsvLine(line, ",");
+    const txType = (fields[cols.type] ?? "").trim().toLowerCase();
+    if (txType !== "conversion") continue;
+    const feeVal = parseNumber(fields[cols.fee] ?? "0");
+    const feeDec = new Decimal(feeVal);
+    if (feeDec.isZero()) continue;
+    const dateRaw = (fields[cols.date] ?? "").trim();
+    const ccy = (fields[cols.ccy] ?? "EUR").trim();
+    const existing = conversionFees.get(dateRaw);
+    if (!existing || feeDec.abs().greaterThan(new Decimal(existing.fee).abs())) {
+      conversionFees.set(dateRaw, { fee: feeDec.abs().toString(), currency: ccy });
+    }
+  }
+
   for (let i = 1; i < lines.length; i++) {
     const line = lines[i]!.trim();
     if (!line) continue;
@@ -224,6 +246,11 @@ function parseLightyearCsv(lines: string[]): Statement {
       const absDec = netDec.abs();
       const isFxBuy = netDec.greaterThan(0);
 
+      // Look up commission from paired leg (fee may be on the EUR row we skip)
+      const pairedFee = conversionFees.get(dateRaw);
+      const commissionVal = pairedFee ? pairedFee.fee : new Decimal(fee).abs().toString();
+      const commCurrency = pairedFee ? pairedFee.currency : currency;
+
       trades.push({
         tradeID: `lightyear-fx-${reference || `${tradeDate}-${currency}-${i}`}`,
         accountId: "",
@@ -244,8 +271,8 @@ function parseLightyearCsv(lines: string[]): Statement {
         buySell: isFxBuy ? "BUY" : "SELL",
         openCloseIndicator: isFxBuy ? "O" : "C",
         exchange: "LIGHTYEAR",
-        commissionCurrency: currency,
-        commission: "0",
+        commissionCurrency: commCurrency,
+        commission: `-${commissionVal}`,
         taxes: "0",
         multiplier: "1",
       });

--- a/tests/engine/fx-fifo.test.ts
+++ b/tests/engine/fx-fifo.test.ts
@@ -287,6 +287,72 @@ describe("FxFifoEngine", () => {
       // Verify lotId traceability
       expect(disposals[0]!.lotId).toBe("FX-1");
     });
+
+    it("should include commission in cost basis on BUY", () => {
+      const engine = new FxFifoEngine();
+      engine.processEvents([
+        // Acquire 1000 USD at 0.92 EUR/USD with 3 EUR commission
+        { date: "2025-01-01", currency: "USD", quantity: new Decimal(1000), ecbRate: new Decimal("0.92"), trigger: "conversion", commissionEur: new Decimal("3") },
+        // Dispose 1000 USD at 0.95 EUR/USD (no commission on sell)
+        { date: "2025-06-01", currency: "USD", quantity: new Decimal(-1000), ecbRate: new Decimal("0.95"), trigger: "conversion" },
+      ]);
+
+      const disposals = engine.getDisposals();
+      expect(disposals).toHaveLength(1);
+      // Cost: 1000 * 0.92 + 3 = 923 EUR
+      // Proceeds: 1000 * 0.95 = 950 EUR
+      // Gain: 950 - 923 = 27 EUR (vs 30 without commission)
+      expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("923.00");
+      expect(disposals[0]!.proceedsEur.toFixed(2)).toBe("950.00");
+      expect(disposals[0]!.gainLossEur.toFixed(2)).toBe("27.00");
+    });
+
+    it("should subtract commission from proceeds on SELL", () => {
+      const engine = new FxFifoEngine();
+      engine.processEvents([
+        // Acquire 1000 USD at 0.92 EUR/USD (no commission)
+        { date: "2025-01-01", currency: "USD", quantity: new Decimal(1000), ecbRate: new Decimal("0.92"), trigger: "conversion" },
+        // Dispose 1000 USD at 0.95 EUR/USD with 5 EUR commission
+        { date: "2025-06-01", currency: "USD", quantity: new Decimal(-1000), ecbRate: new Decimal("0.95"), trigger: "conversion", commissionEur: new Decimal("5") },
+      ]);
+
+      const disposals = engine.getDisposals();
+      expect(disposals).toHaveLength(1);
+      // Cost: 1000 * 0.92 = 920 EUR
+      // Proceeds: 1000 * 0.95 - 5 = 945 EUR
+      // Gain: 945 - 920 = 25 EUR (vs 30 without commission)
+      expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("920.00");
+      expect(disposals[0]!.proceedsEur.toFixed(2)).toBe("945.00");
+      expect(disposals[0]!.gainLossEur.toFixed(2)).toBe("25.00");
+    });
+
+    it("should extract commissionEur from CASH trade commission field", () => {
+      const trades = [
+        makeTrade({ buySell: "BUY", quantity: "1000", commission: "-3.50", commissionCurrency: "EUR" }),
+      ];
+      const events = FxFifoEngine.extractFxEvents(trades, rateMap);
+      expect(events).toHaveLength(1);
+      expect(events[0]!.commissionEur!.toFixed(2)).toBe("3.50");
+    });
+
+    it("should convert non-EUR commission to EUR via ECB rate", () => {
+      const trades = [
+        makeTrade({ buySell: "BUY", quantity: "1000", commission: "-2", commissionCurrency: "USD" }),
+      ];
+      const events = FxFifoEngine.extractFxEvents(trades, rateMap);
+      expect(events).toHaveLength(1);
+      // 2 USD * 0.92 EUR/USD = 1.84 EUR
+      expect(events[0]!.commissionEur!.toFixed(2)).toBe("1.84");
+    });
+
+    it("should not set commissionEur when commission is zero", () => {
+      const trades = [
+        makeTrade({ buySell: "BUY", quantity: "1000", commission: "0" }),
+      ];
+      const events = FxFifoEngine.extractFxEvents(trades, rateMap);
+      expect(events).toHaveLength(1);
+      expect(events[0]!.commissionEur).toBeUndefined();
+    });
   });
 
   describe("extractCashFxEvents", () => {

--- a/tests/parsers/lightyear.test.ts
+++ b/tests/parsers/lightyear.test.ts
@@ -399,6 +399,26 @@ describe("lightyearParser", () => {
       expect(fx.quantity).toBe("-500");
     });
 
+    it("should capture commission from EUR leg of conversion pair", () => {
+      const result = lightyearParser.parse(LIGHTYEAR_CSV);
+      const fx = result.trades.find((t) => t.assetCategory === "CASH")!;
+      // Fee=0.21 is on the EUR leg (row 14 in fixture) — parser should extract it
+      expect(fx.commission).toBe("-0.21");
+      expect(fx.commissionCurrency).toBe("EUR");
+    });
+
+    it("should capture commission from FCY leg when fee is there instead", () => {
+      const csv = [
+        "Date,Reference,Ticker,ISIN,Type,Quantity,CCY,Price/share,Gross Amount,FX Rate,Fee,Net Amt.,Tax Amt.",
+        "10/05/2025 12:00:00,CN-0000000098,USD,,Conversion,,USD,,500.00,0.92,2.50,497.50,",
+        "10/05/2025 12:00:00,CN-0000000099,EUR,,Conversion,,EUR,,-460.00,1.087,,,-460.00,",
+      ].join("\n");
+      const result = lightyearParser.parse(csv);
+      const fx = result.trades.find((t) => t.assetCategory === "CASH")!;
+      expect(fx.commission).toBe("-2.5");
+      expect(fx.commissionCurrency).toBe("USD");
+    });
+
     it("should have CASH trades that generate FX events alongside STK trades", () => {
       const result = lightyearParser.parse(LIGHTYEAR_CSV);
       const hasCash = result.trades.some((t) => t.assetCategory === "CASH");


### PR DESCRIPTION
## Summary

- **Layer 1 (parser)**: Lightyear CSV emits FX conversion pairs (one row per currency). The fee can appear on either leg (often on the EUR leg that gets skipped). Added a pre-scan that collects fees by timestamp, then applies them to the non-EUR CASH trade output with correct `commission` and `commissionCurrency` fields.
- **Layer 2 (engine)**: `FxEvent` now carries optional `commissionEur`. BUY events add commission to cost basis (you paid more EUR to acquire FCY). SELL events subtract commission from proceeds proportionally across consumed lots (Art. 37.2 LIRPF).

## Test plan

- [x] 2 new parser tests: commission captured from EUR leg and from FCY leg
- [x] 5 new engine tests: commission in cost basis, commission in proceeds, EUR passthrough, non-EUR conversion via ECB rate, zero commission yields undefined
- [x] All 1042 tests pass
- [x] Typecheck clean

Closes #172