### PR TITLE
FIX. Bug. STKs are not processed since version 0.39.2

### DIFF
--- a/src/engine/fx-fifo.ts
+++ b/src/engine/fx-fifo.ts
@@ -92,34 +92,53 @@ export class FxFifoEngine {
     const events: FxEvent[] = [];
 
     for (const trade of trades) {
-      if (trade.currency === "EUR") continue;
-      if (trade.assetCategory !== "CASH") continue;
-      if (FxFifoEngine.isFxconv(trade)) continue;
 
       const date = normalizeDate(trade.settlementDate || trade.tradeDate);
       const ecbRate = getEcbRate(rateMap, date, trade.currency);
       const quantity = new Decimal(trade.quantity).abs();
 
-      // Commission increases cost basis (BUY) or reduces proceeds (SELL)
-      let commissionEur: Decimal | undefined;
-      const commAbs = new Decimal(trade.commission).abs();
-      if (commAbs.greaterThan(0)) {
-        const commCcy = trade.commissionCurrency || trade.currency;
-        if (commCcy === "EUR") {
-          commissionEur = commAbs;
+      if (trade.currency === "EUR") continue;
+      if (trade.assetCategory === "CASH") {
+
+        if (FxFifoEngine.isFxconv(trade)) continue;
+
+        // Commission increases cost basis (BUY) or reduces proceeds (SELL)
+        let commissionEur: Decimal | undefined;
+        const commAbs = new Decimal(trade.commission).abs();
+        if (commAbs.greaterThan(0)) {
+          const commCcy = trade.commissionCurrency || trade.currency;
+          if (commCcy === "EUR") {
+            commissionEur = commAbs;
+          } else {
+            const commRate = getEcbRate(rateMap, date, commCcy);
+            commissionEur = commAbs.mul(commRate);
+          }
+        }
+
+        if (trade.buySell === "BUY") {
+          events.push({ date, currency: trade.currency, quantity, ecbRate, trigger: "conversion", commissionEur });
         } else {
-          const commRate = getEcbRate(rateMap, date, commCcy);
-          commissionEur = commAbs.mul(commRate);
+          events.push({ date, currency: trade.currency, quantity: quantity.negated(), ecbRate, trigger: "conversion", commissionEur });
+        }
+      } else if (trade.assetCategory !== "WAR") {
+        // Multi-currency account: securities trade = implicit FX event
+        const tradeMoney = new Decimal(trade.tradeMoney).abs();
+        if (tradeMoney.isZero()) continue;
+
+        if (trade.buySell === "BUY") {
+          events.push({ date, currency: trade.currency, quantity: tradeMoney.negated(), ecbRate, trigger: "stock_purchase" });
+        } else {
+          events.push({ date, currency: trade.currency, quantity: tradeMoney, ecbRate, trigger: "stock_sale" });
+        }
+
+        // Commission also consumes FCY (paid in commissionCurrency)
+        const commission = new Decimal(trade.commission).abs();
+        if (commission.greaterThan(0) && trade.commissionCurrency !== "EUR") {
+          const commRate = getEcbRate(rateMap, date, trade.commissionCurrency);
+          events.push({ date, currency: trade.commissionCurrency, quantity: commission.negated(), ecbRate: commRate, trigger: "commission" });
         }
       }
-
-      if (trade.buySell === "BUY") {
-        events.push({ date, currency: trade.currency, quantity, ecbRate, trigger: "conversion", commissionEur });
-      } else {
-        events.push({ date, currency: trade.currency, quantity: quantity.negated(), ecbRate, trigger: "conversion", commissionEur });
-      }
     }
-
     return events;
   }
 

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -180,7 +180,7 @@ export interface FxLot {
 }
 
 /** What triggered an FX disposal */
-export type FxTrigger = "conversion" | "dividend" | "interest" | "commission";
+export type FxTrigger = "conversion" | "dividend" | "interest" | "commission" | "stock_purchase" | "stock_sale";
 
 /** Result of consuming FX lots via FIFO for a currency disposal */
 export interface FxDisposal {


### PR DESCRIPTION
Desde la versión 0.39.2 no se procesaban FxEvents que no fueran de cash. Los demás quedaban fuera. La lógica de esa parte también fue eliminada.

    for (const trade of trades) {
      if (trade.currency === "EUR") continue;
      if (trade.assetCategory !== "CASH") continue;

Se ha restaurado la lógica. Debería haber afectado a todos los brokers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FX event tracking for multi-currency accounts now includes foreign exchange transactions from securities trades and commissions.
  * Enhanced FX trigger categorization to include stock purchase and sale events for improved tax reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/DeclaRenta/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->