### PR TITLE
fix(web): use Spanish number format for EUR amounts

### DIFF
--- a/src/web/casilla-detail.ts
+++ b/src/web/casilla-detail.ts
@@ -7,6 +7,7 @@
 
 import type { TaxSummary, FifoDisposal, FxDisposal, DividendEntry, InterestEntry } from "../types/tax.js";
 import { t } from "../i18n/index.js";
+import { fmtEur } from "./format.js";
 
 /** Escape HTML special characters to prevent XSS in rendered strings. */
 function esc(s: string): string {
@@ -48,7 +49,7 @@ function renderDisposalsDetail(disposals: FifoDisposal[], label: string): string
           <td>${esc(d.symbol)}</td>
           <td>${formatDate(d.sellDate)}</td>
           <td>${d.quantity.toString()}</td>
-          <td class="${d.gainLossEur.greaterThanOrEqualTo(0) ? "gain" : "loss"}">${d.proceedsEur.toFixed(2)}</td>
+          <td class="${d.gainLossEur.greaterThanOrEqualTo(0) ? "gain" : "loss"}">${fmtEur(d.proceedsEur)}</td>
         </tr>`).join("")}
       </tbody>
     </table>`;
@@ -69,7 +70,7 @@ function renderDividendsDetail(entries: DividendEntry[]): string {
           <td class="mono">${esc(d.isin)}</td>
           <td>${esc(d.symbol)}</td>
           <td>${formatDate(d.payDate)}</td>
-          <td>${d.grossAmountEur.toFixed(2)}</td>
+          <td>${fmtEur(d.grossAmountEur)}</td>
           <td>${esc(d.withholdingCountry)}</td>
         </tr>`).join("")}
       </tbody>
@@ -90,7 +91,7 @@ function renderInterestDetail(entries: InterestEntry[], filterType: "earned" | "
         <tr>
           <td>${formatDate(e.date)}</td>
           <td>${esc(e.description)}</td>
-          <td>${e.amountEur.toFixed(2)}</td>
+          <td>${fmtEur(e.amountEur)}</td>
         </tr>`).join("")}
       </tbody>
     </table>`;
@@ -107,8 +108,8 @@ function renderDoubleTaxDetail(report: TaxSummary): string {
       <tbody>${countries.map(([country, data]) => `
         <tr>
           <td>${esc(country)}</td>
-          <td>${data.taxPaid.toFixed(2)}</td>
-          <td>${data.deductionAllowed.toFixed(2)}</td>
+          <td>${fmtEur(data.taxPaid)}</td>
+          <td>${fmtEur(data.deductionAllowed)}</td>
         </tr>`).join("")}
       </tbody>
     </table>`;
@@ -129,8 +130,8 @@ function renderFxDisposalsDetail(disposals: FxDisposal[], label: string): string
           <td>${esc(d.currency)}</td>
           <td>${formatDate(d.disposeDate)}</td>
           <td>${formatDate(d.acquireDate)}</td>
-          <td>${d.quantity.toFixed(2)}</td>
-          <td class="${d.gainLossEur.greaterThanOrEqualTo(0) ? "gain" : "loss"}">${d.gainLossEur.toFixed(2)}</td>
+          <td>${fmtEur(d.quantity)}</td>
+          <td class="${d.gainLossEur.greaterThanOrEqualTo(0) ? "gain" : "loss"}">${fmtEur(d.gainLossEur)}</td>
           <td>${esc(d.trigger)}</td>
           <td>${esc(d.lotId)}</td>
         </tr>`).join("")}
@@ -142,63 +143,63 @@ const CASILLAS: CasillaConfig[] = [
   {
     code: "0327",
     i18nKey: "casilla.transmission_value",
-    getValue: (r) => r.capitalGains.transmissionValue.toFixed(2),
+    getValue: (r) => fmtEur(r.capitalGains.transmissionValue),
     getClass: () => "",
     getDetail: (r) => renderDisposalsDetail(r.capitalGains.disposals, t("casilla.transmission_value")),
   },
   {
     code: "0328",
     i18nKey: "casilla.acquisition_value",
-    getValue: (r) => r.capitalGains.acquisitionValue.toFixed(2),
+    getValue: (r) => fmtEur(r.capitalGains.acquisitionValue),
     getClass: () => "",
     getDetail: (r) => renderDisposalsDetail(r.capitalGains.disposals, t("casilla.acquisition_value")),
   },
   {
     code: "1633",
     i18nKey: "casilla.fx_transmission_value",
-    getValue: (r) => r.fxGains.transmissionValue.toFixed(2),
+    getValue: (r) => fmtEur(r.fxGains.transmissionValue),
     getClass: () => "",
     getDetail: (r) => renderFxDisposalsDetail(r.fxGains.disposals, t("casilla.fx_transmission_value")),
   },
   {
     code: "1637",
     i18nKey: "casilla.fx_acquisition_value",
-    getValue: (r) => r.fxGains.acquisitionValue.toFixed(2),
+    getValue: (r) => fmtEur(r.fxGains.acquisitionValue),
     getClass: () => "",
     getDetail: (r) => renderFxDisposalsDetail(r.fxGains.disposals, t("casilla.fx_acquisition_value")),
   },
   {
     code: "",
     i18nKey: "casilla.net_gain_loss",
-    getValue: (r) => r.capitalGains.netGainLoss.plus(r.fxGains.netGainLoss).toFixed(2),
+    getValue: (r) => fmtEur(r.capitalGains.netGainLoss.plus(r.fxGains.netGainLoss)),
     getClass: (r) => r.capitalGains.netGainLoss.plus(r.fxGains.netGainLoss).greaterThanOrEqualTo(0) ? "gain" : "loss",
     getDetail: () => "",
   },
   {
     code: "0029",
     i18nKey: "casilla.gross_dividends",
-    getValue: (r) => r.dividends.grossIncome.toFixed(2),
+    getValue: (r) => fmtEur(r.dividends.grossIncome),
     getClass: () => "",
     getDetail: (r) => renderDividendsDetail(r.dividends.entries),
   },
   {
     code: "0027",
     i18nKey: "casilla.interest_earned",
-    getValue: (r) => r.interest.earned.toFixed(2),
+    getValue: (r) => fmtEur(r.interest.earned),
     getClass: () => "",
     getDetail: (r) => renderInterestDetail(r.interest.entries, "earned"),
   },
   {
     code: "",
     i18nKey: "casilla.interest_paid",
-    getValue: (r) => r.interest.paid.toFixed(2),
+    getValue: (r) => fmtEur(r.interest.paid),
     getClass: () => "",
     getDetail: (r) => renderInterestDetail(r.interest.entries, "paid"),
   },
   {
     code: "0588",
     i18nKey: "casilla.double_taxation",
-    getValue: (r) => r.doubleTaxation.deduction.toFixed(2),
+    getValue: (r) => fmtEur(r.doubleTaxation.deduction),
     getClass: () => "",
     getDetail: (r) => renderDoubleTaxDetail(r),
   },
@@ -233,7 +234,7 @@ export function renderCasillaCards(container: HTMLElement, report: TaxSummary): 
   }).join("");
 
   const blockedWarning = report.capitalGains.blockedLosses.greaterThan(0)
-    ? `<p class="warning">${t("casilla.blocked_losses", { amount: report.capitalGains.blockedLosses.toFixed(2) })}</p>`
+    ? `<p class="warning">${t("casilla.blocked_losses", { amount: fmtEur(report.capitalGains.blockedLosses) })}</p>`
     : "";
 
   const msgs = report.messages;

--- a/src/web/charts.ts
+++ b/src/web/charts.ts
@@ -7,6 +7,7 @@
 
 import Decimal from "decimal.js";
 import { t } from "../i18n/index.js";
+import { fmtEur } from "./format.js";
 
 // ---------------------------------------------------------------------------
 // Shared
@@ -151,7 +152,7 @@ export function renderHorizontalBarChart(title: string, items: { label: string; 
     return `
       <text x="${labelW - 4}" y="${y + barH / 2 + 4}" text-anchor="end" fill="var(--text)" font-size="11">${escSvg(d.label)}</text>
       <rect x="${labelW}" y="${y}" width="${w}" height="${barH}" rx="4" fill="${d.color}" opacity="0.8"/>
-      <text x="${labelW + w + 6}" y="${y + barH / 2 + 4}" fill="var(--muted)" font-size="10">${d.value.toFixed(2)} EUR</text>
+      <text x="${labelW + w + 6}" y="${y + barH / 2 + 4}" fill="var(--muted)" font-size="10">${fmtEur(d.value)} EUR</text>
     `;
   }).join("");
 
@@ -306,16 +307,16 @@ export function renderTaxBracketCard(
   const tableRows = rows.map((r) =>
     `<tr>
       <td><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:${r.color};margin-right:6px"></span>${escSvg(r.label)}</td>
-      <td style="text-align:right">${r.amount.toFixed(2)} &euro;</td>
+      <td style="text-align:right">${fmtEur(r.amount)} &euro;</td>
       <td style="text-align:right">${(r.rate * 100).toFixed(0)}%</td>
-      <td style="text-align:right">${r.tax.toFixed(2)} &euro;</td>
+      <td style="text-align:right">${fmtEur(r.tax)} &euro;</td>
     </tr>`,
   ).join("");
 
   const deductionRow = doubleTaxDeduction > 0
     ? `<tr class="muted">
         <td colspan="3" style="text-align:right">${escSvg(t("tax.double_tax_deduction"))}</td>
-        <td style="text-align:right">-${doubleTaxDeduction.toFixed(2)} &euro;</td>
+        <td style="text-align:right">-${fmtEur(doubleTaxDeduction)} &euro;</td>
       </tr>`
     : "";
 
@@ -337,7 +338,7 @@ export function renderTaxBracketCard(
         ${deductionRow}
         <tr style="font-weight:700;border-top:2px solid var(--border,#ccc)">
           <td colspan="3" style="text-align:right">${escSvg(t("tax.total_estimated"))}</td>
-          <td style="text-align:right">${netTax.toFixed(2)} &euro;</td>
+          <td style="text-align:right">${fmtEur(netTax)} &euro;</td>
         </tr>
         <tr class="muted">
           <td colspan="3" style="text-align:right">${escSvg(t("tax.effective_rate"))}</td>
@@ -351,11 +352,11 @@ export function renderTaxBracketCard(
 
 function renderBreakdown(b: TaxBaseBreakdown): string {
   const lines: string[] = [];
-  if (b.capitalGains !== 0) lines.push(`<span>${escSvg(t("tax.breakdown_capital_gains"))}: <strong>${b.capitalGains.toFixed(2)} &euro;</strong></span>`);
-  if (b.fxGains !== 0) lines.push(`<span>${escSvg(t("tax.breakdown_fx_gains"))}: <strong>${b.fxGains.toFixed(2)} &euro;</strong></span>`);
-  if (b.dividends !== 0) lines.push(`<span>${escSvg(t("tax.breakdown_dividends"))}: <strong>${b.dividends.toFixed(2)} &euro;</strong></span>`);
-  if (b.interest !== 0) lines.push(`<span>${escSvg(t("tax.breakdown_interest"))}: <strong>${b.interest.toFixed(2)} &euro;</strong></span>`);
-  if (b.blockedLosses > 0) lines.push(`<span>${escSvg(t("tax.breakdown_blocked_losses"))}: <strong>+${b.blockedLosses.toFixed(2)} &euro;</strong></span>`);
+  if (b.capitalGains !== 0) lines.push(`<span>${escSvg(t("tax.breakdown_capital_gains"))}: <strong>${fmtEur(b.capitalGains)} &euro;</strong></span>`);
+  if (b.fxGains !== 0) lines.push(`<span>${escSvg(t("tax.breakdown_fx_gains"))}: <strong>${fmtEur(b.fxGains)} &euro;</strong></span>`);
+  if (b.dividends !== 0) lines.push(`<span>${escSvg(t("tax.breakdown_dividends"))}: <strong>${fmtEur(b.dividends)} &euro;</strong></span>`);
+  if (b.interest !== 0) lines.push(`<span>${escSvg(t("tax.breakdown_interest"))}: <strong>${fmtEur(b.interest)} &euro;</strong></span>`);
+  if (b.blockedLosses > 0) lines.push(`<span>${escSvg(t("tax.breakdown_blocked_losses"))}: <strong>+${fmtEur(b.blockedLosses)} &euro;</strong></span>`);
   if (lines.length === 0) return "";
   return `<div class="bracket-breakdown muted" style="font-size:0.8rem;margin-bottom:8px;display:flex;flex-wrap:wrap;gap:4px 12px">${lines.join("")}</div>`;
 }

--- a/src/web/format.ts
+++ b/src/web/format.ts
@@ -1,10 +1,14 @@
 import type Decimal from "decimal.js";
 
 /**
- * Format a Decimal or number as Spanish locale: dot for thousands, comma for decimals.
+ * Format any numeric value using Spanish locale conventions:
+ * dot as thousands separator, comma as decimal separator.
+ * Used for EUR amounts, foreign currency quantities, and any user-facing number.
  * Example: 3301.71 → "3.301,71"
  */
 export function fmtEur(d: Decimal | number, decimals = 2): string {
+  // Both branches call .toFixed() but resolve to different implementations:
+  // Number.prototype.toFixed vs Decimal.prototype.toFixed (arbitrary precision)
   const str = typeof d === "number" ? d.toFixed(decimals) : d.toFixed(decimals);
   const [intPart, decPart] = str.split(".");
   const withThousands = intPart!.replace(/\B(?=(\d{3})+(?!\d))/g, ".");

--- a/src/web/format.ts
+++ b/src/web/format.ts
@@ -1,0 +1,12 @@
+import type Decimal from "decimal.js";
+
+/**
+ * Format a Decimal or number as Spanish locale: dot for thousands, comma for decimals.
+ * Example: 3301.71 → "3.301,71"
+ */
+export function fmtEur(d: Decimal | number, decimals = 2): string {
+  const str = typeof d === "number" ? d.toFixed(decimals) : d.toFixed(decimals);
+  const [intPart, decPart] = str.split(".");
+  const withThousands = intPart!.replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+  return decPart !== undefined ? `${withThousands},${decPart}` : withThousands;
+}

--- a/src/web/main.ts
+++ b/src/web/main.ts
@@ -33,6 +33,7 @@ import { t, initLocale, setLocale, getCurrentLocale, getLocaleNames, type Locale
 import { validateStatement, renderValidationIssues } from "./validation.js";
 import { renderOperationsAnnex } from "./operations-annex.js";
 import { createEmptyStatement, finalizeMergedStatement, mergeStatement } from "../parsers/merge.js";
+import { fmtEur } from "./format.js";
 import Decimal from "decimal.js";
 
 Decimal.set({ precision: 20, rounding: Decimal.ROUND_HALF_UP });
@@ -859,9 +860,9 @@ function renderOperationsTable() {
             <td>${formatDate(d.acquireDate)}</td>
             <td>${formatDate(d.sellDate)}</td>
             <td>${d.quantity.toString()}</td>
-            <td>${d.costBasisEur.toFixed(2)}</td>
-            <td>${d.proceedsEur.toFixed(2)}</td>
-            <td class="${d.gainLossEur.greaterThanOrEqualTo(0) ? 'gain' : 'loss'}">${d.gainLossEur.toFixed(2)}</td>
+            <td>${fmtEur(d.costBasisEur)}</td>
+            <td>${fmtEur(d.proceedsEur)}</td>
+            <td class="${d.gainLossEur.greaterThanOrEqualTo(0) ? 'gain' : 'loss'}">${fmtEur(d.gainLossEur)}</td>
             <td>${d.holdingPeriodDays}</td>
           </tr>
         `).join("")}
@@ -915,8 +916,8 @@ function renderDividendsTable(report: TaxSummary) {
             <td class="mono">${esc(d.isin)}</td>
             <td>${esc(d.symbol)}</td>
             <td>${formatDate(d.payDate)}</td>
-            <td>${d.grossAmountEur.toFixed(2)}</td>
-            <td>${d.withholdingTaxEur.toFixed(2)}</td>
+            <td>${fmtEur(d.grossAmountEur)}</td>
+            <td>${fmtEur(d.withholdingTaxEur)}</td>
             <td>${esc(d.withholdingCountry)}</td>
           </tr>
         `).join("")}

--- a/src/web/operations-annex.ts
+++ b/src/web/operations-annex.ts
@@ -35,7 +35,6 @@ function fmtDate(d: string): string {
   return `${clean.slice(6, 8)}/${clean.slice(4, 6)}/${clean.slice(0, 4)}`;
 }
 
-function fmtNum(d: Decimal): string { return fmtEur(d); }
 
 export function renderOperationsAnnex(report: TaxSummary): string {
   const disposals = report.capitalGains.disposals;
@@ -65,7 +64,7 @@ export function renderOperationsAnnex(report: TaxSummary): string {
       <summary class="annex-group-header">
         <span class="annex-group-name">${esc(label)}</span>
         <span class="annex-group-count">${ops.length} ${t("annex.operations")}</span>
-        <span class="annex-group-total ${glClass}">${subtotalGL.greaterThanOrEqualTo(0) ? "+" : ""}${fmtNum(subtotalGL)} EUR</span>
+        <span class="annex-group-total ${glClass}">${subtotalGL.greaterThanOrEqualTo(0) ? "+" : ""}${fmtEur(subtotalGL)} EUR</span>
       </summary>
       <div class="annex-table-wrap">
         <table class="annex-table">
@@ -98,9 +97,9 @@ export function renderOperationsAnnex(report: TaxSummary): string {
               <td>${fmtDate(d.acquireDate)}</td>
               <td>${fmtDate(d.sellDate)}</td>
               <td>${d.quantity.toFixed(d.quantity.mod(1).isZero() ? 0 : 4)}</td>
-              <td class="num">${fmtNum(d.costBasisEur)}</td>
-              <td class="num">${fmtNum(d.proceedsEur)}</td>
-              <td class="num ${cls}">${d.gainLossEur.greaterThanOrEqualTo(0) ? "+" : ""}${fmtNum(d.gainLossEur)}</td>
+              <td class="num">${fmtEur(d.costBasisEur)}</td>
+              <td class="num">${fmtEur(d.proceedsEur)}</td>
+              <td class="num ${cls}">${d.gainLossEur.greaterThanOrEqualTo(0) ? "+" : ""}${fmtEur(d.gainLossEur)}</td>
             </tr>`;
     });
 
@@ -109,9 +108,9 @@ export function renderOperationsAnnex(report: TaxSummary): string {
           <tfoot>
             <tr class="annex-subtotal">
               <td colspan="6">${esc(label)}</td>
-              <td class="num">${fmtNum(subtotalCost)}</td>
-              <td class="num">${fmtNum(subtotalProceeds)}</td>
-              <td class="num ${glClass}">${subtotalGL.greaterThanOrEqualTo(0) ? "+" : ""}${fmtNum(subtotalGL)} EUR</td>
+              <td class="num">${fmtEur(subtotalCost)}</td>
+              <td class="num">${fmtEur(subtotalProceeds)}</td>
+              <td class="num ${glClass}">${subtotalGL.greaterThanOrEqualTo(0) ? "+" : ""}${fmtEur(subtotalGL)} EUR</td>
             </tr>
           </tfoot>
         </table>

--- a/src/web/operations-annex.ts
+++ b/src/web/operations-annex.ts
@@ -6,6 +6,7 @@
 import Decimal from "decimal.js";
 import { t } from "../i18n/index.js";
 import type { TaxSummary, FifoDisposal } from "../types/tax.js";
+import { fmtEur } from "./format.js";
 
 const ASSET_LABELS: Record<string, string> = {
   STK: "Acciones cotizadas",
@@ -35,7 +36,7 @@ function fmtDate(d: string): string {
 }
 
 function fmtNum(d: Decimal): string {
-  return d.toFixed(2).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+  return fmtEur(d);
 }
 
 export function renderOperationsAnnex(report: TaxSummary): string {

--- a/src/web/operations-annex.ts
+++ b/src/web/operations-annex.ts
@@ -35,9 +35,7 @@ function fmtDate(d: string): string {
   return `${clean.slice(6, 8)}/${clean.slice(4, 6)}/${clean.slice(0, 4)}`;
 }
 
-function fmtNum(d: Decimal): string {
-  return fmtEur(d);
-}
+function fmtNum(d: Decimal): string { return fmtEur(d); }
 
 export function renderOperationsAnnex(report: TaxSummary): string {
   const disposals = report.capitalGains.disposals;

--- a/src/web/section-720.ts
+++ b/src/web/section-720.ts
@@ -12,6 +12,7 @@ import { checkModelo720Thresholds } from "../generators/modelo720.js";
 import type { Statement } from "../types/broker.js";
 import type { EcbRateMap } from "../types/ecb.js";
 import Decimal from "decimal.js";
+import { fmtEur } from "./format.js";
 
 function esc(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
@@ -106,7 +107,7 @@ export function renderSection720(statement: Statement, rateMap: EcbRateMap): voi
         <div class="threshold-fill ${cat.exceeds ? "over" : "under"}" style="width: ${pct}%"></div>
       </div>
       <div class="threshold-labels">
-        <span>${t("m720.total_value", { amount: cat.total.toFixed(2) })}</span>
+        <span>${t("m720.total_value", { amount: fmtEur(cat.total) })}</span>
         <span>50.000 €</span>
       </div>
       <p class="${cat.exceeds ? "warning" : "muted"}">${cat.exceeds ? t("m720.category_exceeded") : t("m720.category_not_exceeded")}</p>
@@ -115,7 +116,7 @@ export function renderSection720(statement: Statement, rateMap: EcbRateMap): voi
 
   if (exceeds) {
     const totalValue = thresholds.values.total.plus(thresholds.accounts.total);
-    html += `<p class="warning">${t("m720.threshold_exceeded", { amount: totalValue.toFixed(2) })}</p>`;
+    html += `<p class="warning">${t("m720.threshold_exceeded", { amount: fmtEur(totalValue) })}</p>`;
   }
 
   // Positions table
@@ -138,7 +139,7 @@ export function renderSection720(statement: Statement, rateMap: EcbRateMap): voi
         } catch {
           rate = getEcbRate(rateMap, dateForRates, p.currency);
         }
-        const val = new Decimal(p.positionValue).mul(rate).toFixed(2);
+        const val = fmtEur(new Decimal(p.positionValue).mul(rate));
         return `<tr><td class="mono">${esc(p.isin)}</td><td>${esc(p.description)}</td><td>${esc(p.isin.slice(0, 2))}</td><td>${val}</td></tr>`;
       }).join("")}</tbody>
     </table></div>`;
@@ -168,8 +169,8 @@ export function renderSection720(statement: Statement, rateMap: EcbRateMap): voi
       </tr></thead>
       <tbody>${cashBalances.map((cb) => {
         const ecbRate = cb.currency === "EUR" ? new Decimal(1) : getEcbRate(rateMap, dateForRates, cb.currency);
-        const val = new Decimal(cb.endingCash).mul(ecbRate).toFixed(2);
-        const avg = cb.averageQ4Cash ? new Decimal(cb.averageQ4Cash).mul(ecbRate).toFixed(2) : "—";
+        const val = fmtEur(new Decimal(cb.endingCash).mul(ecbRate));
+        const avg = cb.averageQ4Cash ? fmtEur(new Decimal(cb.averageQ4Cash).mul(ecbRate)) : "—";
         return `<tr><td>${esc(cb.currency)}</td><td>${val}</td><td>${avg}</td></tr>`;
       }).join("")}</tbody>
     </table></div>`;

--- a/src/web/section-721.ts
+++ b/src/web/section-721.ts
@@ -11,6 +11,7 @@ import type { Statement } from "../types/broker.js";
 import type { EcbRateMap } from "../types/ecb.js";
 import { getEcbRate } from "../engine/ecb.js";
 import Decimal from "decimal.js";
+import { fmtEur } from "./format.js";
 
 function esc(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
@@ -106,14 +107,14 @@ export function renderSection721(statement: Statement, rateMap: EcbRateMap): voi
       <div class="threshold-fill ${exceeds ? "over" : "under"}" style="width: ${pct}%"></div>
     </div>
     <div class="threshold-labels">
-      <span>${t("m721.total_value", { amount: totalValue.toFixed(2) })}</span>
+      <span>${t("m721.total_value", { amount: fmtEur(totalValue) })}</span>
       <span>50.000 €</span>
     </div>
   </div>
   <p class="${exceeds ? "warning" : "muted"}">
     ${exceeds
-      ? t("m721.threshold_exceeded", { amount: totalValue.toFixed(2) })
-      : t("m721.threshold_not_exceeded", { amount: totalValue.toFixed(2) })}
+      ? t("m721.threshold_exceeded", { amount: fmtEur(totalValue) })
+      : t("m721.threshold_not_exceeded", { amount: fmtEur(totalValue) })}
   </p>`;
 
   // Positions table
@@ -125,7 +126,7 @@ export function renderSection721(statement: Statement, rateMap: EcbRateMap): voi
     </tr></thead>
     <tbody>${positions.map((p) => {
       const rate = getEcbRate(rateMap, yearEnd, p.currency);
-      const val = new Decimal(p.positionValue).mul(rate).toFixed(2);
+      const val = fmtEur(new Decimal(p.positionValue).mul(rate));
       const exchange = p.isin && p.isin.length >= 2 ? p.isin.slice(0, 2) : "—";
       return `<tr>
         <td class="mono">${esc(p.description || p.isin || p.symbol)}</td>

--- a/src/web/section-d6.ts
+++ b/src/web/section-d6.ts
@@ -12,6 +12,7 @@ import type { Statement } from "../types/broker.js";
 import type { OpenPosition } from "../types/ibkr.js";
 import type { EcbRateMap } from "../types/ecb.js";
 import Decimal from "decimal.js";
+import { fmtEur } from "./format.js";
 
 function esc(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
@@ -101,7 +102,7 @@ export function renderSectionD6(statement: Statement, rateMap: EcbRateMap): void
     const rate = getEcbRate(rateMap, yearEnd, p.currency);
     return sum.plus(new Decimal(p.positionValue).mul(rate));
   }, new Decimal(0));
-  html += `<p><strong>${t("d6.total_value", { amount: totalValue.toFixed(2) })}</strong></p>`;
+  html += `<p><strong>${t("d6.total_value", { amount: fmtEur(totalValue) })}</strong></p>`;
 
   // Positions table
   html += `<h3>${t("d6.positions_title")}</h3>
@@ -113,7 +114,7 @@ export function renderSectionD6(statement: Statement, rateMap: EcbRateMap): void
     <tbody>${positions
       .map((p) => {
         const rate = getEcbRate(rateMap, yearEnd, p.currency);
-        const val = new Decimal(p.positionValue).mul(rate).toFixed(2);
+        const val = fmtEur(new Decimal(p.positionValue).mul(rate));
         return `<tr>
         <td class="mono">${esc(p.isin)}</td><td>${esc(p.description)}</td>
         <td>${esc(p.isin.slice(0, 2))}</td><td>${new Decimal(p.quantity).toString()}</td><td>${val}</td>
@@ -193,7 +194,7 @@ function renderAforixGuide(
   for (let i = 0; i < positions.length; i++) {
     const p = positions[i]!;
     const rate = getEcbRate(rateMap, yearEnd, p.currency);
-    const val = new Decimal(p.positionValue).mul(rate).toFixed(2);
+    const val = fmtEur(new Decimal(p.positionValue).mul(rate));
     html += `<p style="margin-top:1rem;font-weight:600">${t("d6.aforix_position_of", { index: String(i + 1), total: String(positions.length) })}</p>`;
     html += aforixField("ISIN", p.isin);
     html += aforixField("Denominación", p.description);

--- a/src/web/year-compare.ts
+++ b/src/web/year-compare.ts
@@ -8,6 +8,7 @@
 import type { TaxSummary } from "../types/tax.js";
 import { t } from "../i18n/index.js";
 import { saveReport, loadAllReports, clearAllReports, type StoredReport } from "./storage.js";
+import { fmtEur } from "./format.js";
 
 /** Escape HTML special characters to prevent XSS in rendered strings. */
 function esc(s: string): string {
@@ -117,7 +118,7 @@ export function renderYearComparison(container: HTMLElement): void {
   // Data rows
   const rows = COMPARISON_ROWS.map((row) => {
     const values = sorted.map((r) => r.casillas[row.key]);
-    const valueCells = values.map((v) => `<td>${v.toFixed(2)}</td>`).join("");
+    const valueCells = values.map((v) => `<td>${fmtEur(v)}</td>`).join("");
 
     const varCells = values.length >= 2
       ? values.slice(0, -1).map((v, i) => {

--- a/tests/web/format.test.ts
+++ b/tests/web/format.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import Decimal from "decimal.js";
+import { fmtEur } from "../../src/web/format.js";
+
+describe("fmtEur — Spanish number formatting", () => {
+  it("formats thousands with dot and decimals with comma", () => {
+    expect(fmtEur(new Decimal("3301.71"))).toBe("3.301,71");
+  });
+
+  it("formats large numbers", () => {
+    expect(fmtEur(new Decimal("1234567.89"))).toBe("1.234.567,89");
+  });
+
+  it("formats negative numbers correctly", () => {
+    expect(fmtEur(new Decimal("-3301.71"))).toBe("-3.301,71");
+  });
+
+  it("formats zero", () => {
+    expect(fmtEur(new Decimal("0"))).toBe("0,00");
+  });
+
+  it("formats small numbers without thousands separator", () => {
+    expect(fmtEur(new Decimal("123.45"))).toBe("123,45");
+  });
+
+  it("formats numbers under 1", () => {
+    expect(fmtEur(new Decimal("0.75"))).toBe("0,75");
+  });
+
+  it("accepts plain number type", () => {
+    expect(fmtEur(4402.80)).toBe("4.402,80");
+  });
+
+  it("respects custom decimal places", () => {
+    expect(fmtEur(new Decimal("1234.5678"), 4)).toBe("1.234,5678");
+  });
+
+  it("handles negative thousands correctly", () => {
+    expect(fmtEur(new Decimal("-12345.67"))).toBe("-12.345,67");
+  });
+});

--- a/tests/web/format.test.ts
+++ b/tests/web/format.test.ts
@@ -38,4 +38,8 @@ describe("fmtEur — Spanish number formatting", () => {
   it("handles negative thousands correctly", () => {
     expect(fmtEur(new Decimal("-12345.67"))).toBe("-12.345,67");
   });
+
+  it("handles zero decimals (no comma)", () => {
+    expect(fmtEur(new Decimal("12345"), 0)).toBe("12.345");
+  });
 });


### PR DESCRIPTION
## Summary
- All EUR amounts in the web UI now use Spanish locale formatting: dot for thousands separator, comma for decimal separator (e.g. `3.301,71` instead of `3.301.71`)
- Adds shared `fmtEur()` utility in `src/web/format.ts` used across 8 web modules
- Fixes ambiguous display where "3.301.71" was indistinguishable between thousands and decimals

## Files changed
- `src/web/format.ts` (new) — shared Spanish number formatter
- `src/web/operations-annex.ts` — Anexo C1 table
- `src/web/casilla-detail.ts` — casilla cards and detail tables
- `src/web/main.ts` — operations and dividends tables
- `src/web/charts.ts` — tax bracket breakdown, bar charts
- `src/web/year-compare.ts` — year comparison table
- `src/web/section-720.ts` — Modelo 720 amounts
- `src/web/section-721.ts` — Modelo 721 amounts
- `src/web/section-d6.ts` — Modelo D-6 amounts
- `tests/web/format.test.ts` (new) — 9 test cases for the formatter

## Test plan
- [x] All 1057 tests pass
- [x] TypeScript strict check passes
- [x] fmtEur handles: positive, negative, zero, large numbers, custom decimals
- [ ] Visual check: upload a broker file and verify amounts show as "3.301,71" format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * EUR amounts across tax reports, financial tables, position summaries, Section 720/721 displays, and year comparisons now use consistent Spanish number formatting with periods as thousands separators and commas as decimal separators.

* **Tests**
  * Added tests validating Spanish-style EUR number formatting including handling of negative values, decimals, and both numeric and decimal input types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/DeclaRenta/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->