### PR TITLE
fix: gate empty casilla CSV rows and correct acquisition drill-downs

### DIFF
--- a/src/generators/csv.ts
+++ b/src/generators/csv.ts
@@ -74,10 +74,14 @@ export function formatCsv(report: TaxSummary): string {
   const blocks = computeCasillaBlocksWithFx(report);
   lines.push("# RESUMEN CASILLAS");
   lines.push("Casilla,Concepto,Valor_EUR");
-  lines.push(`0328,Valor de transmision (acciones negociadas),${blocks.listedShares.transmissionValue.toFixed(2)}`);
-  lines.push(`0331,Valor de adquisicion (acciones negociadas),${blocks.listedShares.acquisitionValue.toFixed(2)}`);
-  lines.push(`1633,Valor de transmision (otros elementos: opciones/cripto/fondos/divisa),${blocks.otherElements.transmissionValue.toFixed(2)}`);
-  lines.push(`1637,Valor de adquisicion (otros elementos: opciones/cripto/fondos/divisa),${blocks.otherElements.acquisitionValue.toFixed(2)}`);
+  if (blocks.listedShares.count > 0) {
+    lines.push(`0328,Valor de transmision (acciones negociadas),${blocks.listedShares.transmissionValue.toFixed(2)}`);
+    lines.push(`0331,Valor de adquisicion (acciones negociadas),${blocks.listedShares.acquisitionValue.toFixed(2)}`);
+  }
+  if (blocks.otherElements.count > 0) {
+    lines.push(`1633,Valor de transmision (otros elementos: opciones/cripto/fondos/divisa),${blocks.otherElements.transmissionValue.toFixed(2)}`);
+    lines.push(`1637,Valor de adquisicion (otros elementos: opciones/cripto/fondos/divisa),${blocks.otherElements.acquisitionValue.toFixed(2)}`);
+  }
   lines.push(`0029,Dividendos brutos,${report.dividends.grossIncome.toFixed(2)}`);
   lines.push(`—,Intereses pagados al broker (margen no deducible — informativo),${report.interest.paid.toFixed(2)}`);
   lines.push(`0027,Intereses de cuentas,${report.interest.earned.toFixed(2)}`);

--- a/src/web/casilla-detail.ts
+++ b/src/web/casilla-detail.ts
@@ -46,23 +46,32 @@ function listedShareDisposals(r: TaxSummary): FifoDisposal[] {
   return r.capitalGains.disposals.filter((d) => isListedShare(d));
 }
 
-/** Render a detail table of FIFO disposals for a casilla drill-down. */
-function renderDisposalsDetail(disposals: FifoDisposal[], label: string): string {
+/**
+ * Render a detail table of FIFO disposals for a casilla drill-down.
+ * `mode` selects which date/amount the table reflects so acquisition cards
+ * (0331/1637) show acquireDate + costBasisEur, not the transmission figures.
+ */
+function renderDisposalsDetail(
+  disposals: FifoDisposal[],
+  label: string,
+  mode: "transmission" | "acquisition" = "transmission",
+): string {
   if (disposals.length === 0) return `<p class="muted">${t("casilla.no_operations")}</p>`;
+  const dateHeader = mode === "acquisition" ? t("table.buy_date") : t("table.sell_date");
   return `
     <p class="detail-label">${esc(label)} (${disposals.length})</p>
     <table class="detail-table">
       <thead><tr>
-        <th>ISIN</th><th>${t("table.symbol")}</th><th>${t("table.sell_date")}</th>
+        <th>ISIN</th><th>${t("table.symbol")}</th><th>${dateHeader}</th>
         <th>${t("table.units")}</th><th>EUR</th>
       </tr></thead>
       <tbody>${disposals.map((d) => `
         <tr>
           <td class="mono">${esc(d.isin)}</td>
           <td>${esc(d.symbol)}</td>
-          <td>${formatDate(d.sellDate)}</td>
+          <td>${formatDate(mode === "acquisition" ? d.acquireDate : d.sellDate)}</td>
           <td>${d.quantity.toString()}</td>
-          <td class="${d.gainLossEur.greaterThanOrEqualTo(0) ? "gain" : "loss"}">${fmtEur(d.proceedsEur)}</td>
+          <td>${fmtEur(mode === "acquisition" ? d.costBasisEur : d.proceedsEur)}</td>
         </tr>`).join("")}
       </tbody>
     </table>`;
@@ -128,8 +137,16 @@ function renderDoubleTaxDetail(report: TaxSummary): string {
     </table>`;
 }
 
-/** Render a detail table of FX disposals for casilla 1633/1637 drill-down. */
-function renderFxDisposalsDetail(disposals: FxDisposal[], label: string): string {
+/**
+ * Render a detail table of FX disposals for casilla 1633/1637 drill-down.
+ * `mode` selects the EUR amount: transmission (1633) shows proceedsEur,
+ * acquisition (1637) shows costBasisEur — matching the parent casilla.
+ */
+function renderFxDisposalsDetail(
+  disposals: FxDisposal[],
+  label: string,
+  mode: "transmission" | "acquisition" = "transmission",
+): string {
   if (disposals.length === 0) return `<p class="muted">${t("casilla.no_operations")}</p>`;
   return `
     <p class="detail-label">${esc(label)} (${disposals.length})</p>
@@ -144,7 +161,7 @@ function renderFxDisposalsDetail(disposals: FxDisposal[], label: string): string
           <td>${formatDate(d.disposeDate)}</td>
           <td>${formatDate(d.acquireDate)}</td>
           <td>${fmtEur(d.quantity)}</td>
-          <td class="${d.gainLossEur.greaterThanOrEqualTo(0) ? "gain" : "loss"}">${fmtEur(d.gainLossEur)}</td>
+          <td>${fmtEur(mode === "acquisition" ? d.costBasisEur : d.proceedsEur)}</td>
           <td>${esc(d.trigger)}</td>
           <td>${esc(d.lotId)}</td>
         </tr>`).join("")}
@@ -167,7 +184,7 @@ const CASILLAS: CasillaConfig[] = [
     i18nKey: "casilla.listed_acquisition_value",
     getValue: (_r, blocks) => fmtEur(blocks.listedShares.acquisitionValue),
     getClass: () => "",
-    getDetail: (r) => renderDisposalsDetail(listedShareDisposals(r), t("casilla.listed_acquisition_value")),
+    getDetail: (r) => renderDisposalsDetail(listedShareDisposals(r), t("casilla.listed_acquisition_value"), "acquisition"),
     visible: (_r, blocks) => blocks.listedShares.count > 0,
   },
   // Otros elementos patrimoniales: opciones/cripto/fondos (Art. 37.1.m) + divisa
@@ -188,8 +205,8 @@ const CASILLAS: CasillaConfig[] = [
     getValue: (_r, blocks) => fmtEur(blocks.otherElements.acquisitionValue),
     getClass: () => "",
     getDetail: (r) =>
-      renderDisposalsDetail(otherElementDisposals(r), t("casilla.other_acquisition_value")) +
-      renderFxDisposalsDetail(r.fxGains.disposals, t("casilla.fx_acquisition_value")),
+      renderDisposalsDetail(otherElementDisposals(r), t("casilla.other_acquisition_value"), "acquisition") +
+      renderFxDisposalsDetail(r.fxGains.disposals, t("casilla.fx_acquisition_value"), "acquisition"),
     visible: (_r, blocks) => blocks.otherElements.count > 0,
   },
   {

--- a/tests/generators/csv.test.ts
+++ b/tests/generators/csv.test.ts
@@ -156,6 +156,63 @@ describe("formatCsv", () => {
     expect(csv).toContain("0588,Deduccion doble imposicion,7.50");
   });
 
+  it("should omit 1633/1637 rows when there are no other-element or FX disposals", () => {
+    // STK-only fixture → otros elementos block is empty, so those rows must not appear.
+    const csv = formatCsv(makeReport());
+    const lines = csv.split("\n");
+    expect(lines.some((l) => l.startsWith("1633,"))).toBe(false);
+    expect(lines.some((l) => l.startsWith("1637,"))).toBe(false);
+  });
+
+  it("should omit 0328/0331 rows when there are no listed-share disposals", () => {
+    const report = makeReport();
+    report.capitalGains.disposals[0]!.assetCategory = "OPT";
+    const csv = formatCsv(report);
+    const lines = csv.split("\n");
+    expect(lines.some((l) => l.startsWith("0328,"))).toBe(false);
+    expect(lines.some((l) => l.startsWith("0331,"))).toBe(false);
+    // OPT routes to otros elementos → 1633/1637 present instead.
+    expect(lines.some((l) => l.startsWith("1633,"))).toBe(true);
+    expect(lines.some((l) => l.startsWith("1637,"))).toBe(true);
+  });
+
+  it("should emit 1633/1637 rows when only FX disposals exist (no FIFO other-elements)", () => {
+    const report = makeReport({
+      capitalGains: {
+        transmissionValue: new Decimal(0),
+        acquisitionValue: new Decimal(0),
+        netGainLoss: new Decimal(0),
+        blockedLosses: new Decimal(0),
+        disposals: [],
+      },
+      fxGains: {
+        transmissionValue: new Decimal(800),
+        acquisitionValue: new Decimal(750),
+        netGainLoss: new Decimal(50),
+        disposals: [
+          {
+            currency: "USD",
+            disposeDate: "20250615",
+            acquireDate: "20250110",
+            quantity: new Decimal(5000),
+            proceedsEur: new Decimal(800),
+            costBasisEur: new Decimal(750),
+            gainLossEur: new Decimal(50),
+            trigger: "conversion",
+            holdingPeriodDays: 156,
+            lotId: "lot-001",
+          },
+        ],
+      },
+    });
+    const csv = formatCsv(report);
+    const lines = csv.split("\n");
+    expect(lines.some((l) => l.startsWith("1633,Valor de transmision (otros elementos: opciones/cripto/fondos/divisa),800.00"))).toBe(true);
+    expect(lines.some((l) => l.startsWith("1637,Valor de adquisicion (otros elementos: opciones/cripto/fondos/divisa),750.00"))).toBe(true);
+    // No STK disposals → listed-shares rows absent.
+    expect(lines.some((l) => l.startsWith("0328,"))).toBe(false);
+  });
+
   it("should NOT emit the deprecated single-casilla 0327 summary line", () => {
     const csv = formatCsv(makeReport());
     // 0327 is a TEXT field (denominación), never a money box — regression guard


### PR DESCRIPTION
## Summary
Follow-up fixes for the two legitimate CodeRabbit findings on #184.

- **csv.ts** — The casilla summary section emitted `0328/0331` and `1633/1637` rows unconditionally. Now gated behind `blocks.listedShares.count > 0` and `blocks.otherElements.count > 0` (the latter already folds in FX via `computeCasillaBlocksWithFx`), matching the visibility logic the PDF and web renderers already use.
- **casilla-detail.ts** — The expandable drill-down tables for the acquisition cards (`0331` listed shares, `1637` otros elementos + FX) reused the transmission renderers, so they showed `sellDate`/`proceedsEur` under an "acquisition" heading. `renderDisposalsDetail()` and `renderFxDisposalsDetail()` now take a `mode` ("transmission" | "acquisition") and render `acquireDate` + `costBasisEur` for acquisition drill-downs.

Findings intentionally **not** implemented: the NaN-titulares guard (already fixed in #184) and the `>4 titulares` acceptance (intentional — CLI can set any N, guarded by an existing test).

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 1192 passing (added 3 csv row-gating regression tests)