### PR TITLE
fix: redesign fiscal profile page into grouped sections

### DIFF
--- a/src/i18n/locales/ca.ts
+++ b/src/i18n/locales/ca.ts
@@ -163,6 +163,7 @@ const ca: TranslationKeys = {
   "profile.section_personal": "Dades personals",
   "profile.section_declaration": "Configuració de la declaració",
   "profile.nif_label": "NIF/NIE:",
+  "profile.nif_placeholder": "12345678A",
   "profile.surname_label": "Cognoms:",
   "profile.surname_placeholder": "García López",
   "profile.name_label": "Nom:",

--- a/src/i18n/locales/ca.ts
+++ b/src/i18n/locales/ca.ts
@@ -160,6 +160,8 @@ const ca: TranslationKeys = {
 
   "profile.title": "Perfil fiscal",
   "profile.description": "Aquestes dades s'utilitzen per generar els fitxers dels models 720 i D-6.",
+  "profile.section_personal": "Dades personals",
+  "profile.section_declaration": "Configuració de la declaració",
   "profile.nif_label": "NIF/NIE:",
   "profile.surname_label": "Cognoms:",
   "profile.surname_placeholder": "García López",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -161,6 +161,8 @@ const en: TranslationKeys = {
   // Fiscal profile
   "profile.title": "Tax profile",
   "profile.description": "This data is used to generate the Modelo 720 and D-6 files.",
+  "profile.section_personal": "Personal details",
+  "profile.section_declaration": "Declaration settings",
   "profile.nif_label": "NIF/NIE:",
   "profile.surname_label": "Surname:",
   "profile.surname_placeholder": "Smith Jones",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -164,6 +164,7 @@ const en: TranslationKeys = {
   "profile.section_personal": "Personal details",
   "profile.section_declaration": "Declaration settings",
   "profile.nif_label": "NIF/NIE:",
+  "profile.nif_placeholder": "12345678A",
   "profile.surname_label": "Surname:",
   "profile.surname_placeholder": "Smith Jones",
   "profile.name_label": "First name:",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -172,6 +172,8 @@ const es = {
   // Fiscal profile
   "profile.title": "Perfil fiscal",
   "profile.description": "Estos datos se utilizan para generar los ficheros de los modelos 720 y D-6.",
+  "profile.section_personal": "Datos personales",
+  "profile.section_declaration": "Configuración de la declaración",
   "profile.nif_label": "NIF/NIE:",
   "profile.surname_label": "Apellidos:",
   "profile.surname_placeholder": "García López",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -175,6 +175,7 @@ const es = {
   "profile.section_personal": "Datos personales",
   "profile.section_declaration": "Configuración de la declaración",
   "profile.nif_label": "NIF/NIE:",
+  "profile.nif_placeholder": "12345678A",
   "profile.surname_label": "Apellidos:",
   "profile.surname_placeholder": "García López",
   "profile.name_label": "Nombre:",

--- a/src/i18n/locales/eu.ts
+++ b/src/i18n/locales/eu.ts
@@ -160,6 +160,8 @@ const eu: TranslationKeys = {
 
   "profile.title": "Profil fiskala",
   "profile.description": "Datu hauek 720 eta D-6 ereduen fitxategiak sortzeko erabiltzen dira.",
+  "profile.section_personal": "Datu pertsonalak",
+  "profile.section_declaration": "Aitorpenaren konfigurazioa",
   "profile.nif_label": "NIF/NIE:",
   "profile.surname_label": "Abizenak:",
   "profile.surname_placeholder": "García López",

--- a/src/i18n/locales/eu.ts
+++ b/src/i18n/locales/eu.ts
@@ -163,6 +163,7 @@ const eu: TranslationKeys = {
   "profile.section_personal": "Datu pertsonalak",
   "profile.section_declaration": "Aitorpenaren konfigurazioa",
   "profile.nif_label": "NIF/NIE:",
+  "profile.nif_placeholder": "12345678A",
   "profile.surname_label": "Abizenak:",
   "profile.surname_placeholder": "García López",
   "profile.name_label": "Izena:",

--- a/src/i18n/locales/gl.ts
+++ b/src/i18n/locales/gl.ts
@@ -163,6 +163,7 @@ const gl: TranslationKeys = {
   "profile.section_personal": "Datos persoais",
   "profile.section_declaration": "Configuración da declaración",
   "profile.nif_label": "NIF/NIE:",
+  "profile.nif_placeholder": "12345678A",
   "profile.surname_label": "Apelidos:",
   "profile.surname_placeholder": "García López",
   "profile.name_label": "Nome:",

--- a/src/i18n/locales/gl.ts
+++ b/src/i18n/locales/gl.ts
@@ -160,6 +160,8 @@ const gl: TranslationKeys = {
 
   "profile.title": "Perfil fiscal",
   "profile.description": "Estes datos utilízanse para xerar os ficheiros dos modelos 720 e D-6.",
+  "profile.section_personal": "Datos persoais",
+  "profile.section_declaration": "Configuración da declaración",
   "profile.nif_label": "NIF/NIE:",
   "profile.surname_label": "Apelidos:",
   "profile.surname_placeholder": "García López",

--- a/src/web/profile.ts
+++ b/src/web/profile.ts
@@ -126,55 +126,67 @@ export function initProfile(): void {
 
   container.innerHTML = `
     <form class="profile-form" id="profile-form" autocomplete="on">
-      <label>
-        <span>${t("profile.nif_label")}</span>
-        <input type="text" id="profile-nif" value="${esc(profile.nif)}" placeholder="12345678A" maxlength="9" autocomplete="off" />
-      </label>
-      <label>
-        <span>${t("profile.surname_label")}</span>
-        <input type="text" id="profile-surname" value="${esc(profile.apellidos)}" placeholder="${t("profile.surname_placeholder")}" autocomplete="family-name" />
-      </label>
-      <label>
-        <span>${t("profile.name_label")}</span>
-        <input type="text" id="profile-name" value="${esc(profile.nombre)}" placeholder="${t("profile.name_placeholder")}" autocomplete="given-name" />
-      </label>
-      <label>
-        <span>${t("profile.ccaa_label")}</span>
-        <select id="profile-ccaa">
-          <option value="">—</option>
-          ${ccaaOptions}
-        </select>
-      </label>
-      <label>
-        <span>${t("profile.phone_label")}</span>
-        <input type="tel" id="profile-phone" value="${esc(profile.telefono)}" placeholder="${t("profile.phone_placeholder")}" maxlength="15" autocomplete="tel" />
-      </label>
-      <label>
-        <span>${t("config.year_label")}</span>
-        <select id="profile-year">
-          ${yearOptions}
-        </select>
-      </label>
-      <label>
-        <span>${t("profile.titulares_label")}</span>
-        <select id="profile-titulares" aria-describedby="titulares-detail">
-          ${titularesOptions}
-        </select>
-      </label>
-      <p class="field-detail" id="titulares-detail">${t("profile.titulares_detail")}</p>
-      <div class="monodivisa-callout">
-        <label class="monodivisa-toggle">
-          <input type="checkbox" id="profile-monodivisa" aria-describedby="monodivisa-detail monodivisa-warning" ${profile.monodivisa ? "checked" : ""} />
-          <span class="monodivisa-label">
-            <strong>${t("profile.monodivisa_label")}</strong>
-          </span>
-        </label>
-        <p class="monodivisa-detail" id="monodivisa-detail">${t("profile.monodivisa_detail")}</p>
-        <p class="monodivisa-warning" id="monodivisa-warning" role="alert" aria-live="polite" ${profile.monodivisa ? "" : 'hidden'}>${t("profile.monodivisa_warning")}</p>
+      <fieldset class="profile-group">
+        <legend class="profile-group-title">${t("profile.section_personal")}</legend>
+        <div class="profile-grid">
+          <label>
+            <span>${t("profile.nif_label")}</span>
+            <input type="text" id="profile-nif" value="${esc(profile.nif)}" placeholder="12345678A" maxlength="9" autocomplete="off" />
+          </label>
+          <label>
+            <span>${t("profile.surname_label")}</span>
+            <input type="text" id="profile-surname" value="${esc(profile.apellidos)}" placeholder="${t("profile.surname_placeholder")}" autocomplete="family-name" />
+          </label>
+          <label>
+            <span>${t("profile.name_label")}</span>
+            <input type="text" id="profile-name" value="${esc(profile.nombre)}" placeholder="${t("profile.name_placeholder")}" autocomplete="given-name" />
+          </label>
+          <label>
+            <span>${t("profile.ccaa_label")}</span>
+            <select id="profile-ccaa">
+              <option value="">—</option>
+              ${ccaaOptions}
+            </select>
+          </label>
+          <label>
+            <span>${t("profile.phone_label")}</span>
+            <input type="tel" id="profile-phone" value="${esc(profile.telefono)}" placeholder="${t("profile.phone_placeholder")}" maxlength="15" autocomplete="tel" />
+          </label>
+        </div>
+      </fieldset>
+
+      <fieldset class="profile-group">
+        <legend class="profile-group-title">${t("profile.section_declaration")}</legend>
+        <div class="profile-grid">
+          <label>
+            <span>${t("config.year_label")}</span>
+            <select id="profile-year">
+              ${yearOptions}
+            </select>
+          </label>
+          <label>
+            <span>${t("profile.titulares_label")}</span>
+            <select id="profile-titulares" aria-describedby="titulares-detail">
+              ${titularesOptions}
+            </select>
+          </label>
+        </div>
+        <p class="field-detail" id="titulares-detail">${t("profile.titulares_detail")}</p>
+        <div class="monodivisa-callout">
+          <label class="monodivisa-toggle">
+            <input type="checkbox" id="profile-monodivisa" aria-describedby="monodivisa-detail monodivisa-warning" ${profile.monodivisa ? "checked" : ""} />
+            <span class="monodivisa-label"><strong>${t("profile.monodivisa_label")}</strong></span>
+          </label>
+          <p class="monodivisa-detail" id="monodivisa-detail">${t("profile.monodivisa_detail")}</p>
+          <p class="monodivisa-warning" id="monodivisa-warning" role="alert" aria-live="polite" ${profile.monodivisa ? "" : 'hidden'}>${t("profile.monodivisa_warning")}</p>
+        </div>
+      </fieldset>
+
+      <div class="profile-actions">
+        <button type="submit" class="btn-primary" id="profile-save-btn">${t("profile.save_btn")}</button>
+        <p class="profile-saved-msg" id="profile-saved-msg">${t("profile.saved")}</p>
       </div>
-      <button type="submit" class="btn-primary" id="profile-save-btn">${t("profile.save_btn")}</button>
     </form>
-    <p class="profile-saved-msg" id="profile-saved-msg">${t("profile.saved")}</p>
   `;
 
   function collectProfile(): FiscalProfile {

--- a/src/web/profile.ts
+++ b/src/web/profile.ts
@@ -131,7 +131,7 @@ export function initProfile(): void {
         <div class="profile-grid">
           <label>
             <span>${t("profile.nif_label")}</span>
-            <input type="text" id="profile-nif" value="${esc(profile.nif)}" placeholder="12345678A" maxlength="9" autocomplete="off" />
+            <input type="text" id="profile-nif" value="${esc(profile.nif)}" placeholder="${t("profile.nif_placeholder")}" maxlength="9" autocomplete="off" />
           </label>
           <label>
             <span>${t("profile.surname_label")}</span>

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -1663,16 +1663,40 @@ footer a:hover {
 
 /* Profile form */
 .profile-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  margin-top: 1.5rem;
+  max-width: 720px;
+}
+
+.profile-group {
+  border: none;
+  border-top: 1px solid var(--border);
+  padding: 1.25rem 0 0;
+  margin: 0;
+}
+
+.profile-group-title {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  padding: 0;
+  margin-bottom: 1rem;
+}
+
+.profile-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1rem;
-  margin-top: 1rem;
+  gap: 1rem 1.25rem;
 }
 
 .profile-form label {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.35rem;
 }
 
 .profile-form label span {
@@ -1681,20 +1705,23 @@ footer a:hover {
   color: var(--muted);
 }
 
-.profile-form .profile-full-width {
-  grid-column: 1 / -1;
+.field-detail {
+  font-size: 0.78rem;
+  color: var(--muted);
+  line-height: 1.5;
+  margin: 0.75rem 0 0;
 }
 
-.profile-form button[type="submit"] {
-  grid-column: 1 / -1;
-  justify-self: start;
-  margin-top: 0.5rem;
+.profile-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 }
 
 .profile-saved-msg {
   color: var(--success);
   font-size: 0.85rem;
-  margin-top: 0.5rem;
+  margin: 0;
   opacity: 0;
   transition: opacity 0.3s;
 }
@@ -1705,16 +1732,16 @@ footer a:hover {
 
 /* Monodivisa callout */
 .monodivisa-callout {
-  grid-column: 1 / -1;
   background: color-mix(in srgb, var(--warning) 8%, transparent);
   border: 1px solid color-mix(in srgb, var(--warning) 30%, transparent);
   border-left: 4px solid var(--warning);
   border-radius: 8px;
-  padding: 12px 16px;
-  margin-top: 0.5rem;
+  padding: 14px 16px;
+  margin-top: 1rem;
 }
-.monodivisa-toggle {
+.profile-form label.monodivisa-toggle {
   display: flex;
+  flex-direction: row;
   align-items: center;
   gap: 10px;
   cursor: pointer;
@@ -1726,7 +1753,7 @@ footer a:hover {
   flex-shrink: 0;
 }
 .monodivisa-label {
-  font-size: 0.85rem;
+  font-size: 0.9rem;
   color: var(--text);
 }
 .monodivisa-detail {
@@ -2532,7 +2559,7 @@ footer a:hover {
   }
 
   .config-grid,
-  .profile-form {
+  .profile-grid {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Summary
The Perfil fiscal page was visually broken: a flat `1fr 1fr` grid where the help texts (the long Art. 11.3 LIRPF titulares paragraph and field hints) had no `grid-column` rule, so they were auto-placed into the next grid cell and floated beside unrelated inputs. The monodivisa checkbox also rendered stacked/centered because the global `.profile-form label { flex-direction: column }` rule applied to its `<label>`.

### Changes
- Split the form into two `<fieldset>` groups — **Datos personales** and **Configuración de la declaración** — with uppercase section titles and a separator.
- Moved the 2-column grid into an inner `.profile-grid`; the form itself is now a vertical flex stack, so help text spans full width beneath its field instead of leaking into the next column.
- Overrode the monodivisa toggle label back to `flex-direction: row` (higher-specificity selector) so the checkbox sits inline with its label.
- Added `profile.section_personal` / `profile.section_declaration` keys to all 5 locales (es, en, ca, eu, gl).

### Verification
- Drove headless Chrome (CDP) to screenshot the rendered page at desktop (1400px) and mobile (390px) widths — both confirmed: grouped sections, full-width help text, inline toggle, single-column reflow on mobile, monodivisa warning toggles visible on check.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 1192 passing
- [x] `npm run build` — web bundle builds
- [x] Visual: desktop + mobile screenshots verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile form now organized into two distinct sections: Personal details and Declaration settings for improved navigation

* **Style**
  * Redesigned profile form layout with grid-based organization and enhanced visual hierarchy
  * Improved spacing and readability across form elements
  * Updated styling for form controls and callouts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/DeclaRenta/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->