### PR TITLE
feat: add deduplication for dividend cash transactions in IBKR parser

### DIFF
--- a/src/parsers/ibkr.ts
+++ b/src/parsers/ibkr.ts
@@ -46,8 +46,8 @@ function ensureArray<T>(val: T | T[] | undefined): T[] {
 
 
 function isDividendCashTransaction(tx: CashTransaction): boolean {
-  const type = (tx.type ?? "").toLowerCase();
-  const description = (tx.description ?? "").toLowerCase();
+  const type = tx.type.toLowerCase();
+  const description = tx.description.toLowerCase();
   return (
     type.includes("dividend") ||
     description.includes("dividend") ||
@@ -78,7 +78,7 @@ function dedupeCashTransactions(transactions: CashTransaction[]): CashTransactio
     const key = `dividend|${normalizedDate}|${tx.amount || ""}|${normalizedIsin}`;
 
     if (seen.has(key)) continue;
-  
+
     seen.set(key, tx);
     result.push(tx);
   }

--- a/src/parsers/ibkr.ts
+++ b/src/parsers/ibkr.ts
@@ -18,6 +18,7 @@ import type {
 } from "../types/ibkr.js";
 import type { BrokerParser, Statement } from "../types/broker.js";
 import type { TaxMessage } from "../types/tax.js";
+import { normalizeDate } from "../engine/dates.js";
 
 const parser = new XMLParser({
   ignoreAttributes: false,
@@ -43,6 +44,47 @@ function ensureArray<T>(val: T | T[] | undefined): T[] {
   return Array.isArray(val) ? val : [val];
 }
 
+
+function isDividendCashTransaction(tx: CashTransaction): boolean {
+  const type = (tx.type ?? "").toLowerCase();
+  const description = (tx.description ?? "").toLowerCase();
+  return (
+    type.includes("dividend") ||
+    description.includes("dividend") ||
+    description.includes("dividendo")
+  );
+}
+/**
+ * Removes duplicate dividend transactions from the cash transactions array.
+ * Duplicates are identified by matching: normalized date + amount + ISIN.
+ * Non-dividend transactions are passed through unchanged.
+ *
+ * @param transactions - Array of cash transactions (may contain dividends and other types)
+ * @returns Deduplicated array with only unique dividends + all non-dividend transactions
+ */
+
+function dedupeCashTransactions(transactions: CashTransaction[]): CashTransaction[] {
+  const seen = new Map<string, CashTransaction>();
+  const result: CashTransaction[] = [];
+
+  for (const tx of transactions) {
+    if (!isDividendCashTransaction(tx)) {
+      result.push(tx);
+      continue;
+    }
+
+    const normalizedDate = normalizeDate(tx.dateTime || tx.settleDate || "");
+    const normalizedIsin = (tx.isin || "").trim().toUpperCase();
+    const key = `dividend|${normalizedDate}|${tx.amount || ""}|${normalizedIsin}`;
+
+    if (seen.has(key)) continue;
+  
+    seen.set(key, tx);
+    result.push(tx);
+  }
+
+  return result;
+}
 /**
  * Parse an IBKR Flex Query XML string into a FlexStatement.
  *
@@ -74,7 +116,9 @@ export function parseIbkrFlexXml(xml: string): FlexStatement {
 
   for (const stmt of statements) {
     trades.push(...ensureArray(stmt.Trades?.Trade).map(mapTrade));
-    cashTransactions.push(...ensureArray(stmt.CashTransactions?.CashTransaction).map(mapCashTransaction));
+    //cashTransactions.push(...ensureArray(stmt.CashTransactions?.CashTransaction).map(mapCashTransaction));
+    const mappedCashTransactions = ensureArray(stmt.CashTransactions?.CashTransaction).map(mapCashTransaction);
+    cashTransactions.push(...dedupeCashTransactions(mappedCashTransactions));
     corporateActions.push(...ensureArray(stmt.CorporateActions?.CorporateAction).map(mapCorporateAction));
     openPositions.push(...ensureArray(stmt.OpenPositions?.OpenPosition).map(mapOpenPosition));
     securitiesInfo.push(...ensureArray(stmt.SecuritiesInfo?.SecurityInfo).map(mapSecurityInfo));

--- a/src/parsers/ibkr.ts
+++ b/src/parsers/ibkr.ts
@@ -123,7 +123,6 @@ export function parseIbkrFlexXml(xml: string): FlexStatement {
 
   for (const stmt of statements) {
     trades.push(...ensureArray(stmt.Trades?.Trade).map(mapTrade));
-    //cashTransactions.push(...ensureArray(stmt.CashTransactions?.CashTransaction).map(mapCashTransaction));
     const mappedCashTransactions = ensureArray(stmt.CashTransactions?.CashTransaction).map(mapCashTransaction);
     cashTransactions.push(...dedupeCashTransactions(mappedCashTransactions));
     corporateActions.push(...ensureArray(stmt.CorporateActions?.CorporateAction).map(mapCorporateAction));

--- a/src/parsers/ibkr.ts
+++ b/src/parsers/ibkr.ts
@@ -73,9 +73,16 @@ function dedupeCashTransactions(transactions: CashTransaction[]): CashTransactio
       continue;
     }
 
-    const normalizedDate = normalizeDate(tx.dateTime || tx.settleDate || "");
+    const normalizedDate = normalizeDate(tx.dateTime || tx.settleDate || "").trim();
     const normalizedIsin = (tx.isin || "").trim().toUpperCase();
-    const key = `dividend|${normalizedDate}|${tx.amount || ""}|${normalizedIsin}`;
+    const normalizedAmount = (tx.amount || "").trim();
+
+    if (!normalizedDate || !normalizedIsin || !normalizedAmount) {
+      result.push(tx);
+      continue;
+    }
+
+    const key = `dividend|${normalizedDate}|${normalizedAmount}|${normalizedIsin}`;
 
     if (seen.has(key)) continue;
 


### PR DESCRIPTION
He observado que según las opciones que se marcan en el apartado CashTransations puede llegar a duplicar los dividendos en DeclaRenta. 

He generado una rutina dentro del parser de IBKR para que compruebe en todos los dividendos si existe un duplicado en la misma fecha, con la misma cantidad y con el mismo isin. 

Dejo un ejemplo que generaría en la versión actual duplicidad de dividendos.
EDIT. Borro el archivo era erroneo. lo vuelvo a subir
EDIT2. NO soy capaz ahora mismo de volver a reproducir el problema. Quería generar un fichero corto mostrando el problema. Tengo el fichero con los dividendo duplicados pero es demasiado grande para anonimizarlo.

EDIT3. Ahora si lo he conseguido con ayuda de @lucasfarre. Es al marcar la opción Sumary. He comprobado que al crear un nuevo FQ si seleccionas CashTransaction vienen seleccionadas todas las opciones superiores excep;to Summary. 

Se confirma que se duplican los dividendos. Que vienen con las propiedades transactionID="" y accountId="-"

[TestDividDuplicadosIBKR.xml](https://github.com/user-attachments/files/28491137/TestDividDuplicadosIBKR.xml)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate dividend cash transactions in IBKR Flex Query imports to improve data accuracy and consistency when importing broker statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->