### PR TITLE
feat(web): value crypto-to-crypto swaps without external price APIs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,8 @@ tests/           Vitest tests mirroring src/ structure
   - **(B) Manual entry**: the user types an EUR-per-unit value in the crypto-rates panel.
 - We DELIBERATELY do NOT call any live external crypto price API/oracle (this would be "option C"). The set of {coins, dates, amounts} a user holds is a portfolio fingerprint that must never leave their machine.
 - The ONLY permitted outbound call remains the ECB SDMX fiat-rate API.
+- **Shared parsing**: `src/engine/manual-rates.ts` is the single source of truth for turning raw `{currency,date,eurPerUnit}` quotes into an `EcbRateMap` (date→YYYY-MM-DD, currency upper-cased + stablecoin-normalized, rate validated with Decimal). Both the web localStorage path and the CLI `--crypto-rates` flag consume it — never re-implement the validation inline.
+- **Known limitation (cross-date phantom gain)**: dropping an unresolvable BUY leg creates no FIFO lot, so a later *resolvable* SELL of that coin taxes full proceeds as gain (costBasis=0). This is conservative (never understates tax) and the dropped leg is always surfaced for manual entry (B). Intentionally not worked around.
 
 ### Spanish Tax Law References
 - **Art. 37.2 LIRPF**: FIFO mandatory for homogeneous securities

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,14 @@ tests/           Vitest tests mirroring src/ structure
 - **NEVER** log financial amounts, NIF, or personal information
 - The only permitted outbound request is to the ECB SDMX API for exchange rates
 
+### Crypto Permuta Valuation (Art. 37.1.h LIRPF)
+- Crypto↔crypto swaps (permutas) are valued via three mechanisms only:
+  - **(A) Skip-and-warn**: trades we cannot value are skipped, the user is warned.
+  - **(D) Cross-leg inference**: the EUR value is inferred from the resolvable side of the swap.
+  - **(B) Manual entry**: the user types an EUR-per-unit value in the crypto-rates panel.
+- We DELIBERATELY do NOT call any live external crypto price API/oracle (this would be "option C"). The set of {coins, dates, amounts} a user holds is a portfolio fingerprint that must never leave their machine.
+- The ONLY permitted outbound call remains the ECB SDMX fiat-rate API.
+
 ### Spanish Tax Law References
 - **Art. 37.2 LIRPF**: FIFO mandatory for homogeneous securities
 - **Art. 33.5.f LIRPF**: Anti-churning rule — losses blocked if same security repurchased within 2 calendar months (listed on regulated markets) or 1 year (unlisted, including most crypto)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -20,6 +20,7 @@ import { parseRevolutXlsx, detectRevolutXlsx } from "../parsers/revolut.js";
 import type { Statement } from "../types/broker.js";
 import type { EcbRateMap } from "../types/ecb.js";
 import { fetchEcbRates } from "../engine/ecb.js";
+import { buildManualRateMap, coerceManualQuotes } from "../engine/manual-rates.js";
 import { generateTaxReport } from "../generators/report.js";
 import { generateModelo720 } from "../generators/modelo720.js";
 import { validateModelo720Records } from "../generators/modelo720-validator.js";
@@ -180,34 +181,8 @@ program
           console.error("Error: --crypto-rates debe ser un array de { currency, date, eurPerUnit }.");
           process.exit(1);
         }
-        manualRates = new Map();
-        let loaded = 0;
-        for (const raw of parsed as unknown[]) {
-          if (raw == null || typeof raw !== "object") continue;
-          const entry = raw as Record<string, unknown>;
-          if (typeof entry.currency !== "string" || typeof entry.date !== "string" || typeof entry.eurPerUnit !== "string") {
-            continue;
-          }
-          // Normalize YYYYMMDD → YYYY-MM-DD
-          const date = /^\d{8}$/.test(entry.date)
-            ? `${entry.date.slice(0, 4)}-${entry.date.slice(4, 6)}-${entry.date.slice(6, 8)}`
-            : entry.date;
-          let rate: Decimal;
-          try {
-            rate = new Decimal(entry.eurPerUnit);
-          } catch {
-            continue;
-          }
-          if (!rate.isFinite() || rate.lessThanOrEqualTo(0)) continue;
-          const currency = entry.currency.toUpperCase();
-          let byDate = manualRates.get(date);
-          if (!byDate) {
-            byDate = new Map();
-            manualRates.set(date, byDate);
-          }
-          byDate.set(currency, rate.toString());
-          loaded++;
-        }
+        manualRates = buildManualRateMap(coerceManualQuotes(parsed));
+        const loaded = [...manualRates.values()].reduce((n, m) => n + m.size, 0);
         console.error(`  Tipos manuales crypto cargados: ${loaded}`);
       }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -11,7 +11,7 @@
  *   declarenta d6 --input flex.xml --year 2025 --nif 12345678A --name "Apellidos, Nombre"
  */
 
-import { readFileSync, writeFileSync } from "fs";
+import { readFileSync, writeFileSync, existsSync } from "fs";
 import { Command } from "commander";
 import Decimal from "decimal.js";
 import { detectBroker, getBroker, brokerParsers } from "../parsers/index.js";
@@ -126,7 +126,8 @@ program
   .option("--prior-losses <file>", "JSON file with prior year losses for carryforward (Art. 49 LIRPF)")
   .option("--monodivisa", "Disable FX FIFO engine — treat all as EUR (like Autodeclaro/Taxdown)")
   .option("--titulares <n>", "Number of account holders. >1 splits all amounts equally per contribuyente (Art. 11.3 LIRPF)", parseInt)
-  .action(async (opts: { input: string[]; year: number; output?: string; format: string; broker?: string; priorLosses?: string; monodivisa?: boolean; titulares?: number }) => {
+  .option("--crypto-rates <json>", "Manual EUR-per-unit quotes for crypto↔crypto swaps without an ECB rate. Inline JSON or path to a JSON file: [{ \"currency\": \"SOL\", \"date\": \"2024-03-01\", \"eurPerUnit\": \"120.50\" }]")
+  .action(async (opts: { input: string[]; year: number; output?: string; format: string; broker?: string; priorLosses?: string; monodivisa?: boolean; titulares?: number; cryptoRates?: string }) => {
     try {
       console.error(`DeclaRenta v${pkg.version} - Ejercicio ${opts.year}, ${opts.input.length} fichero(s)...`);
 
@@ -160,8 +161,58 @@ program
       }
       console.error(`  Tipos ECB cargados: ${allRates.size} fechas (${[...years].sort().join(", ")})`);
 
+      // 2b. Parse optional manual crypto rates (--crypto-rates). Inline JSON or
+      //     a path to a JSON file. Used as a fallback for crypto↔crypto permutas
+      //     that have no ECB rate (Binance Convert, etc.).
+      let manualRates: EcbRateMap | undefined;
+      if (opts.cryptoRates) {
+        let parsed: unknown;
+        try {
+          const raw = existsSync(opts.cryptoRates)
+            ? readFileSync(opts.cryptoRates, "utf-8")
+            : opts.cryptoRates;
+          parsed = JSON.parse(raw);
+        } catch {
+          console.error("Error: --crypto-rates no es JSON válido ni un fichero JSON legible.");
+          process.exit(1);
+        }
+        if (!Array.isArray(parsed)) {
+          console.error("Error: --crypto-rates debe ser un array de { currency, date, eurPerUnit }.");
+          process.exit(1);
+        }
+        manualRates = new Map();
+        let loaded = 0;
+        for (const raw of parsed as unknown[]) {
+          if (raw == null || typeof raw !== "object") continue;
+          const entry = raw as Record<string, unknown>;
+          if (typeof entry.currency !== "string" || typeof entry.date !== "string" || typeof entry.eurPerUnit !== "string") {
+            continue;
+          }
+          // Normalize YYYYMMDD → YYYY-MM-DD
+          const date = /^\d{8}$/.test(entry.date)
+            ? `${entry.date.slice(0, 4)}-${entry.date.slice(4, 6)}-${entry.date.slice(6, 8)}`
+            : entry.date;
+          let rate: Decimal;
+          try {
+            rate = new Decimal(entry.eurPerUnit);
+          } catch {
+            continue;
+          }
+          if (!rate.isFinite() || rate.lessThanOrEqualTo(0)) continue;
+          const currency = entry.currency.toUpperCase();
+          let byDate = manualRates.get(date);
+          if (!byDate) {
+            byDate = new Map();
+            manualRates.set(date, byDate);
+          }
+          byDate.set(currency, rate.toString());
+          loaded++;
+        }
+        console.error(`  Tipos manuales crypto cargados: ${loaded}`);
+      }
+
       // 3. Generate tax report
-      const report = generateTaxReport(merged, allRates, opts.year, { skipFx: opts.monodivisa, titulares: opts.titulares });
+      const report = generateTaxReport(merged, allRates, opts.year, { skipFx: opts.monodivisa, titulares: opts.titulares, manualRates });
       if (opts.titulares && opts.titulares > 1) {
         console.error(`  Titulares: ${opts.titulares} (importes divididos por contribuyente)`);
       }
@@ -244,6 +295,18 @@ program
           console.error(`  ${i.message}`);
           if (i.hint) console.error(`    → ${i.hint}`);
         }
+      }
+
+      // 5b. Surface unresolved crypto↔crypto valuations (no ECB rate, no
+      //     cross-leg). Show only identifying fields, never financial totals.
+      const unresolved = report.unresolvedCryptoValuations;
+      if (unresolved && unresolved.length > 0) {
+        console.error(`\n🪙 ${unresolved.length} permuta(s) crypto sin valoración en EUR:`);
+        for (const u of unresolved) {
+          console.error(`  ${u.symbol} — ${u.quantity} ${u.currency} @ ${u.date}`);
+        }
+        console.error("  → Aporta el valor en EUR por unidad con --crypto-rates");
+        console.error('    Ejemplo: --crypto-rates \'[{"currency":"SOL","date":"2024-03-01","eurPerUnit":"120.50"}]\'');
       }
 
       // 6. Print summary

--- a/src/engine/crypto-valuation.ts
+++ b/src/engine/crypto-valuation.ts
@@ -1,0 +1,183 @@
+/**
+ * Crypto trade valuation pre-pass.
+ *
+ * Crypto↔crypto swaps (e.g. Binance Convert SOL→BTC) are taxable permutas
+ * (Art. 37.1.h LIRPF, DGT V0999-18) but carry no fiat leg, so the FIFO engine
+ * cannot price them via ECB rates and would throw
+ * "No ECB rate available for non-fiat currency".
+ *
+ * This module runs BEFORE the FIFO engine and resolves each trade's value to
+ * EUR using a single precedence chain, expressed as synthetic entries injected
+ * into a CLONED rate map. Because getEcbRate returns ANY rate present in the
+ * map, the FIFO engine then needs zero changes and never throws on a kept trade.
+ *
+ * Precedence per currency that needs valuing:
+ *   1. ECB (fiat / stablecoin) — authoritative, never overridden.
+ *   2. Manual (B) — user-supplied EUR-per-unit quote (crypto only).
+ *   3. Cross-leg (D) — if the other side of the swap is resolvable, infer
+ *      eurRate(currency) = eurRate(symbol) / tradePrice.
+ *      Units: (EUR/symbol) ÷ (currency/symbol) = EUR/currency.
+ *   4. Skip + warn (A) — drop the trade and surface it for manual entry.
+ *
+ * We deliberately do NOT consult any live external price API/oracle (see
+ * CLAUDE.md): the set of {coins, dates, amounts} is a portfolio fingerprint and
+ * must never leave the user's machine.
+ */
+
+import Decimal from "decimal.js";
+import type { Trade } from "../types/ibkr.js";
+import type { EcbRateMap } from "../types/ecb.js";
+import type { TaxMessage, UnresolvedValuation } from "../types/tax.js";
+import { lookupRateInMap, normalizeCurrency, isEcbResolvable } from "./ecb.js";
+
+export interface CryptoValuationResult {
+  /** Trades to feed the FIFO engine (unresolvable ones dropped, commissions neutralized). */
+  trades: Trade[];
+  /** Augmented clone of the input rate map with synthetic crypto rates injected. */
+  rateMap: EcbRateMap;
+  /** Structured messages (warnings/info) about skipped trades and neutralized commissions. */
+  messages: TaxMessage[];
+  /** Trades dropped for lack of a resolvable value — drive the manual-entry UI. */
+  unresolved: UnresolvedValuation[];
+}
+
+/** Normalize a date string to YYYY-MM-DD (accepts YYYYMMDD). */
+function normDate(date: string): string {
+  return date.length === 8 ? `${date.slice(0, 4)}-${date.slice(4, 6)}-${date.slice(6, 8)}` : date;
+}
+
+function cloneRateMap(map: EcbRateMap): EcbRateMap {
+  const clone: EcbRateMap = new Map();
+  for (const [date, currencies] of map) {
+    clone.set(date, new Map(currencies));
+  }
+  return clone;
+}
+
+/** Inject a synthetic rate (EUR per 1 unit of currency) at an exact date. */
+function setRate(map: EcbRateMap, date: string, currency: string, rate: Decimal): void {
+  const key = normDate(date);
+  const resolved = normalizeCurrency(currency);
+  if (!map.has(key)) map.set(key, new Map());
+  map.get(key)!.set(resolved, rate.toFixed(10));
+}
+
+/** Try ECB/synthetic map first (authoritative), then the user's manual quotes. */
+function tryResolve(map: EcbRateMap, manual: EcbRateMap | undefined, date: string, currency: string): Decimal | null {
+  const fromMap = lookupRateInMap(map, date, currency);
+  if (fromMap !== null) return fromMap;
+  if (manual) {
+    const fromManual = lookupRateInMap(manual, date, currency);
+    if (fromManual !== null) return fromManual;
+  }
+  return null;
+}
+
+/**
+ * Resolve every trade to an EUR-valuable state. Only CRYPTO trades can be
+ * unresolvable; fiat/stock trades pass through untouched (their currency is
+ * already in the ECB map).
+ */
+export function resolveCryptoTradeValues(
+  trades: Trade[],
+  rateMap: EcbRateMap,
+  manualRates?: EcbRateMap,
+): CryptoValuationResult {
+  const cloned = cloneRateMap(rateMap);
+  const outTrades: Trade[] = [];
+  const unresolved: UnresolvedValuation[] = [];
+  const seenUnresolved = new Set<string>();
+  let neutralizedCommissions = 0;
+
+  for (const trade of trades) {
+    const date = trade.tradeDate;
+
+    // 1. Resolve the trade's quote currency.
+    let currencyRate = tryResolve(cloned, manualRates, date, trade.currency);
+    let crossLegTried = false;
+
+    if (currencyRate === null && !isEcbResolvable(trade.currency)) {
+      // 2. Cross-leg inference (D): price the unresolvable quote currency from
+      //    the symbol's rate, if the symbol side is resolvable.
+      crossLegTried = true;
+      const tradePrice = (() => {
+        try {
+          return new Decimal(trade.tradePrice || "0");
+        } catch {
+          return new Decimal(0);
+        }
+      })();
+      const symbolRate = tryResolve(cloned, manualRates, date, trade.symbol);
+      if (symbolRate !== null && tradePrice.greaterThan(0)) {
+        currencyRate = symbolRate.div(tradePrice);
+      }
+    }
+
+    if (currencyRate === null) {
+      // 3. Skip + warn (A). Record once per currency+date for manual entry.
+      const key = `${normalizeCurrency(trade.currency)}|${normDate(date)}`;
+      if (!seenUnresolved.has(key)) {
+        seenUnresolved.add(key);
+        unresolved.push({
+          currency: trade.currency,
+          date: normDate(date),
+          symbol: trade.symbol,
+          description: trade.description,
+          quantity: trade.quantity,
+          reason: crossLegTried ? "no-cross-leg" : "no-ecb",
+        });
+      }
+      continue; // drop the trade
+    }
+
+    // Inject the resolved rate so the FIFO engine finds it via getEcbRate.
+    if (lookupRateInMap(cloned, date, trade.currency) === null) {
+      setRate(cloned, date, trade.currency, currencyRate);
+    }
+
+    // 4. Commission currency. If it differs and is unresolvable, neutralize the
+    //    commission rather than dropping the whole (otherwise valid) trade.
+    let commission: Decimal;
+    try {
+      commission = new Decimal(trade.commission || "0");
+    } catch {
+      commission = new Decimal(0);
+    }
+    const commCur = trade.commissionCurrency;
+    if (!commission.isZero() && commCur && commCur !== trade.currency) {
+      const commRate = tryResolve(cloned, manualRates, date, commCur);
+      if (commRate === null) {
+        neutralizedCommissions++;
+        outTrades.push({ ...trade, commission: "0", commissionCurrency: trade.currency });
+        continue;
+      }
+      if (lookupRateInMap(cloned, date, commCur) === null) {
+        setRate(cloned, date, commCur, commRate);
+      }
+    }
+
+    outTrades.push(trade);
+  }
+
+  const messages: TaxMessage[] = [];
+
+  if (unresolved.length > 0) {
+    messages.push({
+      id: "report.crypto_valuation_unresolved",
+      severity: "warning",
+      message: `Hay ${unresolved.length} operación(es) en criptomoneda cuyo valor en euros no se ha podido determinar automáticamente y se han excluido de los cálculos.`,
+      hint: "Sucede en permutas cripto-cripto (p. ej. Binance Convert) cuando ninguna de las dos monedas tiene tipo de cambio oficial del BCE. Introduce manualmente el valor en euros por unidad de cada moneda en la fecha indicada para incluir estas operaciones.",
+    });
+  }
+
+  if (neutralizedCommissions > 0) {
+    messages.push({
+      id: "report.crypto_commission_neutralized",
+      severity: "info",
+      message: `Se ha ignorado la comisión de ${neutralizedCommissions} operación(es) por estar denominada en una criptomoneda sin tipo de cambio disponible.`,
+      hint: "El valor principal de la operación sí se ha calculado; solo se omite la pequeña comisión, cuyo impacto fiscal es mínimo.",
+    });
+  }
+
+  return { trades: outTrades, rateMap: cloned, messages, unresolved };
+}

--- a/src/engine/crypto-valuation.ts
+++ b/src/engine/crypto-valuation.ts
@@ -22,6 +22,14 @@
  * We deliberately do NOT consult any live external price API/oracle (see
  * CLAUDE.md): the set of {coins, dates, amounts} is a portfolio fingerprint and
  * must never leave the user's machine.
+ *
+ * KNOWN LIMITATION (cross-date phantom gain): dropping an unresolvable BUY leg
+ * means no FIFO lot is created for the acquired coin. If a LATER, resolvable
+ * SELL of that same coin then runs, the FIFO engine finds no prior lot and
+ * taxes the full proceeds as gain (costBasis = 0). This is conservative — it
+ * never understates tax — and the dropped leg is always surfaced as an
+ * UnresolvedValuation so the user can supply a manual rate (B) and value the
+ * acquisition correctly. It is intentionally NOT worked around here.
  */
 
 import Decimal from "decimal.js";
@@ -29,6 +37,7 @@ import type { Trade } from "../types/ibkr.js";
 import type { EcbRateMap } from "../types/ecb.js";
 import type { TaxMessage, UnresolvedValuation } from "../types/tax.js";
 import { lookupRateInMap, normalizeCurrency, isEcbResolvable } from "./ecb.js";
+import { normalizeDate } from "./dates.js";
 
 export interface CryptoValuationResult {
   /** Trades to feed the FIFO engine (unresolvable ones dropped, commissions neutralized). */
@@ -41,11 +50,6 @@ export interface CryptoValuationResult {
   unresolved: UnresolvedValuation[];
 }
 
-/** Normalize a date string to YYYY-MM-DD (accepts YYYYMMDD). */
-function normDate(date: string): string {
-  return date.length === 8 ? `${date.slice(0, 4)}-${date.slice(4, 6)}-${date.slice(6, 8)}` : date;
-}
-
 function cloneRateMap(map: EcbRateMap): EcbRateMap {
   const clone: EcbRateMap = new Map();
   for (const [date, currencies] of map) {
@@ -56,7 +60,7 @@ function cloneRateMap(map: EcbRateMap): EcbRateMap {
 
 /** Inject a synthetic rate (EUR per 1 unit of currency) at an exact date. */
 function setRate(map: EcbRateMap, date: string, currency: string, rate: Decimal): void {
-  const key = normDate(date);
+  const key = normalizeDate(date);
   const resolved = normalizeCurrency(currency);
   if (!map.has(key)) map.set(key, new Map());
   map.get(key)!.set(resolved, rate.toFixed(10));
@@ -115,12 +119,12 @@ export function resolveCryptoTradeValues(
 
     if (currencyRate === null) {
       // 3. Skip + warn (A). Record once per currency+date for manual entry.
-      const key = `${normalizeCurrency(trade.currency)}|${normDate(date)}`;
+      const key = `${normalizeCurrency(trade.currency)}|${normalizeDate(date)}`;
       if (!seenUnresolved.has(key)) {
         seenUnresolved.add(key);
         unresolved.push({
           currency: trade.currency,
-          date: normDate(date),
+          date: normalizeDate(date),
           symbol: trade.symbol,
           description: trade.description,
           quantity: trade.quantity,

--- a/src/engine/ecb.ts
+++ b/src/engine/ecb.ts
@@ -153,16 +153,23 @@ export async function fetchEcbRates(year: number, currencies: string[]): Promise
 }
 
 /**
- * Get the ECB rate for a specific date and currency.
- * If the exact date is a weekend/holiday, walks backward up to 10 days.
+ * Look up a rate for a specific date and currency without throwing.
+ *
+ * Handles EUR (always 1), stablecoin normalization, date format normalization,
+ * and the 10-day backward walk for weekends/holidays. Returns null on miss so
+ * callers can decide whether a miss is fatal (getEcbRate) or recoverable
+ * (crypto-valuation pre-pass: skip-and-warn / cross-leg inference / manual).
+ *
+ * NOTE: this returns ANY rate present in the map for the resolved currency,
+ * including synthetic crypto rates injected by the valuation pre-pass — it does
+ * NOT gate on ECB_CURRENCIES membership.
  *
  * @param rateMap - Pre-fetched rate map
  * @param date - Date string (YYYY-MM-DD or YYYYMMDD)
  * @param currency - Currency code (e.g. "USD")
- * @returns EUR per 1 unit of foreign currency
- * @throws Error if no rate found within 10 business days
+ * @returns EUR per 1 unit of foreign currency, or null if not found
  */
-export function getEcbRate(rateMap: EcbRateMap, date: string, currency: string): Decimal {
+export function lookupRateInMap(rateMap: EcbRateMap, date: string, currency: string): Decimal | null {
   if (currency === "EUR") return new Decimal(1);
 
   // Normalize stablecoins to their fiat equivalent
@@ -187,6 +194,28 @@ export function getEcbRate(rateMap: EcbRateMap, date: string, currency: string):
     // Walk backward one day
     d.setDate(d.getDate() - 1);
   }
+
+  return null;
+}
+
+/**
+ * Get the ECB rate for a specific date and currency.
+ * If the exact date is a weekend/holiday, walks backward up to 10 days.
+ *
+ * @param rateMap - Pre-fetched rate map
+ * @param date - Date string (YYYY-MM-DD or YYYYMMDD)
+ * @param currency - Currency code (e.g. "USD")
+ * @returns EUR per 1 unit of foreign currency
+ * @throws Error if no rate found within 10 business days
+ */
+export function getEcbRate(rateMap: EcbRateMap, date: string, currency: string): Decimal {
+  const rate = lookupRateInMap(rateMap, date, currency);
+  if (rate !== null) return rate;
+
+  const resolved = normalizeCurrency(currency);
+  const normalizedDate = date.length === 8
+    ? `${date.slice(0, 4)}-${date.slice(4, 6)}-${date.slice(6, 8)}`
+    : date;
 
   if (!ECB_CURRENCIES.has(resolved)) {
     throw new Error(`No ECB rate available for non-fiat currency ${currency}. Provide EUR-valued transactions or a supported fiat/stablecoin quote currency.`);

--- a/src/engine/manual-rates.ts
+++ b/src/engine/manual-rates.ts
@@ -28,15 +28,33 @@ export interface ManualRateQuote {
 }
 
 /**
+ * Normalize a human-typed decimal string to the dot-decimal form decimal.js
+ * accepts. Spanish/EU users type "142,50" or "1.234,56"; we strip thousands
+ * separators (spaces, NBSP, thin space) and convert a comma decimal mark to a
+ * dot. A dot-only string (already canonical) passes through untouched.
+ */
+function normalizeDecimalString(raw: string): string {
+  let s = raw.trim().replace(/[\s  ]/g, "");
+  if (s.includes(",")) {
+    // Comma present → treat comma as the decimal mark and dots as thousands.
+    s = s.replace(/\./g, "").replace(",", ".");
+  }
+  return s;
+}
+
+/**
  * Validate and normalize a single quote. Returns null if the quote is unusable
- * (bad shape or non-positive/non-finite rate) so callers can skip it.
+ * (bad shape or non-positive/non-finite rate) so callers can skip it. The
+ * stored eurPerUnit is canonicalized to dot-decimal so every consumer parses it
+ * identically with decimal.js.
  */
 export function normalizeManualQuote(
   quote: ManualRateQuote,
 ): { date: string; currency: string; eurPerUnit: string } | null {
+  const eurPerUnit = normalizeDecimalString(quote.eurPerUnit);
   let rate: Decimal;
   try {
-    rate = new Decimal(quote.eurPerUnit);
+    rate = new Decimal(eurPerUnit);
   } catch {
     return null;
   }
@@ -45,7 +63,7 @@ export function normalizeManualQuote(
   return {
     date: normalizeDate(quote.date),
     currency: normalizeCurrency(quote.currency.toUpperCase()),
-    eurPerUnit: quote.eurPerUnit,
+    eurPerUnit,
   };
 }
 

--- a/src/engine/manual-rates.ts
+++ b/src/engine/manual-rates.ts
@@ -1,0 +1,87 @@
+/**
+ * Shared manual crypto-rate parsing.
+ *
+ * Both the web UI (localStorage) and the CLI (`--crypto-rates`) let the user
+ * supply EUR-per-unit quotes for crypto↔crypto permutas that have no ECB rate.
+ * This module is the single source of truth for turning those raw quotes into
+ * an EcbRateMap, so the validation/normalization rules can't drift between the
+ * two entry points.
+ *
+ * Rules applied to every quote:
+ *   - date    → normalized to YYYY-MM-DD (accepts YYYYMMDD and IBKR datetimes)
+ *   - currency→ upper-cased AND stablecoin-normalized (USDT→USD) so the key
+ *     matches how lookups resolve currencies; otherwise a hand-typed "USDT"
+ *     would be stored under a key the lookup never queries.
+ *   - eurPerUnit → validated with Decimal; non-finite or ≤0 entries dropped.
+ */
+
+import Decimal from "decimal.js";
+import type { EcbRateMap } from "../types/ecb.js";
+import { normalizeDate } from "./dates.js";
+import { normalizeCurrency } from "./ecb.js";
+
+/** One raw manual quote as typed by the user / stored on disk. */
+export interface ManualRateQuote {
+  currency: string;
+  date: string;
+  eurPerUnit: string;
+}
+
+/**
+ * Validate and normalize a single quote. Returns null if the quote is unusable
+ * (bad shape or non-positive/non-finite rate) so callers can skip it.
+ */
+export function normalizeManualQuote(
+  quote: ManualRateQuote,
+): { date: string; currency: string; eurPerUnit: string } | null {
+  let rate: Decimal;
+  try {
+    rate = new Decimal(quote.eurPerUnit);
+  } catch {
+    return null;
+  }
+  if (!rate.isFinite() || rate.lessThanOrEqualTo(0)) return null;
+
+  return {
+    date: normalizeDate(quote.date),
+    currency: normalizeCurrency(quote.currency.toUpperCase()),
+    eurPerUnit: quote.eurPerUnit,
+  };
+}
+
+/**
+ * Build an EcbRateMap (date → currency → EUR-per-1-unit) from raw quotes.
+ * Invalid entries are silently skipped. Later quotes for the same currency+date
+ * win (last-write-wins), matching how the UI upserts a single row.
+ */
+export function buildManualRateMap(quotes: ManualRateQuote[]): EcbRateMap {
+  const map: EcbRateMap = new Map();
+  for (const quote of quotes) {
+    const norm = normalizeManualQuote(quote);
+    if (norm === null) continue;
+    if (!map.has(norm.date)) map.set(norm.date, new Map());
+    map.get(norm.date)!.set(norm.currency, norm.eurPerUnit);
+  }
+  return map;
+}
+
+/**
+ * Narrow arbitrary parsed JSON to ManualRateQuote[]. Tolerates corrupt data:
+ * non-arrays yield [], and entries missing the three string fields are dropped.
+ */
+export function coerceManualQuotes(parsed: unknown): ManualRateQuote[] {
+  if (!Array.isArray(parsed)) return [];
+  const quotes: ManualRateQuote[] = [];
+  for (const raw of parsed as unknown[]) {
+    if (raw == null || typeof raw !== "object") continue;
+    const rec = raw as Record<string, unknown>;
+    if (
+      typeof rec.currency === "string" &&
+      typeof rec.date === "string" &&
+      typeof rec.eurPerUnit === "string"
+    ) {
+      quotes.push({ currency: rec.currency, date: rec.date, eurPerUnit: rec.eurPerUnit });
+    }
+  }
+  return quotes;
+}

--- a/src/generators/report.ts
+++ b/src/generators/report.ts
@@ -112,6 +112,14 @@ export function generateTaxReport(
   const resolvedRateMap = valuation.rateMap;
   const resolvedTrades = valuation.trades;
 
+  // NOTE: only the FIFO engine consumes `resolvedRateMap` (the clone augmented
+  // with synthetic crypto rates). Dividends, interest and the FX engine below
+  // intentionally read the ORIGINAL `rateMap`: those paths only touch
+  // ECB-resolvable (fiat) currencies — crypto-denominated income has no ECB
+  // rate and is skipped/warned separately (see `unresolvableInterest`). If
+  // crypto income valuation is ever added, switch those callers to
+  // `resolvedRateMap` so the injected synthetic rates apply there too.
+
   // 1. FIFO capital gains (process ALL years, filter to target year)
   const fifoEngine = new FifoEngine();
   fifoEngine.processTrades(

--- a/src/generators/report.ts
+++ b/src/generators/report.ts
@@ -16,6 +16,7 @@ import { detectWashSales } from "../engine/wash-sale.js";
 import { calculateDividends } from "../engine/dividends.js";
 import { calculateDoubleTaxation } from "../engine/double-taxation.js";
 import { getEcbRate, isEcbResolvable } from "../engine/ecb.js";
+import { resolveCryptoTradeValues } from "../engine/crypto-valuation.js";
 import { normalizeDate } from "../engine/dates.js";
 
 const DATE_RE = /\b(\d{4})-\d{2}-\d{2}\b/;
@@ -80,6 +81,12 @@ export interface ReportOptions {
    * their proportional share.
    */
   titulares?: number;
+  /**
+   * User-supplied EUR-per-unit quotes (date → currency → rate) for crypto
+   * currencies that have no ECB rate (crypto↔crypto permutas). Consulted as a
+   * fallback by the crypto valuation pre-pass, never overriding ECB rates.
+   */
+  manualRates?: EcbRateMap;
 }
 
 /**
@@ -97,11 +104,19 @@ export function generateTaxReport(
   year: number,
   options?: ReportOptions,
 ): TaxSummary {
+  // 0. Crypto valuation pre-pass (A/D/B). Resolves crypto↔crypto permutas to
+  //    EUR via cross-leg inference or user manual quotes, injecting synthetic
+  //    rates into a cloned map. Unresolvable trades are dropped (and surfaced)
+  //    so the FIFO engine never throws on a non-fiat currency.
+  const valuation = resolveCryptoTradeValues(statement.trades, rateMap, options?.manualRates);
+  const resolvedRateMap = valuation.rateMap;
+  const resolvedTrades = valuation.trades;
+
   // 1. FIFO capital gains (process ALL years, filter to target year)
   const fifoEngine = new FifoEngine();
   fifoEngine.processTrades(
-    statement.trades,
-    rateMap,
+    resolvedTrades,
+    resolvedRateMap,
     statement.corporateActions,
     statement.optionExercises,
   );
@@ -224,11 +239,20 @@ export function generateTaxReport(
   const yearWarnings = filterByYear(fifoEngine.warnings, yearStr, (w) => w);
   const yearMessages = filterByYear(fifoEngine.messages, yearStr, (m) => m.message, (m) => m.context);
 
+  // Crypto valuation pre-pass messages (filtered to the target year by date).
+  const cryptoValuationMessages = filterByYear(valuation.messages, yearStr, (m) => m.message, (m) => m.context);
+  const yearUnresolvedCrypto = valuation.unresolved.filter((u) => u.date.startsWith(yearStr));
+
   // Prepend parser warnings (unparsed sections, etc.)
-  const allWarnings = [...(statement.parserWarnings ?? []), ...yearWarnings, ...fxWarningsList];
+  const allWarnings = [
+    ...(statement.parserWarnings ?? []),
+    ...yearWarnings,
+    ...fxWarningsList,
+    ...cryptoValuationMessages.map((m) => m.message),
+  ];
 
   // Aggregate structured messages from all sources
-  const allMessages: TaxMessage[] = [...(statement.parserMessages ?? []), ...yearMessages, ...fxMessagesList];
+  const allMessages: TaxMessage[] = [...(statement.parserMessages ?? []), ...yearMessages, ...fxMessagesList, ...cryptoValuationMessages];
 
   // Crypto-denominated income (staking rewards paid in the coin) can't be valued
   // via ECB rates. We skip it rather than crash; the user must value it manually.
@@ -268,6 +292,7 @@ export function generateTaxReport(
     year,
     warnings: allWarnings,
     messages: allMessages,
+    unresolvedCryptoValuations: yearUnresolvedCrypto.length > 0 ? yearUnresolvedCrypto : undefined,
     capitalGains: {
       transmissionValue,
       acquisitionValue,

--- a/src/i18n/locales/ca.ts
+++ b/src/i18n/locales/ca.ts
@@ -478,6 +478,20 @@ const ca: TranslationKeys = {
   "pdf.dt_allowed": "Deducció permesa",
   "pdf.ecb_note": "Tipus ECB: tipus de canvi oficial del Banc Central Europeu (EUR per 1 unitat de divisa estrangera) en la data de l'operació. Font: ECB SDMX API.",
   "pdf.footer": "DeclaRenta — https://declarenta.com — Aquest informe és orientatiu i no substitueix l'assessorament fiscal professional.",
+
+  // Manual crypto valuation
+  "crypto_rates.title": "Valoració manual de criptomonedes",
+  "crypto_rates.description": "Alguns intercanvis entre criptomonedes no s'han pogut valorar automàticament perquè cap de les dues divises té un tipus de canvi oficial del BCE. Introdueix el valor en euros per unitat en la data de l'operació per incloure'ls.",
+  "crypto_rates.help": "Mai consultem preus de criptomonedes a internet: la teva cartera es manté privada. Cerca tu mateix el valor en euros (p. ex. a l'historial del teu exchange o en una web de preus) i introdueix-lo aquí.",
+  "crypto_rates.col_asset": "Actiu",
+  "crypto_rates.col_date": "Data",
+  "crypto_rates.col_quantity": "Quantitat",
+  "crypto_rates.col_currency": "Moneda",
+  "crypto_rates.col_eur_per_unit": "EUR per unitat",
+  "crypto_rates.placeholder": "p. ex. 142,50",
+  "crypto_rates.save_btn": "Desa i recalcula",
+  "crypto_rates.saved": "Desat",
+  "crypto_rates.recalculate_hint": "Els valors es desen al teu navegador i l'informe es recalcula.",
 };
 
 export default ca;

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -482,6 +482,20 @@ const en: TranslationKeys = {
   "pdf.dt_allowed": "Deduction allowed",
   "pdf.ecb_note": "ECB rate: official European Central Bank exchange rate (EUR per 1 unit of foreign currency) on the transaction date. Source: ECB SDMX API.",
   "pdf.footer": "DeclaRenta — https://declarenta.com — This report is informational only and does not replace professional tax advice.",
+
+  // Manual crypto valuation
+  "crypto_rates.title": "Manual crypto valuation",
+  "crypto_rates.description": "Some crypto-to-crypto swaps could not be valued automatically because neither currency has an official ECB exchange rate. Enter the value in euros per unit on the trade date to include them.",
+  "crypto_rates.help": "We never look up crypto prices online — your portfolio stays private. Find the EUR value yourself (e.g. from your exchange's history or a price site) and enter it here.",
+  "crypto_rates.col_asset": "Asset",
+  "crypto_rates.col_date": "Date",
+  "crypto_rates.col_quantity": "Quantity",
+  "crypto_rates.col_currency": "Currency",
+  "crypto_rates.col_eur_per_unit": "EUR per unit",
+  "crypto_rates.placeholder": "e.g. 142.50",
+  "crypto_rates.save_btn": "Save and recalculate",
+  "crypto_rates.saved": "Saved",
+  "crypto_rates.recalculate_hint": "Values are saved in your browser and the report is recalculated.",
 };
 
 export default en;

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -511,6 +511,20 @@ const es = {
   "pdf.dt_allowed": "Deducción permitida",
   "pdf.ecb_note": "Tipo ECB: tipo de cambio oficial del Banco Central Europeo (EUR por 1 unidad de divisa extranjera) en la fecha de la operación. Fuente: ECB SDMX API.",
   "pdf.footer": "DeclaRenta — https://declarenta.com — Este informe es orientativo y no sustituye al asesoramiento fiscal profesional.",
+
+  // Manual crypto valuation
+  "crypto_rates.title": "Valoración manual de criptomonedas",
+  "crypto_rates.description": "Algunos canjes entre criptomonedas no se han podido valorar automáticamente porque ninguna de las dos divisas tiene un tipo de cambio oficial del BCE. Introduce el valor en euros por unidad en la fecha de la operación para incluirlos.",
+  "crypto_rates.help": "Nunca consultamos precios de criptomonedas en internet: tu cartera permanece privada. Busca tú mismo el valor en euros (p. ej. en el historial de tu exchange o en una web de precios) e introdúcelo aquí.",
+  "crypto_rates.col_asset": "Activo",
+  "crypto_rates.col_date": "Fecha",
+  "crypto_rates.col_quantity": "Cantidad",
+  "crypto_rates.col_currency": "Moneda",
+  "crypto_rates.col_eur_per_unit": "EUR por unidad",
+  "crypto_rates.placeholder": "p. ej. 142,50",
+  "crypto_rates.save_btn": "Guardar y recalcular",
+  "crypto_rates.saved": "Guardado",
+  "crypto_rates.recalculate_hint": "Los valores se guardan en tu navegador y el informe se recalcula.",
 } as const;
 
 export type TranslationKeys = Record<keyof typeof es, string>;

--- a/src/i18n/locales/eu.ts
+++ b/src/i18n/locales/eu.ts
@@ -478,6 +478,20 @@ const eu: TranslationKeys = {
   "pdf.dt_allowed": "Baimendutako kenkaria",
   "pdf.ecb_note": "ECB tasa: Europako Banku Zentralaren truke-tasa ofiziala (EUR 1 atzerriko moneta-unitate bakoitzeko) eragiketa-datan. Iturria: ECB SDMX API.",
   "pdf.footer": "DeclaRenta — https://declarenta.com — Txosten hau informatiboa da eta ez du zerga-aholkularitza profesionala ordezten.",
+
+  // Manual crypto valuation
+  "crypto_rates.title": "Kriptomoneten eskuzko balioespena",
+  "crypto_rates.description": "Kriptomoneten arteko trukaketa batzuk ezin izan dira automatikoki baloratu, bi monetatako batek ere ez baitu BZEren truke-tasa ofizialik. Sartu eragiketaren dataren araberako balioa euroetan unitateko, haiek sartzeko.",
+  "crypto_rates.help": "Inoiz ez ditugu kriptomoneten prezioak interneten kontsultatzen: zure zorroa pribatu mantentzen da. Bilatu zuk zeuk euroetako balioa (adib. zure exchange-aren historian edo prezio-webgune batean) eta sartu hemen.",
+  "crypto_rates.col_asset": "Aktiboa",
+  "crypto_rates.col_date": "Data",
+  "crypto_rates.col_quantity": "Kantitatea",
+  "crypto_rates.col_currency": "Moneta",
+  "crypto_rates.col_eur_per_unit": "EUR unitateko",
+  "crypto_rates.placeholder": "adib. 142,50",
+  "crypto_rates.save_btn": "Gorde eta birkalkulatu",
+  "crypto_rates.saved": "Gordeta",
+  "crypto_rates.recalculate_hint": "Balioak zure nabigatzailean gordetzen dira eta txostena birkalkulatzen da.",
 };
 
 export default eu;

--- a/src/i18n/locales/gl.ts
+++ b/src/i18n/locales/gl.ts
@@ -478,6 +478,20 @@ const gl: TranslationKeys = {
   "pdf.dt_allowed": "Dedución permitida",
   "pdf.ecb_note": "Tipo ECB: tipo de cambio oficial do Banco Central Europeo (EUR por 1 unidade de divisa estranxeira) na data da operación. Fonte: ECB SDMX API.",
   "pdf.footer": "DeclaRenta — https://declarenta.com — Este informe é orientativo e non substitúe o asesoramento fiscal profesional.",
+
+  // Manual crypto valuation
+  "crypto_rates.title": "Valoración manual de criptomoedas",
+  "crypto_rates.description": "Algúns intercambios entre criptomoedas non se puideron valorar automaticamente porque ningunha das dúas divisas ten un tipo de cambio oficial do BCE. Introduce o valor en euros por unidade na data da operación para incluílos.",
+  "crypto_rates.help": "Nunca consultamos prezos de criptomoedas en internet: a túa carteira mantense privada. Busca ti mesmo o valor en euros (p. ex. no historial do teu exchange ou nunha web de prezos) e introdúceo aquí.",
+  "crypto_rates.col_asset": "Activo",
+  "crypto_rates.col_date": "Data",
+  "crypto_rates.col_quantity": "Cantidade",
+  "crypto_rates.col_currency": "Moeda",
+  "crypto_rates.col_eur_per_unit": "EUR por unidade",
+  "crypto_rates.placeholder": "p. ex. 142,50",
+  "crypto_rates.save_btn": "Gardar e recalcular",
+  "crypto_rates.saved": "Gardado",
+  "crypto_rates.recalculate_hint": "Os valores gárdanse no teu navegador e o informe recalcúlase.",
 };
 
 export default gl;

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -14,6 +14,29 @@ export interface TaxMessage {
   context?: Record<string, string>;
 }
 
+/**
+ * A trade whose value could not be resolved to EUR automatically — i.e. a
+ * crypto-denominated leg (e.g. a crypto↔crypto swap on Binance Convert) with
+ * neither an ECB rate nor a cross-leg inference available. Surfaced to the user
+ * so they can supply a manual EUR-per-unit quote for that currency+date.
+ *
+ * Carries no monetary amounts beyond what the user needs to identify the trade
+ * (symbol, date, quantity, the unresolved currency) — never logs NIF or totals.
+ */
+export interface UnresolvedValuation {
+  /** Currency code that has no resolvable rate (e.g. "SOL") */
+  currency: string;
+  /** Trade date (YYYY-MM-DD) the rate is needed for */
+  date: string;
+  /** Asset symbol/description for the user to recognize the trade */
+  symbol: string;
+  description: string;
+  /** Quantity transacted, as a display string */
+  quantity: string;
+  /** Why it could not be resolved (for the message), e.g. "no-ecb" | "no-cross-leg" */
+  reason: "no-ecb" | "no-cross-leg";
+}
+
 /** Option exercise/close scenario per DGT V0137-23 (Art. 37.1.m LIRPF) */
 export type OptionScenario = "expiration" | "close" | "exercise";
 
@@ -112,6 +135,12 @@ export interface TaxSummary {
   warnings: string[];
   /** Structured three-tier messages (error/warning/info) */
   messages: TaxMessage[];
+  /**
+   * Crypto-denominated trades that could not be valued automatically (no ECB
+   * rate, no cross-leg inference). The web/CLI surfaces these so the user can
+   * provide a manual EUR-per-unit quote. Empty/absent when everything resolved.
+   */
+  unresolvedCryptoValuations?: UnresolvedValuation[];
 
   /**
    * Capital gains: Ganancias y pérdidas patrimoniales. These aggregate totals

--- a/src/web/main.ts
+++ b/src/web/main.ts
@@ -25,6 +25,7 @@ import { initProfile, getProfile, saveProfile } from "./profile.js";
 import { initBrokerGuides, getSelectedBrokerIds, BROKER_ID_TO_PARSER } from "./broker-guides.js";
 import { resolveDetection, DETECTION_ERROR } from "./detection-cache.js";
 import { esc } from "./esc.js";
+import { getManualRates, renderManualRatesPanel, bindManualRatesPanel } from "./manual-rates.js";
 import { initSection720, renderSection720, rerenderSection720 } from "./section-720.js";
 import { initSection721, renderSection721, rerenderSection721 } from "./section-721.js";
 import { initSectionD6, renderSectionD6, rerenderSectionD6 } from "./section-d6.js";
@@ -616,6 +617,7 @@ async function processFiles(): Promise<void> {
     const report = generateTaxReport(merged, allRates, year, {
       skipFx: profileForReport.monodivisa,
       titulares: profileForReport.titulares,
+      manualRates: getManualRates(),
     });
     currentReport = report;
     currentBrokers = detectedBrokers;
@@ -769,6 +771,25 @@ function renderResults(report: TaxSummary) {
         void processFiles();
       }
     });
+  }
+
+  // Manual crypto valuation panel — surfaced when some crypto↔crypto swaps
+  // could not be valued automatically (no ECB rate / no cross-leg). Re-rendered
+  // here each time results render, so it stays in sync on locale change too.
+  const resultsSectionEl = document.getElementById("wizard-step-3")!;
+  resultsSectionEl.querySelectorAll(".crypto-rates-panel").forEach((el) => el.remove());
+  const unresolved = report.unresolvedCryptoValuations;
+  if (unresolved && unresolved.length > 0) {
+    const panelHtml = renderManualRatesPanel(unresolved);
+    casillasDiv.insertAdjacentHTML("beforebegin", panelHtml);
+    const panel = resultsSectionEl.querySelector<HTMLElement>(".crypto-rates-panel");
+    if (panel) {
+      bindManualRatesPanel(panel, () => {
+        // Re-run the full pipeline so the newly-entered manual rates take
+        // effect — no re-upload needed (statement is cached in mergedStatement).
+        void processFiles();
+      });
+    }
   }
 
   // Expandable casilla cards (replaces old table)

--- a/src/web/manual-rates.ts
+++ b/src/web/manual-rates.ts
@@ -13,17 +13,13 @@
 import { t, type TranslationKey } from "../i18n/index.js";
 import type { EcbRateMap } from "../types/ecb.js";
 import type { UnresolvedValuation } from "../types/tax.js";
+import { buildManualRateMap, coerceManualQuotes, normalizeManualQuote, type ManualRateQuote } from "../engine/manual-rates.js";
 import { esc } from "./esc.js";
-import Decimal from "decimal.js";
 
 const STORAGE_KEY = "declarenta_manual_rates";
 
 /** Shape persisted on disk: a flat array of manual quotes. */
-interface StoredManualRate {
-  currency: string;
-  date: string;
-  eurPerUnit: string;
-}
+type StoredManualRate = ManualRateQuote;
 
 /**
  * Reference the new `crypto_rates.*` i18n keys without a compile-time
@@ -44,17 +40,7 @@ function readStored(): StoredManualRate[] {
   }
   if (!raw) return [];
   try {
-    const parsed: unknown = JSON.parse(raw);
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter((e): e is StoredManualRate => {
-      if (e == null || typeof e !== "object") return false;
-      const rec = e as Record<string, unknown>;
-      return (
-        typeof rec.currency === "string" &&
-        typeof rec.date === "string" &&
-        typeof rec.eurPerUnit === "string"
-      );
-    });
+    return coerceManualQuotes(JSON.parse(raw));
   } catch {
     return [];
   }
@@ -71,50 +57,32 @@ function writeStored(entries: StoredManualRate[]): void {
 
 /**
  * Build an EcbRateMap (date → currency → EUR-per-1-unit) from stored manual
- * quotes. Each rate is validated with Decimal; invalid or non-positive entries
- * are skipped. Returns an empty map if nothing valid is stored.
+ * quotes, delegating all validation/normalization to the shared engine helper
+ * so the web and CLI paths can never diverge.
  */
 export function getManualRates(): EcbRateMap {
-  const map: EcbRateMap = new Map();
-  for (const entry of readStored()) {
-    let rate: Decimal;
-    try {
-      rate = new Decimal(entry.eurPerUnit);
-    } catch {
-      continue;
-    }
-    if (!rate.isFinite() || rate.lessThanOrEqualTo(0)) continue;
-
-    if (!map.has(entry.date)) {
-      map.set(entry.date, new Map());
-    }
-    map.get(entry.date)!.set(entry.currency, entry.eurPerUnit);
-  }
-  return map;
+  return buildManualRateMap(readStored());
 }
 
 /** Persist a single manual EUR-per-unit quote for a currency+date pair. */
 export function setManualRate(currency: string, date: string, eurPerUnit: string): void {
-  // Upper-case to match how trade currencies are stored (and the CLI path),
-  // so a hand-typed "sol" still matches symbol "SOL" in cross-leg inference.
-  const cur = currency.toUpperCase();
-  const entries = readStored().filter((e) => !(e.currency === cur && e.date === date));
-  entries.push({ currency: cur, date, eurPerUnit });
+  // Normalize the key exactly as lookups do (upper-case + stablecoin→fiat +
+  // date to YYYY-MM-DD), so a hand-typed "sol"/"USDT" matches at lookup time
+  // and re-saving the same row upserts instead of duplicating.
+  const norm = normalizeManualQuote({ currency, date, eurPerUnit });
+  if (norm === null) return;
+  const entries = readStored().filter(
+    (e) => !(e.currency === norm.currency && e.date === norm.date),
+  );
+  entries.push({ currency: norm.currency, date: norm.date, eurPerUnit });
   writeStored(entries);
-}
-
-/** Remove all stored manual rates. */
-export function clearManualRates(): void {
-  try {
-    localStorage.removeItem(STORAGE_KEY);
-  } catch {
-    /* storage unavailable — nothing to clear */
-  }
 }
 
 /** Look up the currently-stored quote for a currency+date pair (for prefill). */
 function storedRateFor(currency: string, date: string): string {
-  const hit = readStored().find((e) => e.currency === currency && e.date === date);
+  const norm = normalizeManualQuote({ currency, date, eurPerUnit: "1" });
+  const key = norm ?? { currency: currency.toUpperCase(), date };
+  const hit = readStored().find((e) => e.currency === key.currency && e.date === key.date);
   return hit?.eurPerUnit ?? "";
 }
 

--- a/src/web/manual-rates.ts
+++ b/src/web/manual-rates.ts
@@ -64,18 +64,25 @@ export function getManualRates(): EcbRateMap {
   return buildManualRateMap(readStored());
 }
 
-/** Persist a single manual EUR-per-unit quote for a currency+date pair. */
-export function setManualRate(currency: string, date: string, eurPerUnit: string): void {
+/**
+ * Persist a single manual EUR-per-unit quote for a currency+date pair.
+ * Returns true if the quote was valid and stored, false if it was rejected
+ * (e.g. non-numeric/non-positive rate) so callers can avoid showing a false
+ * "saved" state or reprocessing the report for nothing.
+ */
+export function setManualRate(currency: string, date: string, eurPerUnit: string): boolean {
   // Normalize the key exactly as lookups do (upper-case + stablecoin→fiat +
-  // date to YYYY-MM-DD), so a hand-typed "sol"/"USDT" matches at lookup time
-  // and re-saving the same row upserts instead of duplicating.
+  // date to YYYY-MM-DD) and canonicalize the rate to dot-decimal, so a
+  // hand-typed "sol"/"USDT"/"142,50" matches and parses at lookup time and
+  // re-saving the same row upserts instead of duplicating.
   const norm = normalizeManualQuote({ currency, date, eurPerUnit });
-  if (norm === null) return;
+  if (norm === null) return false;
   const entries = readStored().filter(
     (e) => !(e.currency === norm.currency && e.date === norm.date),
   );
-  entries.push({ currency: norm.currency, date: norm.date, eurPerUnit });
+  entries.push({ currency: norm.currency, date: norm.date, eurPerUnit: norm.eurPerUnit });
   writeStored(entries);
+  return true;
 }
 
 /** Look up the currently-stored quote for a currency+date pair (for prefill). */
@@ -155,12 +162,13 @@ export function bindManualRatesPanel(container: HTMLElement, onSave: () => void)
       const currency = input.dataset.currency ?? "";
       const date = input.dataset.date ?? "";
       if (!currency || !date) continue;
-      setManualRate(currency, date, value);
-      savedCount++;
+      // Only count entries that actually persisted (valid, parseable rate), so
+      // an invalid input doesn't fake a "saved" state or trigger a no-op rerun.
+      if (setManualRate(currency, date, value)) savedCount++;
     }
 
     const msg = container.querySelector<HTMLElement>(".crypto-rates-saved-msg");
-    if (msg) msg.hidden = false;
+    if (msg) msg.hidden = savedCount === 0;
 
     if (savedCount > 0) onSave();
   });

--- a/src/web/manual-rates.ts
+++ b/src/web/manual-rates.ts
@@ -1,0 +1,199 @@
+/**
+ * Manual crypto valuation rates.
+ *
+ * For crypto↔crypto swaps (e.g. Binance Convert SOL→BTC) that have no ECB
+ * rate, the report generator surfaces `unresolvedCryptoValuations`. This module
+ * lets the user supply manual EUR-per-unit quotes for those currency+date
+ * pairs, persisting them in localStorage so re-processing can value the trades.
+ *
+ * Privacy: only stores currency code, date and the EUR-per-unit quote the user
+ * types — never NIF, totals or any broker-derived financial amounts.
+ */
+
+import { t, type TranslationKey } from "../i18n/index.js";
+import type { EcbRateMap } from "../types/ecb.js";
+import type { UnresolvedValuation } from "../types/tax.js";
+import { esc } from "./esc.js";
+import Decimal from "decimal.js";
+
+const STORAGE_KEY = "declarenta_manual_rates";
+
+/** Shape persisted on disk: a flat array of manual quotes. */
+interface StoredManualRate {
+  currency: string;
+  date: string;
+  eurPerUnit: string;
+}
+
+/**
+ * Reference the new `crypto_rates.*` i18n keys without a compile-time
+ * dependency on the locale files (added by a separate agent). `t()` already
+ * falls back to the raw key string if a translation is missing.
+ */
+function tr(key: string, params?: Record<string, string>): string {
+  return t(key as TranslationKey, params);
+}
+
+/** Read and parse the raw stored array, tolerating corrupt/missing data. */
+function readStored(): StoredManualRate[] {
+  let raw: string | null = null;
+  try {
+    raw = localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return [];
+  }
+  if (!raw) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((e): e is StoredManualRate => {
+      if (e == null || typeof e !== "object") return false;
+      const rec = e as Record<string, unknown>;
+      return (
+        typeof rec.currency === "string" &&
+        typeof rec.date === "string" &&
+        typeof rec.eurPerUnit === "string"
+      );
+    });
+  } catch {
+    return [];
+  }
+}
+
+/** Persist the array back to localStorage. */
+function writeStored(entries: StoredManualRate[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch {
+    /* storage unavailable/full — manual rates simply won't persist */
+  }
+}
+
+/**
+ * Build an EcbRateMap (date → currency → EUR-per-1-unit) from stored manual
+ * quotes. Each rate is validated with Decimal; invalid or non-positive entries
+ * are skipped. Returns an empty map if nothing valid is stored.
+ */
+export function getManualRates(): EcbRateMap {
+  const map: EcbRateMap = new Map();
+  for (const entry of readStored()) {
+    let rate: Decimal;
+    try {
+      rate = new Decimal(entry.eurPerUnit);
+    } catch {
+      continue;
+    }
+    if (!rate.isFinite() || rate.lessThanOrEqualTo(0)) continue;
+
+    if (!map.has(entry.date)) {
+      map.set(entry.date, new Map());
+    }
+    map.get(entry.date)!.set(entry.currency, entry.eurPerUnit);
+  }
+  return map;
+}
+
+/** Persist a single manual EUR-per-unit quote for a currency+date pair. */
+export function setManualRate(currency: string, date: string, eurPerUnit: string): void {
+  // Upper-case to match how trade currencies are stored (and the CLI path),
+  // so a hand-typed "sol" still matches symbol "SOL" in cross-leg inference.
+  const cur = currency.toUpperCase();
+  const entries = readStored().filter((e) => !(e.currency === cur && e.date === date));
+  entries.push({ currency: cur, date, eurPerUnit });
+  writeStored(entries);
+}
+
+/** Remove all stored manual rates. */
+export function clearManualRates(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    /* storage unavailable — nothing to clear */
+  }
+}
+
+/** Look up the currently-stored quote for a currency+date pair (for prefill). */
+function storedRateFor(currency: string, date: string): string {
+  const hit = readStored().find((e) => e.currency === currency && e.date === date);
+  return hit?.eurPerUnit ?? "";
+}
+
+/**
+ * Render the manual-rates panel as an HTML string (so main.ts can inject it
+ * alongside the rest of the results). Every broker/user-derived value is
+ * escaped. Each row carries data-attributes so `bindManualRatesPanel` can read
+ * the inputs back without re-deriving them.
+ */
+export function renderManualRatesPanel(unresolved: UnresolvedValuation[]): string {
+  const rows = unresolved
+    .map((u, i) => {
+      const prefill = storedRateFor(u.currency, u.date);
+      return `<tr>
+        <td>
+          <div class="crypto-rate-asset"><strong>${esc(u.symbol)}</strong></div>
+          <div class="crypto-rate-desc muted">${esc(u.description)}</div>
+        </td>
+        <td>${esc(u.date)}</td>
+        <td class="mono">${esc(u.quantity)}</td>
+        <td class="mono">${esc(u.currency)}</td>
+        <td>
+          <input type="text" inputmode="decimal"
+            class="crypto-rate-input"
+            data-row="${i}"
+            data-currency="${esc(u.currency)}"
+            data-date="${esc(u.date)}"
+            placeholder="${esc(tr("crypto_rates.placeholder"))}"
+            value="${esc(prefill)}" />
+        </td>
+      </tr>`;
+    })
+    .join("");
+
+  return `<div class="crypto-rates-panel">
+    <h3>${esc(tr("crypto_rates.title"))}</h3>
+    <p>${esc(tr("crypto_rates.description"))}</p>
+    <p class="muted">${esc(tr("crypto_rates.help"))}</p>
+    <div class="table-wrapper"><table>
+      <thead><tr>
+        <th>${esc(tr("crypto_rates.col_asset"))}</th>
+        <th>${esc(tr("crypto_rates.col_date"))}</th>
+        <th>${esc(tr("crypto_rates.col_quantity"))}</th>
+        <th>${esc(tr("crypto_rates.col_currency"))}</th>
+        <th>${esc(tr("crypto_rates.col_eur_per_unit"))}</th>
+      </tr></thead>
+      <tbody>${rows}</tbody>
+    </table></div>
+    <button type="button" id="crypto-rates-save-btn" class="btn-cta">${esc(tr("crypto_rates.save_btn"))}</button>
+    <span class="crypto-rates-saved-msg" hidden>${esc(tr("crypto_rates.saved"))}</span>
+    <p class="muted crypto-rates-recalculate-hint">${esc(tr("crypto_rates.recalculate_hint"))}</p>
+  </div>`;
+}
+
+/**
+ * Wire the save button after the panel HTML has been injected into `container`.
+ * On save: reads each non-empty input, persists it via setManualRate, then
+ * invokes `onSave` (which re-runs the report so the new rates take effect).
+ */
+export function bindManualRatesPanel(container: HTMLElement, onSave: () => void): void {
+  const btn = container.querySelector<HTMLButtonElement>("#crypto-rates-save-btn");
+  if (!btn) return;
+
+  btn.addEventListener("click", () => {
+    const inputs = [...container.querySelectorAll<HTMLInputElement>(".crypto-rate-input")];
+    let savedCount = 0;
+    for (const input of inputs) {
+      const value = input.value.trim();
+      if (!value) continue;
+      const currency = input.dataset.currency ?? "";
+      const date = input.dataset.date ?? "";
+      if (!currency || !date) continue;
+      setManualRate(currency, date, value);
+      savedCount++;
+    }
+
+    const msg = container.querySelector<HTMLElement>(".crypto-rates-saved-msg");
+    if (msg) msg.hidden = false;
+
+    if (savedCount > 0) onSave();
+  });
+}

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -2746,6 +2746,112 @@ footer a:hover {
   }
 }
 
+/* Manual crypto-rates panel — actionable warning to value unvaluable swaps */
+.crypto-rates-panel {
+  margin: 1.5rem 0;
+  padding: 1.25rem 1.5rem;
+  background: var(--warning-bg);
+  border: 1px solid var(--warning-border);
+  border-left: 4px solid var(--warning);
+  border-radius: 8px;
+}
+
+.crypto-rates-panel h3,
+.crypto-rates-panel h4 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  color: var(--warning);
+}
+
+.crypto-rates-panel > p {
+  font-size: 0.875rem;
+  color: var(--text);
+  margin: 0 0 0.5rem;
+  line-height: 1.6;
+}
+
+.crypto-rates-help {
+  font-size: 0.8rem;
+  color: var(--muted);
+  margin: 0 0 1rem;
+  line-height: 1.5;
+}
+
+.crypto-rate-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.crypto-rate-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 0.5rem 0.75rem;
+  padding: 0.6rem 0.75rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+.crypto-rate-info {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.crypto-rate-asset {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.crypto-rate-meta {
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+
+.crypto-rate-row input[type="text"] {
+  width: 11rem;
+  max-width: 100%;
+  font-family: "SF Mono", "Fira Code", monospace;
+  font-size: 0.9rem;
+}
+
+.crypto-rate-row button {
+  margin: 0;
+  padding: 0.5rem 1.25rem;
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.crypto-rate-row.saved {
+  border-color: var(--success);
+}
+
+.crypto-rate-saved {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--success);
+}
+
+@media (max-width: 768px) {
+  .crypto-rate-row {
+    grid-template-columns: 1fr;
+  }
+
+  .crypto-rate-row input[type="text"] {
+    width: 100%;
+  }
+
+  .crypto-rate-row button {
+    width: 100%;
+  }
+}
+
 /* Three-tier message system */
 .msg-section {
   margin-top: 1rem;

--- a/src/web/style.css
+++ b/src/web/style.css
@@ -2770,35 +2770,17 @@ footer a:hover {
   line-height: 1.6;
 }
 
-.crypto-rates-help {
+/* Help text (rendered as <p class="muted">) sits below the description. */
+.crypto-rates-panel .muted {
   font-size: 0.8rem;
   color: var(--muted);
   margin: 0 0 1rem;
   line-height: 1.5;
 }
 
-.crypto-rate-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.crypto-rate-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto;
-  align-items: center;
-  gap: 0.5rem 0.75rem;
-  padding: 0.6rem 0.75rem;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-}
-
-.crypto-rate-info {
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
+/* The table itself inherits the global table styles via .table-wrapper. */
+.crypto-rates-panel .table-wrapper {
+  margin-bottom: 1rem;
 }
 
 .crypto-rate-asset {
@@ -2806,48 +2788,48 @@ footer a:hover {
   font-size: 0.9rem;
 }
 
-.crypto-rate-meta {
+.crypto-rate-desc {
   font-size: 0.78rem;
   color: var(--muted);
 }
 
-.crypto-rate-row input[type="text"] {
+.crypto-rate-input {
   width: 11rem;
   max-width: 100%;
   font-family: "SF Mono", "Fira Code", monospace;
   font-size: 0.9rem;
 }
 
-.crypto-rate-row button {
+#crypto-rates-save-btn {
   margin: 0;
   padding: 0.5rem 1.25rem;
   font-size: 0.85rem;
   white-space: nowrap;
 }
 
-.crypto-rate-row.saved {
-  border-color: var(--success);
-}
-
-.crypto-rate-saved {
+.crypto-rates-saved-msg {
   display: inline-flex;
   align-items: center;
   gap: 0.3rem;
+  margin-left: 0.75rem;
   font-size: 0.8rem;
   font-weight: 600;
   color: var(--success);
 }
 
-@media (max-width: 768px) {
-  .crypto-rate-row {
-    grid-template-columns: 1fr;
-  }
+.crypto-rates-recalculate-hint {
+  font-size: 0.8rem;
+  color: var(--muted);
+  margin: 0.75rem 0 0;
+  line-height: 1.5;
+}
 
-  .crypto-rate-row input[type="text"] {
+@media (max-width: 768px) {
+  .crypto-rate-input {
     width: 100%;
   }
 
-  .crypto-rate-row button {
+  #crypto-rates-save-btn {
     width: 100%;
   }
 }

--- a/tests/engine/crypto-valuation.test.ts
+++ b/tests/engine/crypto-valuation.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect } from "vitest";
+import Decimal from "decimal.js";
+import { resolveCryptoTradeValues } from "../../src/engine/crypto-valuation.js";
+import { lookupRateInMap } from "../../src/engine/ecb.js";
+import type { EcbRateMap } from "../../src/types/ecb.js";
+import type { Trade } from "../../src/types/ibkr.js";
+
+// All fixtures below are ANONYMIZED: synthetic account IDs, no real NIF/names.
+
+function makeRateMap(rates: Record<string, Record<string, string>>): EcbRateMap {
+  const map: EcbRateMap = new Map();
+  for (const [date, currencies] of Object.entries(rates)) {
+    map.set(date, new Map(Object.entries(currencies)));
+  }
+  return map;
+}
+
+/**
+ * Build a minimal CRYPTO swap Trade. `currency` is the quote coin (the side that
+ * may be unresolvable); `symbol` is the asset coin; `tradePrice` is units of
+ * `currency` per 1 `symbol`.
+ */
+function makeCryptoTrade(overrides: Partial<Trade>): Trade {
+  const tradeDate = overrides.tradeDate ?? "2025-04-10";
+  return {
+    tradeID: "t1",
+    accountId: "ACC-TEST",
+    symbol: "BTC",
+    description: "Convert SOL to BTC",
+    isin: "",
+    assetCategory: "CRYPTO",
+    currency: "SOL",
+    tradeDate,
+    settlementDate: tradeDate,
+    quantity: "0.02",
+    tradePrice: "1500",
+    tradeMoney: "30",
+    proceeds: "30",
+    cost: "30",
+    fifoPnlRealized: "0",
+    fxRateToBase: "0",
+    buySell: "BUY",
+    openCloseIndicator: "O",
+    exchange: "BINANCE",
+    commissionCurrency: "SOL",
+    commission: "0",
+    taxes: "0",
+    multiplier: "1",
+    ...overrides,
+  };
+}
+
+describe("resolveCryptoTradeValues", () => {
+  describe("(D) cross-leg inference", () => {
+    it("infers the SOL rate from a resolvable BTC leg, keeps the trade, leaves the original map unmutated", () => {
+      // BTC is resolvable via a direct synthetic rate (EUR per 1 BTC).
+      // tradePrice = 1500 SOL per 1 BTC. So eurRate(SOL) = eurRate(BTC) / 1500.
+      const btcRate = "60000.0000000000"; // EUR per BTC
+      const rateMap = makeRateMap({ "2025-04-10": { BTC: btcRate } });
+      const trade = makeCryptoTrade({
+        currency: "SOL",
+        symbol: "BTC",
+        tradePrice: "1500",
+        commissionCurrency: "SOL",
+        commission: "0",
+      });
+
+      const result = resolveCryptoTradeValues([trade], rateMap);
+
+      // Trade is kept.
+      expect(result.trades).toHaveLength(1);
+      expect(result.unresolved).toHaveLength(0);
+
+      // Injected SOL rate = eurRate(BTC) / tradePrice = 60000 / 1500 = 40.
+      const injected = lookupRateInMap(result.rateMap, "2025-04-10", "SOL");
+      expect(injected).not.toBeNull();
+      const expected = new Decimal(btcRate).div(new Decimal("1500"));
+      expect(injected!.toFixed(10)).toBe(expected.toFixed(10));
+
+      // Original map is NOT mutated (no SOL entry leaked back).
+      expect(lookupRateInMap(rateMap, "2025-04-10", "SOL")).toBeNull();
+    });
+  });
+
+  describe("(B) manual rate path", () => {
+    it("keeps and resolves a swap via manualRates when neither leg is ECB-resolvable", () => {
+      // Neither SOL nor BTC are in the ECB map; manual provides SOL directly.
+      const rateMap: EcbRateMap = new Map();
+      const manualRates = makeRateMap({ "2025-04-10": { SOL: "42.0000000000" } });
+      const trade = makeCryptoTrade({ currency: "SOL", symbol: "BTC", tradePrice: "1500" });
+
+      const result = resolveCryptoTradeValues([trade], rateMap, manualRates);
+
+      expect(result.trades).toHaveLength(1);
+      expect(result.unresolved).toHaveLength(0);
+      const injected = lookupRateInMap(result.rateMap, "2025-04-10", "SOL");
+      expect(injected!.toFixed(2)).toBe("42.00");
+    });
+  });
+
+  describe("(A) skip + warn", () => {
+    it("drops the trade and surfaces one no-cross-leg unresolved entry plus one warning", () => {
+      // Neither leg resolvable, no manual rate → cross-leg attempted but fails.
+      const rateMap: EcbRateMap = new Map();
+      const trade = makeCryptoTrade({ currency: "SOL", symbol: "BTC", tradePrice: "1500" });
+
+      const result = resolveCryptoTradeValues([trade], rateMap);
+
+      expect(result.trades).toHaveLength(0);
+      expect(result.unresolved).toHaveLength(1);
+      expect(result.unresolved[0]!.currency).toBe("SOL");
+      expect(result.unresolved[0]!.reason).toBe("no-cross-leg");
+
+      const warnings = result.messages.filter((m) => m.id === "report.crypto_valuation_unresolved");
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]!.severity).toBe("warning");
+    });
+  });
+
+  describe("commission neutralization", () => {
+    it("keeps a resolvable trade but neutralizes a commission in an unresolvable coin", () => {
+      // Trade currency SOL is resolvable via manual; commission is in a different
+      // unresolvable coin (DOGE) → commission neutralized, info message emitted.
+      const rateMap: EcbRateMap = new Map();
+      const manualRates = makeRateMap({ "2025-04-10": { SOL: "42.0000000000" } });
+      const trade = makeCryptoTrade({
+        currency: "SOL",
+        symbol: "BTC",
+        tradePrice: "1500",
+        commission: "1.5",
+        commissionCurrency: "DOGE",
+      });
+
+      const result = resolveCryptoTradeValues([trade], rateMap, manualRates);
+
+      expect(result.trades).toHaveLength(1);
+      const kept = result.trades[0]!;
+      expect(kept.commission).toBe("0");
+      expect(kept.commissionCurrency).toBe("SOL");
+
+      const info = result.messages.filter((m) => m.id === "report.crypto_commission_neutralized");
+      expect(info).toHaveLength(1);
+      expect(info[0]!.severity).toBe("info");
+    });
+  });
+
+  describe("paired Convert legs resolve or drop together (permuta symmetry)", () => {
+    // A Binance Convert SOL→BTC emits TWO legs sharing a timestamp:
+    //   SELL: symbol=SOL, currency=BTC, tradePrice = BTC per 1 SOL
+    //   BUY:  symbol=BTC, currency=SOL, tradePrice = SOL per 1 BTC  (reciprocal)
+    // Because cross-leg inference is available on BOTH legs, each resolves iff
+    // (R(SOL) OR R(BTC)); the conditions are identical, so the legs can never
+    // split (one kept, one dropped) — which would corrupt FIFO lots.
+    function makeConvertPair(opts: { sellTradePrice: string; buyTradePrice: string }): Trade[] {
+      const date = "2025-04-10";
+      const sell = makeCryptoTrade({
+        tradeID: "conv-sell", symbol: "SOL", currency: "BTC",
+        buySell: "SELL", openCloseIndicator: "C",
+        tradePrice: opts.sellTradePrice, commissionCurrency: "BTC",
+        description: "Convert SOL to BTC", tradeDate: date,
+      });
+      const buy = makeCryptoTrade({
+        tradeID: "conv-buy", symbol: "BTC", currency: "SOL",
+        buySell: "BUY", openCloseIndicator: "O",
+        tradePrice: opts.buyTradePrice, commissionCurrency: "SOL",
+        description: "Convert SOL to BTC", tradeDate: date,
+      });
+      return [sell, buy];
+    }
+
+    it("keeps BOTH legs when only the BTC side is ECB/synthetic-resolvable", () => {
+      // 1 SOL = 0.000666... BTC (sell price); 1 BTC = 1500 SOL (buy price).
+      const pair = makeConvertPair({ sellTradePrice: new Decimal(1).div(1500).toString(), buyTradePrice: "1500" });
+      const rateMap = makeRateMap({ "2025-04-10": { BTC: "60000.0000000000" } });
+
+      const result = resolveCryptoTradeValues(pair, rateMap);
+
+      expect(result.trades).toHaveLength(2);
+      expect(result.unresolved).toHaveLength(0);
+    });
+
+    it("drops BOTH legs together when neither side is resolvable", () => {
+      const pair = makeConvertPair({ sellTradePrice: new Decimal(1).div(1500).toString(), buyTradePrice: "1500" });
+      const rateMap: EcbRateMap = new Map();
+
+      const result = resolveCryptoTradeValues(pair, rateMap);
+
+      expect(result.trades).toHaveLength(0);
+      // Deduped per currency+date, but both coins surface (BTC and SOL).
+      const currencies = result.unresolved.map((u) => u.currency).sort();
+      expect(currencies).toEqual(["BTC", "SOL"]);
+    });
+  });
+
+  describe("pass-through", () => {
+    it("returns a plain USD stock trade unchanged", () => {
+      const rateMap = makeRateMap({ "2025-03-15": { USD: "0.92" } });
+      const stock: Trade = {
+        tradeID: "s1",
+        accountId: "ACC-TEST",
+        symbol: "AAPL",
+        description: "APPLE INC",
+        isin: "US0378331005",
+        assetCategory: "STK",
+        currency: "USD",
+        tradeDate: "2025-03-15",
+        settlementDate: "2025-03-15",
+        quantity: "10",
+        tradePrice: "100",
+        tradeMoney: "1000",
+        proceeds: "1000",
+        cost: "1000",
+        fifoPnlRealized: "0",
+        fxRateToBase: "0.92",
+        buySell: "BUY",
+        openCloseIndicator: "O",
+        exchange: "NASDAQ",
+        commissionCurrency: "USD",
+        commission: "1",
+        taxes: "0",
+        multiplier: "1",
+      };
+
+      const result = resolveCryptoTradeValues([stock], rateMap);
+
+      expect(result.trades).toHaveLength(1);
+      expect(result.trades[0]).toBe(stock); // same reference — untouched
+      expect(result.unresolved).toHaveLength(0);
+      expect(result.messages).toHaveLength(0);
+    });
+  });
+});

--- a/tests/engine/ecb.test.ts
+++ b/tests/engine/ecb.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getEcbRate, getQ4AverageRate } from "../../src/engine/ecb.js";
+import { getEcbRate, getQ4AverageRate, lookupRateInMap } from "../../src/engine/ecb.js";
 import type { EcbRateMap } from "../../src/types/ecb.js";
 
 function makeRateMap(rates: Record<string, Record<string, string>>): EcbRateMap {
@@ -9,6 +9,47 @@ function makeRateMap(rates: Record<string, Record<string, string>>): EcbRateMap 
   }
   return map;
 }
+
+describe("lookupRateInMap", () => {
+  it("returns 1 for EUR without consulting the map", () => {
+    const empty: EcbRateMap = new Map();
+    expect(lookupRateInMap(empty, "2025-03-15", "EUR")!.toNumber()).toBe(1);
+  });
+
+  it("normalizes a stablecoin (USDT) to the underlying USD rate", () => {
+    const rates = makeRateMap({ "2025-03-15": { USD: "0.92" } });
+    // USDT is not present in the map, but normalizes to USD.
+    expect(lookupRateInMap(rates, "2025-03-15", "USDT")!.toFixed(2)).toBe("0.92");
+  });
+
+  it("walks backward over a weekend gap to the prior business day", () => {
+    // Friday 2025-03-14 has a rate; Sunday 2025-03-16 must fall back to it.
+    const rates = makeRateMap({ "2025-03-14": { USD: "0.92" } });
+    expect(lookupRateInMap(rates, "2025-03-16", "USD")!.toFixed(2)).toBe("0.92");
+  });
+
+  it("returns null for a currency not in the map (no throw)", () => {
+    const rates = makeRateMap({ "2025-03-15": { USD: "0.92" } });
+    expect(lookupRateInMap(rates, "2025-03-15", "SOL")).toBeNull();
+  });
+
+  it("does NOT gate on ECB membership — returns a synthetic in-map crypto rate", () => {
+    // A synthetic rate injected by the valuation pre-pass for a non-fiat coin.
+    const rates = makeRateMap({ "2025-03-15": { SOL: "0.0123456789" } });
+    const rate = lookupRateInMap(rates, "2025-03-15", "SOL");
+    expect(rate).not.toBeNull();
+    expect(rate!.toFixed(10)).toBe("0.0123456789");
+  });
+});
+
+describe("getEcbRate non-fiat error", () => {
+  it("throws the non-fiat message for an unknown crypto miss", () => {
+    const rates = makeRateMap({ "2025-03-15": { USD: "0.92" } });
+    expect(() => getEcbRate(rates, "2025-03-15", "SOL")).toThrow(
+      "No ECB rate available for non-fiat currency SOL",
+    );
+  });
+});
 
 describe("getEcbRate", () => {
   it("should return 1 for EUR currency", () => {

--- a/tests/engine/manual-rates.test.ts
+++ b/tests/engine/manual-rates.test.ts
@@ -30,9 +30,22 @@ describe("normalizeManualQuote", () => {
     expect(normalizeManualQuote({ currency: "SOL", date: "2025-04-10", eurPerUnit: "abc" })).toBeNull();
   });
 
-  it("preserves the raw eurPerUnit string (no precision loss)", () => {
+  it("preserves a canonical dot-decimal string (no precision loss)", () => {
     const norm = normalizeManualQuote({ currency: "SOL", date: "2025-04-10", eurPerUnit: "40.1234567890123" });
     expect(norm!.eurPerUnit).toBe("40.1234567890123");
+  });
+
+  it("accepts a comma decimal mark (Spanish/EU input) and canonicalizes to a dot", () => {
+    const norm = normalizeManualQuote({ currency: "SOL", date: "2025-04-10", eurPerUnit: "142,50" });
+    expect(norm).not.toBeNull();
+    expect(norm!.eurPerUnit).toBe("142.50");
+  });
+
+  it("strips thousands separators (dots + spaces) with a comma decimal mark", () => {
+    const norm = normalizeManualQuote({ currency: "SOL", date: "2025-04-10", eurPerUnit: "1.234,56" });
+    expect(norm!.eurPerUnit).toBe("1234.56");
+    const spaced = normalizeManualQuote({ currency: "SOL", date: "2025-04-10", eurPerUnit: "1 234,56" });
+    expect(spaced!.eurPerUnit).toBe("1234.56");
   });
 });
 

--- a/tests/engine/manual-rates.test.ts
+++ b/tests/engine/manual-rates.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildManualRateMap,
+  coerceManualQuotes,
+  normalizeManualQuote,
+} from "../../src/engine/manual-rates.js";
+import { lookupRateInMap } from "../../src/engine/ecb.js";
+
+// All fixtures ANONYMIZED: synthetic coins/dates, no NIF/name/amounts.
+
+describe("normalizeManualQuote", () => {
+  it("upper-cases the currency and normalizes YYYYMMDD dates", () => {
+    const norm = normalizeManualQuote({ currency: "sol", date: "20250410", eurPerUnit: "40" });
+    expect(norm).not.toBeNull();
+    expect(norm!.currency).toBe("SOL");
+    expect(norm!.date).toBe("2025-04-10");
+    expect(norm!.eurPerUnit).toBe("40");
+  });
+
+  it("normalizes a stablecoin ticker to its fiat key (USDT → USD)", () => {
+    // Lookups resolve USDT→USD, so a manual USDT key must also be stored as USD,
+    // otherwise the lookup would never find it.
+    const norm = normalizeManualQuote({ currency: "usdt", date: "2025-04-10", eurPerUnit: "0.92" });
+    expect(norm!.currency).toBe("USD");
+  });
+
+  it("rejects non-positive, non-finite and non-numeric rates", () => {
+    expect(normalizeManualQuote({ currency: "SOL", date: "2025-04-10", eurPerUnit: "0" })).toBeNull();
+    expect(normalizeManualQuote({ currency: "SOL", date: "2025-04-10", eurPerUnit: "-5" })).toBeNull();
+    expect(normalizeManualQuote({ currency: "SOL", date: "2025-04-10", eurPerUnit: "abc" })).toBeNull();
+  });
+
+  it("preserves the raw eurPerUnit string (no precision loss)", () => {
+    const norm = normalizeManualQuote({ currency: "SOL", date: "2025-04-10", eurPerUnit: "40.1234567890123" });
+    expect(norm!.eurPerUnit).toBe("40.1234567890123");
+  });
+});
+
+describe("buildManualRateMap", () => {
+  it("builds a date→currency→rate map and resolves via lookupRateInMap", () => {
+    const map = buildManualRateMap([
+      { currency: "SOL", date: "20250410", eurPerUnit: "40" },
+      { currency: "DOGE", date: "2025-04-11", eurPerUnit: "0.15" },
+    ]);
+    expect(lookupRateInMap(map, "2025-04-10", "SOL")!.toFixed(0)).toBe("40");
+    expect(lookupRateInMap(map, "2025-04-11", "DOGE")!.toFixed(2)).toBe("0.15");
+  });
+
+  it("skips invalid entries but keeps valid ones", () => {
+    const map = buildManualRateMap([
+      { currency: "SOL", date: "2025-04-10", eurPerUnit: "40" },
+      { currency: "BAD", date: "2025-04-10", eurPerUnit: "-1" },
+    ]);
+    expect(lookupRateInMap(map, "2025-04-10", "SOL")).not.toBeNull();
+    expect(lookupRateInMap(map, "2025-04-10", "BAD")).toBeNull();
+  });
+
+  it("is last-write-wins for the same currency+date", () => {
+    const map = buildManualRateMap([
+      { currency: "SOL", date: "2025-04-10", eurPerUnit: "40" },
+      { currency: "SOL", date: "2025-04-10", eurPerUnit: "42" },
+    ]);
+    expect(lookupRateInMap(map, "2025-04-10", "SOL")!.toFixed(0)).toBe("42");
+  });
+
+  it("returns an empty map for no quotes", () => {
+    expect(buildManualRateMap([]).size).toBe(0);
+  });
+});
+
+describe("coerceManualQuotes", () => {
+  it("returns [] for non-array input", () => {
+    expect(coerceManualQuotes(null)).toEqual([]);
+    expect(coerceManualQuotes({})).toEqual([]);
+    expect(coerceManualQuotes("nope")).toEqual([]);
+  });
+
+  it("drops entries missing any of the three string fields", () => {
+    const quotes = coerceManualQuotes([
+      { currency: "SOL", date: "2025-04-10", eurPerUnit: "40" },
+      { currency: "SOL", date: "2025-04-10" }, // missing eurPerUnit
+      { currency: "SOL", date: 20250410, eurPerUnit: "40" }, // date not a string
+      null,
+      42,
+    ]);
+    expect(quotes).toHaveLength(1);
+    expect(quotes[0]).toEqual({ currency: "SOL", date: "2025-04-10", eurPerUnit: "40" });
+  });
+
+  it("round-trips through buildManualRateMap from raw JSON", () => {
+    const parsed: unknown = JSON.parse('[{"currency":"sol","date":"20250410","eurPerUnit":"40"}]');
+    const map = buildManualRateMap(coerceManualQuotes(parsed));
+    expect(lookupRateInMap(map, "2025-04-10", "SOL")!.toFixed(0)).toBe("40");
+  });
+});

--- a/tests/generators/report-crypto.test.ts
+++ b/tests/generators/report-crypto.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import { generateTaxReport } from "../../src/generators/report.js";
+import type { FlexStatement, Trade } from "../../src/types/ibkr.js";
+import type { EcbRateMap } from "../../src/types/ecb.js";
+
+// Anonymized fixtures: synthetic account IDs, no real NIF/names/balances.
+
+function makeRateMap(rates: Record<string, Record<string, string>>): EcbRateMap {
+  const map: EcbRateMap = new Map();
+  for (const [date, currencies] of Object.entries(rates)) {
+    map.set(date, new Map(Object.entries(currencies)));
+  }
+  return map;
+}
+
+function makeCryptoTrade(overrides: Partial<Trade>): Trade {
+  const tradeDate = overrides.tradeDate ?? "2025-04-10";
+  return {
+    tradeID: "t",
+    accountId: "ACC-TEST",
+    symbol: "SOL",
+    description: "Binance Convert",
+    isin: "",
+    assetCategory: "CRYPTO",
+    currency: "BTC",
+    tradeDate,
+    settlementDate: tradeDate,
+    quantity: "100",
+    tradePrice: "0.0005",
+    tradeMoney: "0.05",
+    proceeds: "0.05",
+    cost: "0.05",
+    fifoPnlRealized: "0",
+    fxRateToBase: "0",
+    buySell: "BUY",
+    openCloseIndicator: "O",
+    exchange: "BINANCE",
+    commissionCurrency: "BTC",
+    commission: "0",
+    taxes: "0",
+    multiplier: "1",
+    ...overrides,
+  };
+}
+
+function makeStatement(trades: Trade[]): FlexStatement {
+  return {
+    accountId: "ACC-TEST",
+    fromDate: "20250101",
+    toDate: "20251231",
+    period: "Annual",
+    trades,
+    cashTransactions: [],
+    corporateActions: [],
+    openPositions: [],
+    securitiesInfo: [],
+  };
+}
+
+describe("generateTaxReport — crypto↔crypto permutas", () => {
+  // A crypto↔crypto swap pair: acquire SOL (priced in BTC), later sell SOL (priced
+  // in BTC). Both legs are CRYPTO with NO fiat leg. The quote currency (BTC) and
+  // asset (SOL) have no ECB rate.
+  const buy = makeCryptoTrade({
+    tradeID: "buy-sol",
+    tradeDate: "2025-04-10",
+    symbol: "SOL",
+    currency: "BTC",
+    quantity: "100",
+    tradePrice: "0.0005", // 0.0005 BTC per SOL
+    buySell: "BUY",
+    openCloseIndicator: "O",
+  });
+  const sell = makeCryptoTrade({
+    tradeID: "sell-sol",
+    tradeDate: "2025-09-20",
+    symbol: "SOL",
+    currency: "BTC",
+    quantity: "-100",
+    tradePrice: "0.0006", // 0.0006 BTC per SOL (appreciated)
+    buySell: "SELL",
+    openCloseIndicator: "C",
+  });
+
+  it("does NOT throw and surfaces unresolvedCryptoValuations when rates are sparse", () => {
+    // Sparse map: only an unrelated USD rate, nothing for SOL or BTC.
+    const rateMap = makeRateMap({ "2025-04-10": { USD: "0.92" } });
+    const statement = makeStatement([buy, sell]);
+
+    let report!: ReturnType<typeof generateTaxReport>;
+    expect(() => {
+      report = generateTaxReport(statement, rateMap, 2025);
+    }).not.toThrow();
+
+    // Both legs (BTC quote currency on two dates) are surfaced for manual entry.
+    expect(report.unresolvedCryptoValuations).toBeDefined();
+    expect(report.unresolvedCryptoValuations!.length).toBeGreaterThan(0);
+    for (const u of report.unresolvedCryptoValuations!) {
+      expect(u.currency).toBe("BTC");
+    }
+    // Dropped trades → no disposals computed.
+    expect(report.capitalGains.disposals).toHaveLength(0);
+  });
+
+  it("values the permuta when manualRates cover BTC on both dates", () => {
+    const rateMap: EcbRateMap = new Map();
+    // Manual EUR-per-BTC quotes on each trade date.
+    const manualRates = makeRateMap({
+      "2025-04-10": { BTC: "60000.0000000000" },
+      "2025-09-20": { BTC: "62000.0000000000" },
+    });
+    const statement = makeStatement([buy, sell]);
+
+    const report = generateTaxReport(statement, rateMap, 2025, { manualRates });
+
+    // Everything resolved → no unresolved entries.
+    expect(report.unresolvedCryptoValuations).toBeUndefined();
+
+    // One SOL disposal, capital gains computed.
+    expect(report.capitalGains.disposals).toHaveLength(1);
+    // Proceeds: 100 × 0.0006 BTC × 62000 EUR/BTC = 3720 EUR
+    expect(report.capitalGains.transmissionValue.toFixed(2)).toBe("3720.00");
+    // Cost: 100 × 0.0005 BTC × 60000 EUR/BTC = 3000 EUR
+    expect(report.capitalGains.acquisitionValue.toFixed(2)).toBe("3000.00");
+    expect(report.capitalGains.netGainLoss.toFixed(2)).toBe("720.00");
+  });
+});

--- a/tests/web/manual-rates.test.ts
+++ b/tests/web/manual-rates.test.ts
@@ -48,9 +48,20 @@ describe("setManualRate / getManualRates", () => {
   });
 
   it("ignores an invalid (non-positive) rate rather than persisting it", () => {
-    setManualRate("SOL", "2025-04-10", "0");
+    expect(setManualRate("SOL", "2025-04-10", "0")).toBe(false);
     expect(store[KEY]).toBeUndefined();
     expect(getManualRates().size).toBe(0);
+  });
+
+  it("returns true and canonicalizes a comma-decimal rate on persist", () => {
+    expect(setManualRate("SOL", "2025-04-10", "142,50")).toBe(true);
+    const stored = JSON.parse(store[KEY]!) as { eurPerUnit: string }[];
+    expect(stored[0]!.eurPerUnit).toBe("142.50");
+    expect(lookupRateInMap(getManualRates(), "2025-04-10", "SOL")!.toFixed(2)).toBe("142.50");
+  });
+
+  it("returns false for a non-numeric rate", () => {
+    expect(setManualRate("SOL", "2025-04-10", "abc")).toBe(false);
   });
 });
 

--- a/tests/web/manual-rates.test.ts
+++ b/tests/web/manual-rates.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getManualRates, setManualRate } from "../../src/web/manual-rates.js";
+import { lookupRateInMap } from "../../src/engine/ecb.js";
+
+// Shim localStorage exactly as tests/web/profile.test.ts does (no jsdom).
+let store: Record<string, string> = {};
+beforeEach(() => {
+  store = {};
+  globalThis.localStorage = {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, val: string) => { store[key] = val; },
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    removeItem: (key: string) => { delete store[key]; },
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    clear: () => { Object.keys(store).forEach((k) => { delete store[k]; }); },
+    get length() { return Object.keys(store).length; },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+  };
+});
+
+const KEY = "declarenta_manual_rates";
+
+describe("setManualRate / getManualRates", () => {
+  it("persists a quote and resolves it through getManualRates", () => {
+    setManualRate("SOL", "2025-04-10", "40");
+    const map = getManualRates();
+    expect(lookupRateInMap(map, "2025-04-10", "SOL")!.toFixed(0)).toBe("40");
+  });
+
+  it("upper-cases a hand-typed lowercase currency", () => {
+    setManualRate("sol", "2025-04-10", "40");
+    expect(lookupRateInMap(getManualRates(), "2025-04-10", "SOL")).not.toBeNull();
+  });
+
+  it("normalizes a stablecoin ticker so the USD-keyed lookup matches", () => {
+    setManualRate("USDT", "2025-04-10", "0.92");
+    // Stored under USD; lookupRateInMap normalizes USDT→USD too.
+    expect(lookupRateInMap(getManualRates(), "2025-04-10", "USDT")!.toFixed(2)).toBe("0.92");
+    expect(lookupRateInMap(getManualRates(), "2025-04-10", "USD")!.toFixed(2)).toBe("0.92");
+  });
+
+  it("upserts (does not duplicate) when the same currency+date is saved twice", () => {
+    setManualRate("SOL", "2025-04-10", "40");
+    setManualRate("SOL", "2025-04-10", "42");
+    const stored: unknown = JSON.parse(store[KEY]!);
+    expect(Array.isArray(stored) && stored.length).toBe(1);
+    expect(lookupRateInMap(getManualRates(), "2025-04-10", "SOL")!.toFixed(0)).toBe("42");
+  });
+
+  it("ignores an invalid (non-positive) rate rather than persisting it", () => {
+    setManualRate("SOL", "2025-04-10", "0");
+    expect(store[KEY]).toBeUndefined();
+    expect(getManualRates().size).toBe(0);
+  });
+});
+
+describe("getManualRates resilience", () => {
+  it("returns an empty map when nothing is stored", () => {
+    expect(getManualRates().size).toBe(0);
+  });
+
+  it("tolerates corrupt JSON in storage", () => {
+    store[KEY] = "{not valid json";
+    expect(getManualRates().size).toBe(0);
+  });
+
+  it("tolerates a non-array JSON payload", () => {
+    store[KEY] = '{"currency":"SOL"}';
+    expect(getManualRates().size).toBe(0);
+  });
+
+  it("skips malformed entries but keeps valid ones", () => {
+    store[KEY] = JSON.stringify([
+      { currency: "SOL", date: "2025-04-10", eurPerUnit: "40" },
+      { currency: "BAD" },
+    ]);
+    const map = getManualRates();
+    expect(lookupRateInMap(map, "2025-04-10", "SOL")).not.toBeNull();
+    expect(map.size).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Crypto↔crypto permutas (Art. 37.1.h LIRPF) such as **Binance Convert SOL→BTC** carry no fiat leg, so the FIFO engine threw `No ECB rate available for non-fiat currency` and crashed the entire report (reported in the Telegram channel for a SOL swap).

This adds a **valuation pre-pass** that resolves each trade to EUR *before* the FIFO engine runs, via a single precedence chain expressed as synthetic entries injected into a **cloned** rate map. The financial-critical `fifo.ts` engine is left completely untouched.

### Precedence chain (`src/engine/crypto-valuation.ts`)
1. **ECB** fiat/stablecoin rate — authoritative, never overridden
2. **Manual** user-supplied EUR-per-unit quote
3. **Cross-leg inference** — `eurRate(currency) = eurRate(symbol) / tradePrice` when one leg of the swap is resolvable
4. **Skip + warn** — drop the trade and surface it via `unresolvedCryptoValuations` for manual entry (never silently dropped, never crashes)

### Manual entry (option B)
- **Web**: localStorage-backed panel (`src/web/manual-rates.ts`) shown when a swap can't be valued; saving re-runs the report in place (no re-upload).
- **CLI**: new `--crypto-rates <json>` flag (inline JSON or path to a JSON file).

### Deliberate non-goal: no external price oracle
We do **not** call any live crypto price API. The set of `{coins, dates, amounts}` a user holds is a portfolio fingerprint that must never leave their machine — ECB SDMX stays the only permitted outbound call. Documented in `CLAUDE.md`.

### Notes
- i18n added for **all 5 locales** (es/en/ca/eu/gl).
- Both legs of a Convert pair resolve-or-drop **together** (cross-leg inference is bidirectional) — locked by a regression test, since splitting a pair would corrupt FIFO lots.
- Decimal used throughout; no `Number` coercion; original rate map never mutated.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [x] `npm test` — **1218 passed** (incl. new `crypto-valuation`, `report-crypto`, extended `ecb` suites)
- [ ] Manual: import a Binance Convert (crypto↔crypto) CSV in the web UI → no crash, unresolved-rates panel appears, entering a EUR/unit value recalculates capital gains
- [ ] Manual: `convert --crypto-rates '[{"currency":"SOL","date":"2024-03-01","eurPerUnit":"120.50"}]'` values the swap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Manual crypto exchange rates: Enter EUR-per-unit valuations for crypto-to-crypto swaps that lack official exchange rates.
  * CLI `--crypto-rates` flag: Supply rates via JSON file or inline parameters.
  * Web UI panel: Interactive interface to specify missing exchange rates.
  * Localization support in Spanish, Catalan, Basque, and Galician.

* **Documentation**
  * Crypto swap valuation methodology guide added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->