### PR TITLE
fix(kraken,coinbase): route staking/rewards via Crypto Reward Income bucket

### DIFF
--- a/src/parsers/coinbase.ts
+++ b/src/parsers/coinbase.ts
@@ -83,7 +83,20 @@ function convertTimestamp(ts: string): string {
 // ---------------------------------------------------------------------------
 
 const SKIP_TYPES = ["send", "receive"];
-const INCOME_TYPES = ["staking income", "rewards income", "learning reward"];
+/**
+ * Crypto income types and their Spanish tax bucket:
+ *  - "ahorro": rendimiento del capital mobiliario (savings base, Casilla 0027) —
+ *    staking / holding rewards (DGT V1766-22).
+ *  - "general": ganancia patrimonial no derivada de transmisión (base general,
+ *    Casilla 0304) — Coinbase Earn "learning rewards" are free crypto received
+ *    for completing lessons, with no capital transmitted (Art. 33.1, like an
+ *    airdrop).
+ */
+const INCOME_BUCKETS: Record<string, "ahorro" | "general"> = {
+  "staking income": "ahorro",
+  "rewards income": "ahorro",
+  "learning reward": "general",
+};
 
 // ---------------------------------------------------------------------------
 // Parser
@@ -124,12 +137,16 @@ function parseCoinbaseCsv(lines: string[]): Statement {
     // Skip non-taxable transfers
     if (SKIP_TYPES.includes(txType)) continue;
 
-    // Income transactions (staking, rewards, learning) → interest-like income.
+    // Crypto reward income (staking/rewards → ahorro; learning → base general).
     // These are NOT foreign dividends — no issuer/withholding country and not in
-    // the Art. 80 double-taxation pool. Coinbase reports them with a fiat spot
-    // value (total/subtotal in spotCurrency), so they resolve cleanly via ECB as
-    // Broker Interest Received, keeping them out of calculateDividends().
-    if (INCOME_TYPES.includes(txType)) {
+    // the Art. 80 double-taxation pool. Coinbase reports a fiat spot value
+    // (total/subtotal in spotCurrency), which becomes the EUR cost basis of the
+    // received coins so a later sale isn't double-taxed (Art. 35.1). Routed via
+    // "Crypto Reward Income" + taxBucket so airdrop-like income is never
+    // mis-bucketed into the savings base.
+    const incomeBucket = INCOME_BUCKETS[txType];
+    if (incomeBucket) {
+      const eurAmount = total || subtotal;
       cashTransactions.push({
         transactionID: `coinbase-${txType.replace(/\s+/g, "-")}-${tradeDate}-${asset}-${i}`,
         accountId: "",
@@ -139,9 +156,12 @@ function parseCoinbaseCsv(lines: string[]): Statement {
         currency: spotCurrency || "EUR",
         dateTime: tradeDate,
         settleDate: tradeDate,
-        amount: total || subtotal,
+        amount: eurAmount,
         fxRateToBase: "1",
-        type: "Broker Interest Received",
+        type: "Crypto Reward Income",
+        taxBucket: incomeBucket,
+        rewardQuantity: new Decimal(quantity || "0").abs().toString(),
+        rewardCostBasisEur: new Decimal(eurAmount || "0").abs().toString(),
       });
       continue;
     }

--- a/src/parsers/coinbase.ts
+++ b/src/parsers/coinbase.ts
@@ -91,6 +91,14 @@ const SKIP_TYPES = ["send", "receive"];
  *    Casilla 0304) — Coinbase Earn "learning rewards" are free crypto received
  *    for completing lessons, with no capital transmitted (Art. 33.1, like an
  *    airdrop).
+ *
+ * CAVEAT: "rewards income" is a generic Coinbase label. For holding/staking-style
+ * yield (the common case) ahorro is correct. But Coinbase also uses it for card
+ * cashback / promotional bonuses, which the DGT treats as ganancia patrimonial no
+ * derivada de transmisión (base general). We default the whole label to ahorro:
+ * it covers the majority case and the savings rate (19–28%) is generally ≤ the
+ * general scale, so the bias is conservative-to-neutral. Users with large
+ * promotional "rewards income" should verify its nature (see info message below).
  */
 const INCOME_BUCKETS: Record<string, "ahorro" | "general"> = {
   "staking income": "ahorro",
@@ -112,6 +120,7 @@ function parseCoinbaseCsv(lines: string[]): Statement {
 
   const trades: Trade[] = [];
   const cashTransactions: CashTransaction[] = [];
+  let rewardsIncomeCount = 0;
 
   for (let i = 1; i < lines.length; i++) {
     const line = lines[i]!.trim();
@@ -146,6 +155,7 @@ function parseCoinbaseCsv(lines: string[]): Statement {
     // mis-bucketed into the savings base.
     const incomeBucket = INCOME_BUCKETS[txType];
     if (incomeBucket) {
+      if (txType === "rewards income") rewardsIncomeCount++;
       const eurAmount = total || subtotal;
       cashTransactions.push({
         transactionID: `coinbase-${txType.replace(/\s+/g, "-")}-${tradeDate}-${asset}-${i}`,
@@ -274,6 +284,18 @@ function parseCoinbaseCsv(lines: string[]): Statement {
     });
   }
 
+  // "rewards income" is treated as savings-base income by default, but it can
+  // also cover promotional cashback that is legally base-general. Nudge the user
+  // to verify if any is present (info — no action needed for the common case).
+  const parserMessages = rewardsIncomeCount > 0
+    ? [{
+        id: "coinbase.rewards_income_classification",
+        severity: "info" as const,
+        message: `Se han clasificado ${rewardsIncomeCount} ingreso(s) de tipo "Rewards Income" de Coinbase como rendimientos del capital mobiliario (base del ahorro).`,
+        hint: "Si parte de esos importes son recompensas promocionales o cashback de tarjeta (no rendimientos por mantener o ceder cripto), su tratamiento correcto sería ganancia patrimonial no derivada de transmisión (base general). Revisa su naturaleza si la cantidad es significativa.",
+      }]
+    : undefined;
+
   return {
     accountId: "",
     fromDate: "",
@@ -284,6 +306,7 @@ function parseCoinbaseCsv(lines: string[]): Statement {
     corporateActions: [],
     openPositions: [],
     securitiesInfo: [],
+    ...(parserMessages ? { parserMessages } : {}),
   };
 }
 

--- a/src/parsers/kraken.ts
+++ b/src/parsers/kraken.ts
@@ -289,10 +289,12 @@ function parseLedgersCsv(lines: string[], delimiter: string): Statement {
       const netAmount = amountDec.minus(feeLedgerDec);
 
       // Staking rewards are NOT foreign dividends (no issuer/withholding country,
-      // not in the Art. 80 double-taxation pool). They are income in the staked
-      // crypto. Classify as interest-like income (Broker Interest Received) so
-      // they never enter calculateDividends() — which would try to resolve a
-      // crypto "currency" against ECB rates and fail.
+      // not in the Art. 80 double-taxation pool). They are rendimiento del capital
+      // mobiliario (savings base, Casilla 0027 — DGT V1766-22). Routed via
+      // "Crypto Reward Income" (taxBucket "ahorro") so they never enter
+      // calculateDividends(). Paid in the staked coin with no fiat value here, so
+      // rewardCostBasisEur is omitted — the report values it via ECB/manual rate
+      // (and creates the cost-basis lot) or surfaces it for manual entry.
       cashTransactions.push({
         transactionID: `kraken-staking-${txid}`,
         accountId: "",
@@ -304,7 +306,9 @@ function parseLedgersCsv(lines: string[], delimiter: string): Statement {
         settleDate: tradeDate,
         amount: netAmount.toString(),
         fxRateToBase: "1",
-        type: "Broker Interest Received",
+        type: "Crypto Reward Income",
+        taxBucket: "ahorro",
+        rewardQuantity: netAmount.abs().toString(),
       });
     }
   }

--- a/tests/generators/report-crypto-income-parsers.test.ts
+++ b/tests/generators/report-crypto-income-parsers.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { generateTaxReport } from "../../src/generators/report.js";
+import { coinbaseParser } from "../../src/parsers/coinbase.js";
+import { krakenParser } from "../../src/parsers/kraken.js";
+import type { FlexStatement } from "../../src/types/ibkr.js";
+import type { EcbRateMap } from "../../src/types/ecb.js";
+
+// End-to-end: real parser output → generateTaxReport, proving crypto reward
+// income lands in the correct casilla bucket. Fixtures anonymized (synthetic
+// txids/assets, no NIF/names).
+
+function makeRateMap(rates: Record<string, Record<string, string>>): EcbRateMap {
+  const map: EcbRateMap = new Map();
+  for (const [date, currencies] of Object.entries(rates)) {
+    map.set(date, new Map(Object.entries(currencies)));
+  }
+  return map;
+}
+
+function toStatement(parsed: ReturnType<typeof coinbaseParser.parse>): FlexStatement {
+  return {
+    accountId: "", fromDate: "", toDate: "", period: "",
+    trades: parsed.trades,
+    cashTransactions: parsed.cashTransactions,
+    corporateActions: [],
+    openPositions: [],
+    securitiesInfo: [],
+    ...(parsed.manualRateHints ? { manualRateHints: parsed.manualRateHints } : {}),
+    ...(parsed.parserMessages ? { parserMessages: parsed.parserMessages } : {}),
+  };
+}
+
+const COINBASE_HEADER =
+  "Timestamp,Transaction Type,Asset,Quantity Transacted,Spot Price Currency,Spot Price at Transaction,Subtotal,Total (inclusive of fees and/or spread),Fees and/or Spread,Notes";
+
+const COINBASE_CSV = [
+  COINBASE_HEADER,
+  "2024-08-01T08:00:00Z,Staking Income,ETH,0.01,EUR,3200.00,32.00,32.00,0.00,Staking reward",
+  "2024-11-01T07:30:00Z,Learning Reward,GRT,5.00,EUR,0.20,1.00,1.00,0.00,Earned GRT",
+  "2024-12-01T20:00:00Z,Rewards Income,ALGO,10.00,EUR,0.15,1.50,1.50,0.00,ALGO rewards",
+].join("\n");
+
+const KRAKEN_LEDGERS = [
+  '"txid","refid","time","type","subtype","aclass","asset","amount","fee","balance"',
+  '"LID3","REFID2","2024-06-01 00:00:00","staking","","currency","XETH","0.025","0.0001","5.025"',
+  '"LID4","REFID3","2024-07-15 12:00:00","staking","","currency","DOT","1.5","0.01","100.0"',
+].join("\n");
+
+describe("Coinbase reward income → correct casilla via generateTaxReport", () => {
+  it("routes staking + rewards income to interest (Casilla 0027), learning to generalGains (0304)", () => {
+    const statement = toStatement(coinbaseParser.parse(COINBASE_CSV));
+    const report = generateTaxReport(statement, new Map(), 2024);
+
+    // Staking (32) + Rewards Income (1.50) → savings base, Casilla 0027.
+    expect(report.interest.earned.toFixed(2)).toBe("33.50");
+
+    // Learning reward (1.00) → base general, Casilla 0304 — NOT interest.
+    expect(report.generalGains.total.toFixed(2)).toBe("1.00");
+    expect(report.generalGains.entries).toHaveLength(1);
+    expect(report.generalGains.entries[0]!.symbol).toBe("GRT");
+  });
+
+  it("surfaces an info message about the rewards-income classification assumption", () => {
+    const statement = toStatement(coinbaseParser.parse(COINBASE_CSV));
+    const report = generateTaxReport(statement, new Map(), 2024);
+    expect(report.messages.some((m) => m.id === "coinbase.rewards_income_classification" && m.severity === "info")).toBe(true);
+  });
+
+  it("taxes a later sale of a reward coin only on appreciation (cost-basis lot from EUR value)", () => {
+    // Receive 0.01 ETH staking valued 32 EUR (3200 EUR/ETH), later sell it for 40 EUR.
+    const csv = [
+      COINBASE_HEADER,
+      "2024-08-01T08:00:00Z,Staking Income,ETH,0.01,EUR,3200.00,32.00,32.00,0.00,Staking reward",
+      "2024-10-01T08:00:00Z,Sell,ETH,0.01,EUR,4000.00,40.00,40.00,0.00,Sold ETH",
+    ].join("\n");
+    const statement = toStatement(coinbaseParser.parse(csv));
+    const report = generateTaxReport(statement, makeRateMap({ "2024-10-01": { EUR: "1" } }), 2024);
+    expect(report.capitalGains.disposals).toHaveLength(1);
+    // Gain = 40 proceeds − 32 cost basis = 8, not the full 40 (no double tax).
+    expect(report.capitalGains.acquisitionValue.toFixed(2)).toBe("32.00");
+    expect(report.capitalGains.netGainLoss.toFixed(2)).toBe("8.00");
+    // The 32 EUR was already taxed as ahorro income.
+    expect(report.interest.earned.toFixed(2)).toBe("32.00");
+  });
+});
+
+describe("Kraken coin-denominated staking → correct handling via generateTaxReport", () => {
+  it("surfaces unvalued staking when the reward coin has no ECB/manual rate", () => {
+    const parsed = krakenParser.parse(KRAKEN_LEDGERS);
+    const statement: FlexStatement = {
+      accountId: "", fromDate: "", toDate: "", period: "",
+      trades: parsed.trades, cashTransactions: parsed.cashTransactions,
+      corporateActions: [], openPositions: [], securitiesInfo: [],
+    };
+    const report = generateTaxReport(statement, new Map(), 2024);
+    // No rate for ETH/DOT → not added to interest, surfaced for manual entry.
+    expect(report.interest.earned.toFixed(2)).toBe("0.00");
+    expect(report.messages.some((m) => m.id === "report.crypto_income_unvalued")).toBe(true);
+  });
+
+  it("values Kraken staking via a manual rate when supplied", () => {
+    const parsed = krakenParser.parse(KRAKEN_LEDGERS);
+    const statement: FlexStatement = {
+      accountId: "", fromDate: "", toDate: "", period: "",
+      trades: parsed.trades, cashTransactions: parsed.cashTransactions,
+      corporateActions: [], openPositions: [], securitiesInfo: [],
+    };
+    // ETH 0.0249 net @ 3000 EUR ≈ 74.70; DOT 1.49 net @ 5 EUR ≈ 7.45 → ~82.15.
+    const manualRates = makeRateMap({
+      "2024-06-01": { ETH: "3000" },
+      "2024-07-15": { DOT: "5" },
+    });
+    const report = generateTaxReport(statement, new Map(), 2024, { manualRates });
+    expect(report.interest.earned.toNumber()).toBeGreaterThan(80);
+    expect(report.messages.some((m) => m.id === "report.crypto_income_unvalued")).toBe(false);
+  });
+});

--- a/tests/parsers/coinbase-branches.test.ts
+++ b/tests/parsers/coinbase-branches.test.ts
@@ -88,7 +88,7 @@ describe("coinbaseParser.parse - edge cases", () => {
     const result = coinbaseParser.parse(input);
     expect(result.trades).toHaveLength(0);
     expect(result.cashTransactions).toHaveLength(1);
-    expect(result.cashTransactions[0].type).toBe("Broker Interest Received");
+    expect(result.cashTransactions[0].type).toBe("Crypto Reward Income");
   });
 
   it("should parse rewards income as cash transaction", () => {
@@ -98,7 +98,7 @@ describe("coinbaseParser.parse - edge cases", () => {
     ].join("\n");
     const result = coinbaseParser.parse(input);
     expect(result.cashTransactions).toHaveLength(1);
-    expect(result.cashTransactions[0].type).toBe("Broker Interest Received");
+    expect(result.cashTransactions[0].type).toBe("Crypto Reward Income");
   });
 
   it("should parse learning reward as cash transaction", () => {

--- a/tests/parsers/coinbase.test.ts
+++ b/tests/parsers/coinbase.test.ts
@@ -99,36 +99,42 @@ describe("coinbaseParser", () => {
   // -------------------------------------------------------------------------
 
   describe("parse income transactions", () => {
-    it("should parse Staking Income as interest-like income (not a dividend)", () => {
+    it("should parse Staking Income as ahorro crypto reward income (not a dividend)", () => {
       const result = coinbaseParser.parse(COINBASE_CSV);
       const staking = result.cashTransactions.filter((t) => t.description.includes("staking income"));
       expect(staking).toHaveLength(1);
 
       const tx = staking[0]!;
-      // Crypto staking is income, not a foreign dividend with withholding.
-      expect(tx.type).toBe("Broker Interest Received");
+      // Staking = rendimiento del capital mobiliario (savings base, Casilla 0027).
+      expect(tx.type).toBe("Crypto Reward Income");
+      expect(tx.taxBucket).toBe("ahorro");
       expect(tx.symbol).toBe("ETH");
       expect(tx.currency).toBe("EUR"); // fiat spot value resolves via ECB
       expect(tx.amount).toBe("32.00");
+      expect(tx.rewardCostBasisEur).toBe("32"); // fiat spot value = EUR cost basis
       expect(tx.dateTime).toBe("20240801");
     });
 
-    it("should parse Learning Reward as interest-like income (not a dividend)", () => {
+    it("should parse Learning Reward as base-general crypto reward income (airdrop-like)", () => {
       const result = coinbaseParser.parse(COINBASE_CSV);
       const learning = result.cashTransactions.filter((t) => t.description.includes("learning reward"));
       expect(learning).toHaveLength(1);
 
       expect(learning[0]!.symbol).toBe("GRT");
-      expect(learning[0]!.type).toBe("Broker Interest Received");
+      expect(learning[0]!.type).toBe("Crypto Reward Income");
+      // Coinbase Earn = free crypto for lessons → ganancia no derivada de
+      // transmisión (base general, Casilla 0304), not savings.
+      expect(learning[0]!.taxBucket).toBe("general");
     });
 
-    it("should parse Rewards Income as interest-like income (not a dividend)", () => {
+    it("should parse Rewards Income as ahorro crypto reward income (not a dividend)", () => {
       const result = coinbaseParser.parse(COINBASE_CSV);
       const rewards = result.cashTransactions.filter((t) => t.description.includes("rewards income"));
       expect(rewards).toHaveLength(1);
 
       expect(rewards[0]!.symbol).toBe("ALGO");
-      expect(rewards[0]!.type).toBe("Broker Interest Received");
+      expect(rewards[0]!.type).toBe("Crypto Reward Income");
+      expect(rewards[0]!.taxBucket).toBe("ahorro");
       expect(rewards[0]!.amount).toBe("1.50");
     });
   });

--- a/tests/parsers/fixtures.test.ts
+++ b/tests/parsers/fixtures.test.ts
@@ -115,10 +115,11 @@ describe("fixture file integration", () => {
       const r = coinbaseParser.parse(csv);
       // Convert (sell+buy) + Buy ETH + Sell ETH = 4 trades; Send/Receive skipped
       expect(r.trades).toHaveLength(4);
-      // Staking Income = 1 cash transaction (crypto staking is interest-like
-      // income, not a foreign dividend with withholding)
+      // Staking Income = 1 cash transaction (crypto reward income, ahorro
+      // bucket — not a foreign dividend with withholding)
       expect(r.cashTransactions).toHaveLength(1);
-      expect(r.cashTransactions[0]!.type).toBe("Broker Interest Received");
+      expect(r.cashTransactions[0]!.type).toBe("Crypto Reward Income");
+      expect(r.cashTransactions[0]!.taxBucket).toBe("ahorro");
     });
 
     it("should handle euro currency symbols in values", () => {

--- a/tests/parsers/kraken-branches.test.ts
+++ b/tests/parsers/kraken-branches.test.ts
@@ -10,7 +10,7 @@ describe("krakenParser - Ledgers CSV", () => {
     const result = krakenParser.parse(input);
     expect(result.cashTransactions).toHaveLength(1);
     expect(result.cashTransactions[0].symbol).toBe("ETH");
-    expect(result.cashTransactions[0].type).toBe("Broker Interest Received");
+    expect(result.cashTransactions[0].type).toBe("Crypto Reward Income");
   });
 
   it("should skip non-staking ledger entries", () => {

--- a/tests/parsers/kraken.test.ts
+++ b/tests/parsers/kraken.test.ts
@@ -174,12 +174,17 @@ describe("krakenParser", () => {
       const result = krakenParser.parse(LEDGERS_CSV);
       const ethStake = result.cashTransactions.find((t) => t.symbol === "ETH");
       expect(ethStake).toBeDefined();
-      // Staking is income, not a foreign dividend — classified as interest-like
-      // income so it stays out of the double-taxation/withholding-country pool.
-      expect(ethStake!.type).toBe("Broker Interest Received");
+      // Staking = rendimiento del capital mobiliario (savings base, Casilla
+      // 0027) — routed via Crypto Reward Income/ahorro so it stays out of the
+      // double-taxation/withholding-country pool and isn't mis-bucketed.
+      expect(ethStake!.type).toBe("Crypto Reward Income");
+      expect(ethStake!.taxBucket).toBe("ahorro");
       expect(ethStake!.description).toBe("Staking reward - ETH");
       expect(ethStake!.dateTime).toBe("20240601");
       expect(parseFloat(ethStake!.amount)).toBeCloseTo(0.0249, 4);
+      // Paid in the coin with no fiat value → quantity carried, EUR basis omitted.
+      expect(ethStake!.rewardQuantity).toBeDefined();
+      expect(ethStake!.rewardCostBasisEur).toBeUndefined();
     });
 
     it("should map staking DOT reward with clean symbol", () => {


### PR DESCRIPTION
## Summary

Follow-up to #197. Kraken and Coinbase emitted crypto rewards as `Broker Interest Received`, which routes everything into the **savings base** (Casilla 0027) unconditionally. That mis-buckets airdrop-like income — notably **Coinbase Earn "learning rewards"** (free crypto for completing lessons), which is legally a *ganancia patrimonial no derivada de transmisión* → **base general** (Casilla 0304, Art. 33.1), not savings.

This migrates both parsers to the `Crypto Reward Income` + `taxBucket` model introduced in #197.

- **Coinbase**: `staking income` / `rewards income` → `taxBucket: "ahorro"`; `learning reward` → `"general"`. Carries the fiat spot value as `rewardCostBasisEur`, so the received coins get a cost-basis lot (no double-tax on later sale, Art. 35.1).
- **Kraken**: `staking` → `"ahorro"`, paid in the coin so `rewardCostBasisEur` is omitted (the report values it via ECB/manual rate or surfaces it for manual entry — same as before, but now correctly typed and bucketed).

Trade Republic fiat interest correctly stays `Broker Interest Received`.

### Legal basis
- DGT **V1766-22** — staking/rewards = rendimiento del capital mobiliario (ahorro, 0027).
- Art. **33.1** / DGT V1948-21 — learning rewards / airdrops = ganancia no derivada de transmisión (base general, 0304).

## Test plan
- [x] `npm run typecheck`, `npm run lint`, `npm test` — 1265 tests pass. Updated the Kraken/Coinbase parser + fixture type assertions to the new bucket; added `taxBucket`/`rewardCostBasisEur` assertions.
- [x] `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Crypto rewards and staking income now correctly classified as "Crypto Reward Income" for accurate tax reporting
  * Improved tax categorization distinguishing different reward types
  * Enhanced cost basis and quantity tracking for reward income

* **Tests**
  * Added end-to-end tax report tests covering reward income scenarios across supported exchanges
  * Updated test expectations for new reward classification behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->