### PR TITLE
feat(ibkr): group partial-fill executions into single trades

### DIFF
--- a/src/parsers/ibkr.ts
+++ b/src/parsers/ibkr.ts
@@ -334,25 +334,42 @@ const LEVEL_OF_DETAIL_ORDER = "ORDER";
 const LEVEL_OF_DETAIL_EXECUTION = "EXECUTION";
 
 /**
- * Drop ORDER-level Trade rows when EXECUTION-level rows are also present in the
- * same FlexStatement. IBKR Flex Query allows multiple `levelOfDetail` selections
- * on the Trades section: enabling both "Executions" (per-fill) and "Orders"
- * (aggregated) emits the same activity twice — once per fill, once aggregated.
- * Since {@link mergeExecutionsByOrder} groups by `ibOrderID|tradeDate`, leaving
- * the ORDER row in would double-count quantity, money and commission.
+ * Drop ORDER-level Trade rows when an EXECUTION-level counterpart exists for
+ * the same `ibOrderID`. IBKR Flex Query allows multiple `levelOfDetail`
+ * selections on the Trades section: enabling both "Executions" (per-fill) and
+ * "Orders" (aggregated) emits the same activity twice — once per fill, once
+ * aggregated. Since {@link mergeExecutionsByOrder} groups by
+ * `ibOrderID|tradeDate`, leaving the ORDER row in would double-count quantity,
+ * money and commission.
+ *
+ * The match is per `ibOrderID` rather than a global flag so a hybrid statement
+ * (some orders with both LODs, others with only ORDER — e.g. BookTrade /
+ * internal-transfer rows that may bypass execution detail) keeps the
+ * ORDER-only rows. ORDER rows with no `ibOrderID` are always kept; they cannot
+ * be a duplicate of a keyed EXECUTION row.
  *
  * Symmetric to {@link isCashSummaryRow} for the CashTransactions section, but
  * kept separate because the markers differ (SUMMARY vs ORDER), cash carries a
  * `transactionID/accountId` fallback signal that does not apply to trades, and
- * trades only drop ORDER when EXECUTION is also present (an ORDER-only export
- * remains valid input).
+ * trades only drop ORDER when a matching EXECUTION is also present (a pure
+ * ORDER-only export remains valid input).
  */
 function filterDuplicateLevelOfDetail(rawTrades: Record<string, string>[]): Record<string, string>[] {
-  const hasExecution = rawTrades.some(
-    (t) => (t.levelOfDetail ?? "").toUpperCase() === LEVEL_OF_DETAIL_EXECUTION,
+  const executionOrderIds = new Set<string>();
+  for (const t of rawTrades) {
+    if ((t.levelOfDetail ?? "").toUpperCase() === LEVEL_OF_DETAIL_EXECUTION && t.ibOrderID) {
+      executionOrderIds.add(t.ibOrderID);
+    }
+  }
+  if (executionOrderIds.size === 0) return rawTrades;
+  return rawTrades.filter(
+    (t) =>
+      !(
+        (t.levelOfDetail ?? "").toUpperCase() === LEVEL_OF_DETAIL_ORDER &&
+        t.ibOrderID &&
+        executionOrderIds.has(t.ibOrderID)
+      ),
   );
-  if (!hasExecution) return rawTrades;
-  return rawTrades.filter((t) => (t.levelOfDetail ?? "").toUpperCase() !== LEVEL_OF_DETAIL_ORDER);
 }
 
 /**

--- a/src/parsers/ibkr.ts
+++ b/src/parsers/ibkr.ts
@@ -5,6 +5,7 @@
  * into structured TypeScript objects.
  */
 
+import Decimal from "decimal.js";
 import { XMLParser } from "fast-xml-parser";
 import type {
   FlexStatement,
@@ -79,9 +80,19 @@ export function parseIbkrFlexXml(xml: string): FlexStatement {
   // double-count dividends, withholding, fees and deposits, so they are
   // dropped here before mapping.
   let cashSummaryDuplicatesSkipped = 0;
+  let executionsMergedGroups = 0;
+  let executionsMergedSources = 0;
+  let orderLevelDetailDuplicatesSkipped = 0;
 
   for (const stmt of statements) {
-    trades.push(...ensureArray(stmt.Trades?.Trade).map(mapTrade));
+    const rawTrades = ensureArray(stmt.Trades?.Trade) as Record<string, string>[];
+    const filteredRawTrades = filterDuplicateLevelOfDetail(rawTrades);
+    orderLevelDetailDuplicatesSkipped += rawTrades.length - filteredRawTrades.length;
+    const stmtTrades = filteredRawTrades.map(mapTrade);
+    const { merged, mergedGroupCount, sourceFillCount } = mergeExecutionsByOrder(stmtTrades);
+    trades.push(...merged);
+    executionsMergedGroups += mergedGroupCount;
+    executionsMergedSources += sourceFillCount;
     const rawCash = ensureArray(stmt.CashTransactions?.CashTransaction) as Record<string, string>[];
     const detailCash = rawCash.filter((raw) => !isCashSummaryRow(raw));
     cashSummaryDuplicatesSkipped += rawCash.length - detailCash.length;
@@ -124,6 +135,26 @@ export function parseIbkrFlexXml(xml: string): FlexStatement {
       message: `Se omitieron ${cashSummaryDuplicatesSkipped} filas resumen duplicadas en las transacciones de efectivo.`,
       hint: 'Tu Flex Query tiene activada la opción "Summary" en la sección Cash Transactions, lo que duplica cada movimiento. Puedes desactivarla, pero no es necesario: estas filas se han ignorado automáticamente para evitar duplicar dividendos, retenciones y comisiones.',
       context: { skipped: String(cashSummaryDuplicatesSkipped) },
+    });
+  }
+
+  if (executionsMergedGroups > 0) {
+    parserMessages.push({
+      id: "parser.executions_merged",
+      severity: "info",
+      message: `Se agruparon ${executionsMergedSources} ejecuciones parciales en ${executionsMergedGroups} órdenes.`,
+      hint: "Las órdenes con varias ejecuciones parciales se han combinado en una sola operación, igual que hacen los brokers que informan a Hacienda. El cálculo fiscal no cambia: cantidad total, precio medio ponderado y comisiones suman lo mismo.",
+      context: { sourceFillCount: String(executionsMergedSources), mergedGroupCount: String(executionsMergedGroups) },
+    });
+  }
+
+  if (orderLevelDetailDuplicatesSkipped > 0) {
+    parserMessages.push({
+      id: "parser.order_level_duplicates",
+      severity: "info",
+      message: `Se omitieron ${orderLevelDetailDuplicatesSkipped} filas agregadas de tipo ORDER duplicadas en las operaciones.`,
+      hint: 'Tu Flex Query tiene activado el nivel de detalle "Orders" además de "Executions" en la sección Trades, lo que duplica cada operación. Puedes desactivar "Orders" en la configuración del Flex Query, pero no es necesario: estas filas se han ignorado automáticamente para evitar duplicar cantidades, importes y comisiones.',
+      context: { skipped: String(orderLevelDetailDuplicatesSkipped) },
     });
   }
 
@@ -182,6 +213,113 @@ function mapTrade(raw: Record<string, string>): Trade {
     expiry: raw.expiry || undefined,
     underlyingSymbol: raw.underlyingSymbol || undefined,
     underlyingIsin: raw.underlyingIsin || undefined,
+    ibOrderID: raw.ibOrderID || undefined,
+  };
+}
+
+/**
+ * Collapse same-order partial-fill executions into a single synthetic Trade.
+ *
+ * IBKR emits one `<Trade levelOfDetail="EXECUTION">` per fill; an order that
+ * fills in 3 partials yields 3 Trades sharing the same `ibOrderID` + `tradeDate`.
+ * Hacienda-facing brokers report at the order level, so we mirror that here:
+ * quantities and money sum, price becomes the VWAP. Tax math is unchanged
+ * because FIFO consumes `quantity × tradePrice × multiplier + taxes + commission`,
+ * and the merged values preserve that identity exactly.
+ *
+ * GTC orders that span multiple `tradeDate`s split back into one row per day
+ * (the key includes `tradeDate`), so a year-boundary GTC fill lands in the
+ * correct tax year.
+ *
+ * Trades with no `ibOrderID` pass through un-merged (rare; only carry-forward
+ * edge cases — real IBKR data always populates the field).
+ */
+function mergeExecutionsByOrder(
+  trades: Trade[],
+): { merged: Trade[]; mergedGroupCount: number; sourceFillCount: number } {
+  const groups = new Map<string, Trade[]>();
+  let ungroupedCounter = 0;
+
+  for (const trade of trades) {
+    const key = trade.ibOrderID
+      ? `${trade.ibOrderID}|${trade.tradeDate}`
+      : `__ungrouped_${ungroupedCounter++}__`;
+    let bucket = groups.get(key);
+    if (!bucket) {
+      bucket = [];
+      groups.set(key, bucket);
+    }
+    bucket.push(trade);
+  }
+
+  const merged: Trade[] = [];
+  let mergedGroupCount = 0;
+  let sourceFillCount = 0;
+  for (const bucket of groups.values()) {
+    if (bucket.length === 1) {
+      merged.push(bucket[0]!);
+      continue;
+    }
+    mergedGroupCount++;
+    sourceFillCount += bucket.length;
+    merged.push(mergeTradeGroup(bucket));
+  }
+  return { merged, mergedGroupCount, sourceFillCount };
+}
+
+function mergeTradeGroup(group: Trade[]): Trade {
+  const first = group[0]!;
+  let qty = new Decimal(0);
+  let qtyAbs = new Decimal(0);
+  let money = new Decimal(0);
+  let proceeds = new Decimal(0);
+  let cost = new Decimal(0);
+  let commission = new Decimal(0);
+  let taxes = new Decimal(0);
+  let fifoPnl = new Decimal(0);
+  const notes = new Set<string>();
+  let exchange = first.exchange;
+
+  for (const t of group) {
+    const q = new Decimal(t.quantity);
+    qty = qty.plus(q);
+    qtyAbs = qtyAbs.plus(q.abs());
+    money = money.plus(new Decimal(t.tradeMoney || "0"));
+    proceeds = proceeds.plus(new Decimal(t.proceeds || "0"));
+    cost = cost.plus(new Decimal(t.cost || "0"));
+    commission = commission.plus(new Decimal(t.commission || "0"));
+    taxes = taxes.plus(new Decimal(t.taxes || "0"));
+    fifoPnl = fifoPnl.plus(new Decimal(t.fifoPnlRealized || "0"));
+    if (!exchange) exchange = t.exchange;
+    if (t.notes) {
+      for (const n of t.notes.split(";")) {
+        const trimmed = n.trim();
+        if (trimmed) notes.add(trimmed);
+      }
+    }
+  }
+
+  // VWAP per unit, consistent with IBKR's tradePrice semantics:
+  //   tradeMoney = quantity × tradePrice × multiplier
+  // All fills share the same multiplier (invariant within an order).
+  const multiplier = new Decimal(first.multiplier || "1");
+  const vwap = qtyAbs.isZero() || multiplier.isZero()
+    ? new Decimal(first.tradePrice)
+    : money.abs().dividedBy(qtyAbs.mul(multiplier));
+
+  return {
+    ...first,
+    tradeID: "",
+    quantity: qty.toString(),
+    tradePrice: vwap.toString(),
+    tradeMoney: money.toString(),
+    proceeds: proceeds.toString(),
+    cost: cost.toString(),
+    commission: commission.toString(),
+    taxes: taxes.toString(),
+    fifoPnlRealized: fifoPnl.toString(),
+    exchange,
+    notes: notes.size > 0 ? Array.from(notes).join(";") : undefined,
   };
 }
 
@@ -189,6 +327,33 @@ function mapTrade(raw: Record<string, string>): Trade {
 const LEVEL_OF_DETAIL_SUMMARY = "SUMMARY";
 /** Placeholder accountId IBKR writes on summary rows that omit the official attribute. */
 const SUMMARY_ACCOUNT_PLACEHOLDER = "-";
+/** IBKR's aggregated marker for the Trades section; emitted when the Flex Query
+ *  selects the "Orders" level of detail alongside "Executions". */
+const LEVEL_OF_DETAIL_ORDER = "ORDER";
+/** IBKR's per-fill marker for the Trades section; the default level of detail. */
+const LEVEL_OF_DETAIL_EXECUTION = "EXECUTION";
+
+/**
+ * Drop ORDER-level Trade rows when EXECUTION-level rows are also present in the
+ * same FlexStatement. IBKR Flex Query allows multiple `levelOfDetail` selections
+ * on the Trades section: enabling both "Executions" (per-fill) and "Orders"
+ * (aggregated) emits the same activity twice — once per fill, once aggregated.
+ * Since {@link mergeExecutionsByOrder} groups by `ibOrderID|tradeDate`, leaving
+ * the ORDER row in would double-count quantity, money and commission.
+ *
+ * Symmetric to {@link isCashSummaryRow} for the CashTransactions section, but
+ * kept separate because the markers differ (SUMMARY vs ORDER), cash carries a
+ * `transactionID/accountId` fallback signal that does not apply to trades, and
+ * trades only drop ORDER when EXECUTION is also present (an ORDER-only export
+ * remains valid input).
+ */
+function filterDuplicateLevelOfDetail(rawTrades: Record<string, string>[]): Record<string, string>[] {
+  const hasExecution = rawTrades.some(
+    (t) => (t.levelOfDetail ?? "").toUpperCase() === LEVEL_OF_DETAIL_EXECUTION,
+  );
+  if (!hasExecution) return rawTrades;
+  return rawTrades.filter((t) => (t.levelOfDetail ?? "").toUpperCase() !== LEVEL_OF_DETAIL_ORDER);
+}
 
 /**
  * Detect a duplicate "Summary" cash-transaction row produced when the user

--- a/src/parsers/ibkr.ts
+++ b/src/parsers/ibkr.ts
@@ -231,6 +231,11 @@ function mapTrade(raw: Record<string, string>): Trade {
  * (the key includes `tradeDate`), so a year-boundary GTC fill lands in the
  * correct tax year.
  *
+ * Heterogeneous `buySell` (a BUY-then-SELL flip in one ibOrderID) or mixed
+ * `openCloseIndicator` (Open + Close fills under one id) also stay split:
+ * VWAP across opposite sides is meaningless, and `openCloseIndicator` is
+ * tax-relevant — `fifo.ts` branches on it for cost basis vs proceeds.
+ *
  * Trades with no `ibOrderID` pass through un-merged (rare; only carry-forward
  * edge cases — real IBKR data always populates the field).
  */
@@ -242,7 +247,7 @@ function mergeExecutionsByOrder(
 
   for (const trade of trades) {
     const key = trade.ibOrderID
-      ? `${trade.ibOrderID}|${trade.tradeDate}`
+      ? `${trade.ibOrderID}|${trade.tradeDate}|${trade.buySell}|${trade.openCloseIndicator}`
       : `__ungrouped_${ungroupedCounter++}__`;
     let bucket = groups.get(key);
     if (!bucket) {
@@ -307,9 +312,17 @@ function mergeTradeGroup(group: Trade[]): Trade {
     ? new Decimal(first.tradePrice)
     : money.abs().dividedBy(qtyAbs.mul(multiplier));
 
+  // Stable synthetic tradeID covering the full bucket key
+  // (ibOrderID, tradeDate, buySell, openCloseIndicator). Must mirror
+  // the bucket dimensions in mergeExecutionsByOrder — otherwise two
+  // distinct merged orders would alias to the same ID, re-triggering
+  // the validator's composite-key dedup misflag and breaking the
+  // merge.ts sort tiebreaker.
+  const syntheticTradeId = `merged-${first.ibOrderID}-${first.tradeDate}-${first.buySell}-${first.openCloseIndicator}`;
+
   return {
     ...first,
-    tradeID: "",
+    tradeID: syntheticTradeId,
     quantity: qty.toString(),
     tradePrice: vwap.toString(),
     tradeMoney: money.toString(),
@@ -335,18 +348,23 @@ const LEVEL_OF_DETAIL_EXECUTION = "EXECUTION";
 
 /**
  * Drop ORDER-level Trade rows when an EXECUTION-level counterpart exists for
- * the same `ibOrderID`. IBKR Flex Query allows multiple `levelOfDetail`
- * selections on the Trades section: enabling both "Executions" (per-fill) and
- * "Orders" (aggregated) emits the same activity twice — once per fill, once
- * aggregated. Since {@link mergeExecutionsByOrder} groups by
- * `ibOrderID|tradeDate`, leaving the ORDER row in would double-count quantity,
- * money and commission.
+ * the same `ibOrderID` AND `tradeDate`. IBKR Flex Query allows multiple
+ * `levelOfDetail` selections on the Trades section: enabling both "Executions"
+ * (per-fill) and "Orders" (aggregated) emits the same activity twice — once
+ * per fill, once aggregated. Since {@link mergeExecutionsByOrder} groups by
+ * `ibOrderID|tradeDate|...`, leaving the ORDER row in would double-count
+ * quantity, money and commission.
  *
- * The match is per `ibOrderID` rather than a global flag so a hybrid statement
- * (some orders with both LODs, others with only ORDER — e.g. BookTrade /
- * internal-transfer rows that may bypass execution detail) keeps the
- * ORDER-only rows. ORDER rows with no `ibOrderID` are always kept; they cannot
- * be a duplicate of a keyed EXECUTION row.
+ * The match is per `(ibOrderID, tradeDate)` rather than a global flag, or per
+ * `ibOrderID` alone, so that:
+ *  - hybrid statements (some orders with both LODs, others with only ORDER —
+ *    e.g. BookTrade / internal-transfer rows that may bypass execution detail)
+ *    keep their ORDER-only rows, and
+ *  - a GTC order whose `ibOrderID` carries across days never silently drops an
+ *    ORDER row for a date that has no matching EXECUTION row.
+ *
+ * ORDER rows with no `ibOrderID` are always kept; they cannot be a duplicate
+ * of a keyed EXECUTION row.
  *
  * Symmetric to {@link isCashSummaryRow} for the CashTransactions section, but
  * kept separate because the markers differ (SUMMARY vs ORDER), cash carries a
@@ -355,19 +373,19 @@ const LEVEL_OF_DETAIL_EXECUTION = "EXECUTION";
  * ORDER-only export remains valid input).
  */
 function filterDuplicateLevelOfDetail(rawTrades: Record<string, string>[]): Record<string, string>[] {
-  const executionOrderIds = new Set<string>();
+  const executionKeys = new Set<string>();
   for (const t of rawTrades) {
     if ((t.levelOfDetail ?? "").toUpperCase() === LEVEL_OF_DETAIL_EXECUTION && t.ibOrderID) {
-      executionOrderIds.add(t.ibOrderID);
+      executionKeys.add(`${t.ibOrderID}|${t.tradeDate ?? ""}`);
     }
   }
-  if (executionOrderIds.size === 0) return rawTrades;
+  if (executionKeys.size === 0) return rawTrades;
   return rawTrades.filter(
     (t) =>
       !(
         (t.levelOfDetail ?? "").toUpperCase() === LEVEL_OF_DETAIL_ORDER &&
         t.ibOrderID &&
-        executionOrderIds.has(t.ibOrderID)
+        executionKeys.has(`${t.ibOrderID}|${t.tradeDate ?? ""}`)
       ),
   );
 }

--- a/src/types/ibkr.ts
+++ b/src/types/ibkr.ts
@@ -88,6 +88,8 @@ export interface Trade {
   underlyingSymbol?: string;
   /** Underlying ISIN for derivatives */
   underlyingIsin?: string;
+  /** IBKR order ID — same value across partial-fill executions of one order. Used by the parser to collapse executions into one trade. */
+  ibOrderID?: string;
 }
 
 export interface CashTransaction {

--- a/tests/parsers/ibkr.test.ts
+++ b/tests/parsers/ibkr.test.ts
@@ -956,4 +956,53 @@ describe("IBKR ORDER-level duplicate filtering", () => {
     expect(result.parserMessages?.find((m) => m.id === "parser.order_level_duplicates")).toBeUndefined();
     expect(result.parserMessages?.find((m) => m.id === "parser.executions_merged")).toBeUndefined();
   });
+
+  it("keeps ORDER rows without an EXECUTION counterpart in a mixed export", () => {
+    // Hybrid statement: ORD-X has 2 EXECUTION fills + matching ORDER aggregate
+    // (drop ORDER, merge EXECUTIONs). ORD-Y is a standalone ORDER row with no
+    // EXECUTION counterpart and must be preserved — a per-ibOrderID match
+    // prevents collateral data loss when both LODs are mixed in one statement.
+    const xml = wrap(`
+      <Trade tradeID="E1" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="100" tradePrice="10.00" tradeMoney="1000" proceeds="-1000" cost="1000"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.20" taxes="0"
+             multiplier="1" ibOrderID="ORD-X" levelOfDetail="EXECUTION" />
+      <Trade tradeID="E2" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="100" tradePrice="10.00" tradeMoney="1000" proceeds="-1000" cost="1000"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.20" taxes="0"
+             multiplier="1" ibOrderID="ORD-X" levelOfDetail="EXECUTION" />
+      <Trade tradeID="O1" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="200" tradePrice="10.00" tradeMoney="2000" proceeds="-2000" cost="2000"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.40" taxes="0"
+             multiplier="1" ibOrderID="ORD-X" levelOfDetail="ORDER" />
+      <Trade tradeID="O2" accountId="U9999999" symbol="BETA" description="BETA" isin="US2222222222"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="50" tradePrice="20.00" tradeMoney="1000" proceeds="-1000" cost="1000"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.10" taxes="0"
+             multiplier="1" ibOrderID="ORD-Y" levelOfDetail="ORDER" />
+    `);
+    const result = parseIbkrFlexXml(xml);
+    expect(result.trades).toHaveLength(2);
+    const ordX = result.trades.find((t) => t.ibOrderID === "ORD-X");
+    expect(ordX?.quantity).toBe("200");
+    expect(ordX?.tradeMoney).toBe("2000");
+    const ordY = result.trades.find((t) => t.ibOrderID === "ORD-Y");
+    expect(ordY).toBeDefined();
+    expect(ordY?.quantity).toBe("50");
+    expect(ordY?.tradeMoney).toBe("1000");
+    expect(result.parserMessages?.find((m) => m.id === "parser.order_level_duplicates")?.context).toEqual({
+      skipped: "1",
+    });
+    expect(result.parserMessages?.find((m) => m.id === "parser.executions_merged")?.context).toEqual({
+      sourceFillCount: "2",
+      mergedGroupCount: "1",
+    });
+  });
 });

--- a/tests/parsers/ibkr.test.ts
+++ b/tests/parsers/ibkr.test.ts
@@ -729,3 +729,231 @@ describe("IBKR Summary-option duplicate cash transactions", () => {
     expect(result.parserMessages?.find((m) => m.id === "parser.cash_summary_duplicates")?.context?.skipped).toBe("2");
   });
 });
+
+describe("IBKR partial-fill execution merging", () => {
+  function wrap(tradesXml: string): string {
+    return `<?xml version="1.0"?>
+    <FlexQueryResponse queryName="Merge" type="AF">
+      <FlexStatements count="1">
+        <FlexStatement accountId="U9999999" fromDate="20250101" toDate="20251231" period="LastYear">
+          <Trades>${tradesXml}</Trades>
+          <CorporateActions /><OpenPositions /><SecuritiesInfo />
+        </FlexStatement>
+      </FlexStatements>
+    </FlexQueryResponse>`;
+  }
+
+  it("collapses three same-day executions of one ibOrderID into one trade with VWAP price", () => {
+    // Three BUY fills: 100@10.00, 200@10.50, 100@11.00 → 400 shares, VWAP = 10.50
+    // tradeMoney = 1000 + 2100 + 1100 = 4200; 4200 / 400 = 10.50
+    const xml = wrap(`
+      <Trade tradeID="A1" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="100" tradePrice="10.00" tradeMoney="1000" proceeds="-1000" cost="1000.50"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.20" taxes="0"
+             multiplier="1" ibOrderID="ORDER-1" />
+      <Trade tradeID="A2" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="200" tradePrice="10.50" tradeMoney="2100" proceeds="-2100" cost="2100.30"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.30" taxes="0"
+             multiplier="1" ibOrderID="ORDER-1" />
+      <Trade tradeID="A3" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="100" tradePrice="11.00" tradeMoney="1100" proceeds="-1100" cost="1100.10"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.10" taxes="0"
+             multiplier="1" ibOrderID="ORDER-1" />
+    `);
+    const result = parseIbkrFlexXml(xml);
+    expect(result.trades).toHaveLength(1);
+    const t = result.trades[0]!;
+    expect(t.quantity).toBe("400");
+    expect(Number(t.tradePrice)).toBeCloseTo(10.5, 8);
+    expect(t.tradeMoney).toBe("4200");
+    expect(t.proceeds).toBe("-4200");
+    expect(Number(t.commission)).toBeCloseTo(-0.6, 8);
+    expect(t.tradeID).toBe("");
+    expect(t.ibOrderID).toBe("ORDER-1");
+    expect(result.parserMessages?.find((m) => m.id === "parser.executions_merged")?.context).toEqual({
+      sourceFillCount: "3",
+      mergedGroupCount: "1",
+    });
+  });
+
+  it("splits same ibOrderID across different tradeDate values (GTC overnight)", () => {
+    const xml = wrap(`
+      <Trade tradeID="A1" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20251231" settlementDate="20260102"
+             quantity="50" tradePrice="20.00" tradeMoney="1000" proceeds="-1000" cost="1000"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.50" taxes="0"
+             multiplier="1" ibOrderID="GTC-1" />
+      <Trade tradeID="A2" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20260102" settlementDate="20260106"
+             quantity="50" tradePrice="20.10" tradeMoney="1005" proceeds="-1005" cost="1005"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.50" taxes="0"
+             multiplier="1" ibOrderID="GTC-1" />
+    `);
+    const result = parseIbkrFlexXml(xml);
+    expect(result.trades).toHaveLength(2);
+    expect(result.trades.map((t) => t.tradeDate).sort()).toEqual(["20251231", "20260102"]);
+    expect(result.parserMessages?.find((m) => m.id === "parser.executions_merged")).toBeUndefined();
+  });
+
+  it("mixes single-fill and multi-fill orders, leaves single fills untouched", () => {
+    const xml = wrap(`
+      <Trade tradeID="S1" accountId="U9999999" symbol="ALPHA" description="ALPHA" isin="US1111111111"
+             assetCategory="STK" currency="USD" tradeDate="20250410" settlementDate="20250412"
+             quantity="10" tradePrice="100" tradeMoney="1000" proceeds="-1000" cost="1000"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.10" taxes="0"
+             multiplier="1" ibOrderID="ALONE" />
+      <Trade tradeID="M1" accountId="U9999999" symbol="BETA" description="BETA" isin="US2222222222"
+             assetCategory="STK" currency="USD" tradeDate="20250411" settlementDate="20250413"
+             quantity="3" tradePrice="50" tradeMoney="150" proceeds="-150" cost="150"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.05" taxes="0"
+             multiplier="1" ibOrderID="MULTI" />
+      <Trade tradeID="M2" accountId="U9999999" symbol="BETA" description="BETA" isin="US2222222222"
+             assetCategory="STK" currency="USD" tradeDate="20250411" settlementDate="20250413"
+             quantity="7" tradePrice="51" tradeMoney="357" proceeds="-357" cost="357"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.05" taxes="0"
+             multiplier="1" ibOrderID="MULTI" />
+    `);
+    const result = parseIbkrFlexXml(xml);
+    expect(result.trades).toHaveLength(2);
+    const alpha = result.trades.find((t) => t.symbol === "ALPHA")!;
+    const beta = result.trades.find((t) => t.symbol === "BETA")!;
+    expect(alpha.tradeID).toBe("S1"); // unchanged
+    expect(alpha.quantity).toBe("10");
+    expect(beta.tradeID).toBe(""); // merged
+    expect(beta.quantity).toBe("10");
+    expect(beta.tradeMoney).toBe("507"); // 150 + 357
+    expect(Number(beta.tradePrice)).toBeCloseTo(50.7, 8); // VWAP
+    expect(result.parserMessages?.find((m) => m.id === "parser.executions_merged")?.context).toEqual({
+      sourceFillCount: "2",
+      mergedGroupCount: "1",
+    });
+  });
+
+  it("passes through trades with empty ibOrderID without merging", () => {
+    const xml = wrap(`
+      <Trade tradeID="E1" accountId="U9999999" symbol="GAMMA" description="GAMMA" isin="US3333333333"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="5" tradePrice="40" tradeMoney="200" proceeds="-200" cost="200"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.05" taxes="0"
+             multiplier="1" ibOrderID="" />
+      <Trade tradeID="E2" accountId="U9999999" symbol="GAMMA" description="GAMMA" isin="US3333333333"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="5" tradePrice="40" tradeMoney="200" proceeds="-200" cost="200"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.05" taxes="0"
+             multiplier="1" ibOrderID="" />
+    `);
+    const result = parseIbkrFlexXml(xml);
+    expect(result.trades).toHaveLength(2);
+    expect(result.trades.every((t) => !t.ibOrderID)).toBe(true);
+    expect(result.parserMessages?.find((m) => m.id === "parser.executions_merged")).toBeUndefined();
+  });
+
+  it("preserves option-exercise note markers (Ep/Ex) when merging", () => {
+    const xml = wrap(`
+      <Trade tradeID="O1" accountId="U9999999" symbol="OPT1" description="OPT1" isin=""
+             assetCategory="OPT" currency="USD" tradeDate="20250619" settlementDate="20250620"
+             quantity="-1" tradePrice="0.01" tradeMoney="-1" proceeds="1" cost="-1"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="SELL" openCloseIndicator="C"
+             exchange="CBOE" ibCommissionCurrency="USD" ibCommission="-0.50" taxes="0"
+             multiplier="100" notes="Ep" ibOrderID="OPT-EX" />
+      <Trade tradeID="O2" accountId="U9999999" symbol="OPT1" description="OPT1" isin=""
+             assetCategory="OPT" currency="USD" tradeDate="20250619" settlementDate="20250620"
+             quantity="-1" tradePrice="0.01" tradeMoney="-1" proceeds="1" cost="-1"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="SELL" openCloseIndicator="C"
+             exchange="CBOE" ibCommissionCurrency="USD" ibCommission="-0.50" taxes="0"
+             multiplier="100" notes="Ep" ibOrderID="OPT-EX" />
+    `);
+    const result = parseIbkrFlexXml(xml);
+    expect(result.trades).toHaveLength(1);
+    expect(result.trades[0]!.notes).toBe("Ep");
+    expect(result.trades[0]!.quantity).toBe("-2");
+  });
+});
+
+describe("IBKR ORDER-level duplicate filtering", () => {
+  function wrap(tradesXml: string): string {
+    return `<?xml version="1.0"?>
+    <FlexQueryResponse queryName="LOD" type="AF">
+      <FlexStatements count="1">
+        <FlexStatement accountId="U9999999" fromDate="20250101" toDate="20251231" period="LastYear">
+          <Trades>${tradesXml}</Trades>
+          <CorporateActions /><OpenPositions /><SecuritiesInfo />
+        </FlexStatement>
+      </FlexStatements>
+    </FlexQueryResponse>`;
+  }
+
+  it("drops ORDER-level rows when EXECUTION rows for the same ibOrderID are present", () => {
+    // Two EXECUTION fills (100 + 100 = 200) plus one ORDER aggregate (200) for the
+    // same ibOrderID. Without filtering, mergeExecutionsByOrder would sum all three
+    // and emit quantity=400, doubling the real position.
+    const xml = wrap(`
+      <Trade tradeID="E1" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="100" tradePrice="10.00" tradeMoney="1000" proceeds="-1000" cost="1000"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.20" taxes="0"
+             multiplier="1" ibOrderID="ORD-X" levelOfDetail="EXECUTION" />
+      <Trade tradeID="E2" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="100" tradePrice="10.00" tradeMoney="1000" proceeds="-1000" cost="1000"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.20" taxes="0"
+             multiplier="1" ibOrderID="ORD-X" levelOfDetail="EXECUTION" />
+      <Trade tradeID="O1" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="200" tradePrice="10.00" tradeMoney="2000" proceeds="-2000" cost="2000"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.40" taxes="0"
+             multiplier="1" ibOrderID="ORD-X" levelOfDetail="ORDER" />
+    `);
+    const result = parseIbkrFlexXml(xml);
+    expect(result.trades).toHaveLength(1);
+    expect(result.trades[0]!.quantity).toBe("200");
+    expect(result.trades[0]!.tradeMoney).toBe("2000");
+    expect(result.parserMessages?.find((m) => m.id === "parser.order_level_duplicates")?.context).toEqual({
+      skipped: "1",
+    });
+    expect(result.parserMessages?.find((m) => m.id === "parser.executions_merged")?.context).toEqual({
+      sourceFillCount: "2",
+      mergedGroupCount: "1",
+    });
+  });
+
+  it("keeps ORDER-level rows when no EXECUTION rows are present (ORDER-only export)", () => {
+    // Two ORDER rows with distinct ibOrderIDs and no EXECUTION counterparts. The
+    // export is already aggregated at order level — the filter must be a no-op
+    // and mergeExecutionsByOrder leaves them as singletons.
+    const xml = wrap(`
+      <Trade tradeID="O1" accountId="U9999999" symbol="ALPHA" description="ALPHA" isin="US1111111111"
+             assetCategory="STK" currency="USD" tradeDate="20250410" settlementDate="20250412"
+             quantity="10" tradePrice="100" tradeMoney="1000" proceeds="-1000" cost="1000"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.10" taxes="0"
+             multiplier="1" ibOrderID="ORD-A" levelOfDetail="ORDER" />
+      <Trade tradeID="O2" accountId="U9999999" symbol="BETA" description="BETA" isin="US2222222222"
+             assetCategory="STK" currency="USD" tradeDate="20250411" settlementDate="20250413"
+             quantity="5" tradePrice="50" tradeMoney="250" proceeds="-250" cost="250"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.05" taxes="0"
+             multiplier="1" ibOrderID="ORD-B" levelOfDetail="ORDER" />
+    `);
+    const result = parseIbkrFlexXml(xml);
+    expect(result.trades).toHaveLength(2);
+    expect(result.parserMessages?.find((m) => m.id === "parser.order_level_duplicates")).toBeUndefined();
+    expect(result.parserMessages?.find((m) => m.id === "parser.executions_merged")).toBeUndefined();
+  });
+});

--- a/tests/parsers/ibkr.test.ts
+++ b/tests/parsers/ibkr.test.ts
@@ -774,7 +774,7 @@ describe("IBKR partial-fill execution merging", () => {
     expect(t.tradeMoney).toBe("4200");
     expect(t.proceeds).toBe("-4200");
     expect(Number(t.commission)).toBeCloseTo(-0.6, 8);
-    expect(t.tradeID).toBe("");
+    expect(t.tradeID).toBe("merged-ORDER-1-20250515-BUY-O");
     expect(t.ibOrderID).toBe("ORDER-1");
     expect(result.parserMessages?.find((m) => m.id === "parser.executions_merged")?.context).toEqual({
       sourceFillCount: "3",
@@ -830,7 +830,7 @@ describe("IBKR partial-fill execution merging", () => {
     const beta = result.trades.find((t) => t.symbol === "BETA")!;
     expect(alpha.tradeID).toBe("S1"); // unchanged
     expect(alpha.quantity).toBe("10");
-    expect(beta.tradeID).toBe(""); // merged
+    expect(beta.tradeID).toBe("merged-MULTI-20250411-BUY-O"); // merged
     expect(beta.quantity).toBe("10");
     expect(beta.tradeMoney).toBe("507"); // 150 + 357
     expect(Number(beta.tradePrice)).toBeCloseTo(50.7, 8); // VWAP
@@ -1003,6 +1003,221 @@ describe("IBKR ORDER-level duplicate filtering", () => {
     expect(result.parserMessages?.find((m) => m.id === "parser.executions_merged")?.context).toEqual({
       sourceFillCount: "2",
       mergedGroupCount: "1",
+    });
+  });
+});
+
+describe("IBKR heterogeneous-order safeguards", () => {
+  function wrap(tradesXml: string): string {
+    return `<?xml version="1.0"?>
+    <FlexQueryResponse queryName="Heter" type="AF">
+      <FlexStatements count="1">
+        <FlexStatement accountId="U9999999" fromDate="20250101" toDate="20251231" period="LastYear">
+          <Trades>${tradesXml}</Trades>
+          <CorporateActions /><OpenPositions /><SecuritiesInfo />
+        </FlexStatement>
+      </FlexStatements>
+    </FlexQueryResponse>`;
+  }
+
+  it("keeps BUY and SELL fills of the same ibOrderID split (no VWAP across opposite sides)", () => {
+    // Pathological but legal: one ibOrderID with a BUY fill and a SELL fill on
+    // the same day. VWAP across opposite sides would be meaningless; both fills
+    // must land in the report as separate trades.
+    const xml = wrap(`
+      <Trade tradeID="B1" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="100" tradePrice="10.00" tradeMoney="1000" proceeds="-1000" cost="1000"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.20" taxes="0"
+             multiplier="1" ibOrderID="FLIP-1" />
+      <Trade tradeID="S1" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="-40" tradePrice="10.50" tradeMoney="-420" proceeds="420" cost="-420"
+             fifoPnlRealized="20" fxRateToBase="0.92" buySell="SELL" openCloseIndicator="C"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.10" taxes="0"
+             multiplier="1" ibOrderID="FLIP-1" />
+    `);
+    const result = parseIbkrFlexXml(xml);
+    expect(result.trades).toHaveLength(2);
+    const buy = result.trades.find((t) => t.buySell === "BUY")!;
+    const sell = result.trades.find((t) => t.buySell === "SELL")!;
+    expect(buy.quantity).toBe("100");
+    expect(buy.tradeID).toBe("B1"); // single-fill bucket, unchanged
+    expect(sell.quantity).toBe("-40");
+    expect(sell.tradeID).toBe("S1");
+    expect(result.parserMessages?.find((m) => m.id === "parser.executions_merged")).toBeUndefined();
+  });
+
+  it("keeps Open and Close fills of the same ibOrderID split (O/C is tax-relevant)", () => {
+    // FIFO branches on openCloseIndicator (fifo.ts:80). A mixed O/C group must
+    // not be flattened or the cost-basis/proceeds attribution would be wrong.
+    const xml = wrap(`
+      <Trade tradeID="O1" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="50" tradePrice="10.00" tradeMoney="500" proceeds="-500" cost="500"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.10" taxes="0"
+             multiplier="1" ibOrderID="OC-1" />
+      <Trade tradeID="C1" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="50" tradePrice="10.05" tradeMoney="502.5" proceeds="-502.5" cost="502.5"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="C"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.10" taxes="0"
+             multiplier="1" ibOrderID="OC-1" />
+    `);
+    const result = parseIbkrFlexXml(xml);
+    expect(result.trades).toHaveLength(2);
+    const open = result.trades.find((t) => t.openCloseIndicator === "O")!;
+    const close = result.trades.find((t) => t.openCloseIndicator === "C")!;
+    expect(open.quantity).toBe("50");
+    expect(close.quantity).toBe("50");
+    expect(open.tradeID).toBe("O1");
+    expect(close.tradeID).toBe("C1");
+    expect(result.parserMessages?.find((m) => m.id === "parser.executions_merged")).toBeUndefined();
+  });
+
+  it("gives distinct, non-empty tradeIDs to two merged orders that match on date/symbol/qty/price/side", () => {
+    // Two different ibOrderIDs each fill in 2 partials for the same symbol, day,
+    // total quantity, VWAP and side. The validator in src/web/validation.ts
+    // falls back to a composite key when tradeID is empty — empty IDs here
+    // would alias the two merged orders into a spurious "duplicate" warning.
+    // The synthetic `merged-${ibOrderID}-${tradeDate}` id keeps them distinct.
+    const xml = wrap(`
+      <Trade tradeID="A1" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="50" tradePrice="10.00" tradeMoney="500" proceeds="-500" cost="500"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.10" taxes="0"
+             multiplier="1" ibOrderID="ORDER-A" />
+      <Trade tradeID="A2" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="50" tradePrice="10.00" tradeMoney="500" proceeds="-500" cost="500"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.10" taxes="0"
+             multiplier="1" ibOrderID="ORDER-A" />
+      <Trade tradeID="B1" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="50" tradePrice="10.00" tradeMoney="500" proceeds="-500" cost="500"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.10" taxes="0"
+             multiplier="1" ibOrderID="ORDER-B" />
+      <Trade tradeID="B2" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="50" tradePrice="10.00" tradeMoney="500" proceeds="-500" cost="500"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.10" taxes="0"
+             multiplier="1" ibOrderID="ORDER-B" />
+    `);
+    const result = parseIbkrFlexXml(xml);
+    expect(result.trades).toHaveLength(2);
+    const ordA = result.trades.find((t) => t.ibOrderID === "ORDER-A")!;
+    const ordB = result.trades.find((t) => t.ibOrderID === "ORDER-B")!;
+    expect(ordA.tradeID).toBe("merged-ORDER-A-20250515-BUY-O");
+    expect(ordB.tradeID).toBe("merged-ORDER-B-20250515-BUY-O");
+    expect(ordA.tradeID).not.toBe(ordB.tradeID);
+    expect(ordA.tradeID).not.toBe("");
+    expect(ordB.tradeID).not.toBe("");
+    // Same (symbol, isin, tradeDate, quantity, tradePrice, buySell) — the
+    // composite-key fallback would collide; the synthetic tradeID prevents it.
+    expect(ordA.quantity).toBe(ordB.quantity);
+    expect(ordA.tradePrice).toBe(ordB.tradePrice);
+    expect(ordA.tradeDate).toBe(ordB.tradeDate);
+  });
+
+  it("keeps ORDER row on a date where no EXECUTION counterpart exists for the same ibOrderID", () => {
+    // GTC id-reuse / cross-date safety: ORDER row on date B must survive when
+    // EXECUTION rows only exist on date A for the same ibOrderID. Per-ibOrderID
+    // matching would silently drop the date-B ORDER row.
+    const xml = wrap(`
+      <Trade tradeID="E1" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="50" tradePrice="10.00" tradeMoney="500" proceeds="-500" cost="500"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.10" taxes="0"
+             multiplier="1" ibOrderID="REUSE-1" levelOfDetail="EXECUTION" />
+      <Trade tradeID="E2" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="50" tradePrice="10.00" tradeMoney="500" proceeds="-500" cost="500"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.10" taxes="0"
+             multiplier="1" ibOrderID="REUSE-1" levelOfDetail="EXECUTION" />
+      <Trade tradeID="O-A" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="100" tradePrice="10.00" tradeMoney="1000" proceeds="-1000" cost="1000"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.20" taxes="0"
+             multiplier="1" ibOrderID="REUSE-1" levelOfDetail="ORDER" />
+      <Trade tradeID="O-B" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20250516" settlementDate="20250520"
+             quantity="30" tradePrice="11.00" tradeMoney="330" proceeds="-330" cost="330"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.05" taxes="0"
+             multiplier="1" ibOrderID="REUSE-1" levelOfDetail="ORDER" />
+    `);
+    const result = parseIbkrFlexXml(xml);
+    // Expect 2 trades: merged executions on day A, standalone ORDER on day B.
+    expect(result.trades).toHaveLength(2);
+    const dayA = result.trades.find((t) => t.tradeDate === "20250515")!;
+    const dayB = result.trades.find((t) => t.tradeDate === "20250516")!;
+    expect(dayA.quantity).toBe("100"); // 50 + 50 merged executions
+    expect(dayA.tradeID).toBe("merged-REUSE-1-20250515-BUY-O");
+    expect(dayB.quantity).toBe("30"); // ORDER row preserved
+    expect(dayB.tradeID).toBe("O-B");
+    expect(result.parserMessages?.find((m) => m.id === "parser.order_level_duplicates")?.context).toEqual({
+      skipped: "1", // only the day-A ORDER row is a duplicate
+    });
+  });
+
+  it("gives distinct synthetic tradeIDs to Open and Close multi-fill buckets under one ibOrderID (position flip)", () => {
+    // Position-flip case: one ibOrderID covers both closing a short and opening
+    // a new long (or vice versa) — same buySell, different openCloseIndicator.
+    // Each side multi-fills. The bucket key splits on openCloseIndicator, so we
+    // get two merged trades for the same (ibOrderID, tradeDate). The synthetic
+    // tradeID MUST also split on openCloseIndicator (and buySell) — otherwise
+    // both merged trades would alias to the same `merged-${ibOrderID}-${date}`
+    // ID, re-triggering the validation.ts:80 dedup misflag and breaking the
+    // merge.ts sort tiebreaker — i.e. the exact bug the synthetic ID prevents.
+    const xml = wrap(`
+      <Trade tradeID="O1" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="50" tradePrice="10.00" tradeMoney="500" proceeds="-500" cost="500"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.10" taxes="0"
+             multiplier="1" ibOrderID="OC-MULTI" />
+      <Trade tradeID="O2" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="50" tradePrice="10.00" tradeMoney="500" proceeds="-500" cost="500"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="O"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.10" taxes="0"
+             multiplier="1" ibOrderID="OC-MULTI" />
+      <Trade tradeID="C1" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="30" tradePrice="10.00" tradeMoney="300" proceeds="-300" cost="300"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="C"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.05" taxes="0"
+             multiplier="1" ibOrderID="OC-MULTI" />
+      <Trade tradeID="C2" accountId="U9999999" symbol="ACME" description="ACME" isin="US0000000001"
+             assetCategory="STK" currency="USD" tradeDate="20250515" settlementDate="20250517"
+             quantity="20" tradePrice="10.00" tradeMoney="200" proceeds="-200" cost="200"
+             fifoPnlRealized="0" fxRateToBase="0.92" buySell="BUY" openCloseIndicator="C"
+             exchange="NASDAQ" ibCommissionCurrency="USD" ibCommission="-0.05" taxes="0"
+             multiplier="1" ibOrderID="OC-MULTI" />
+    `);
+    const result = parseIbkrFlexXml(xml);
+    expect(result.trades).toHaveLength(2);
+    const open = result.trades.find((t) => t.openCloseIndicator === "O")!;
+    const close = result.trades.find((t) => t.openCloseIndicator === "C")!;
+    expect(open.quantity).toBe("100"); // 50 + 50 merged
+    expect(close.quantity).toBe("50"); // 30 + 20 merged
+    expect(open.tradeID).toBe("merged-OC-MULTI-20250515-BUY-O");
+    expect(close.tradeID).toBe("merged-OC-MULTI-20250515-BUY-C");
+    expect(open.tradeID).not.toBe(close.tradeID);
+    expect(open.tradeID).not.toBe("");
+    expect(close.tradeID).not.toBe("");
+    expect(result.parserMessages?.find((m) => m.id === "parser.executions_merged")?.context).toEqual({
+      sourceFillCount: "4",
+      mergedGroupCount: "2",
     });
   });
 });


### PR DESCRIPTION
## Summary

IBKR Flex Query emits one `<Trade levelOfDetail="EXECUTION">` per fill, so an order that fills in 3 partial executions yields 3 separate Trade rows in our parser. Brokers that report fiscally to Hacienda (and competitors like Autodeclaro / Taxdown) aggregate at the **order level**, so the operations annex was showing many more lines than the user sees on their own broker statement — confusing to reconcile, harder to audit.

This collapses same-order EXECUTION rows by `ibOrderID` + `tradeDate` into a single synthetic Trade. **Tax math is unchanged**: the FIFO engine consumes the exact same totals because the merge preserves the identity

```
tradeMoney = quantity × tradePrice × multiplier
```

— summed quantities and money divide back to the volume-weighted average price.

### What changed

**Parser (`src/parsers/ibkr.ts`)**

- `mergeExecutionsByOrder()` groups EXECUTION rows by `ibOrderID|tradeDate` and aggregates quantity, tradeMoney, proceeds, cost, commission, taxes and `fifoPnlRealized` via `Decimal`. `tradePrice` becomes the VWAP. `notes` are split-trimmed-deduplicated into a `Set` so per-fill markers like `Ep` / `P` survive.
- **GTC year-boundary safe**: the group key includes `tradeDate`, so a GTC order that fills on Dec 31 and Jan 2 splits into two rows landing in the correct tax year (Art. 14 LIRPF).
- Trades with empty `ibOrderID` pass through un-merged. The IBKR Flex schema marks `ibOrderID` as optional (csingley/ibflex `Types.py`: `ibOrderID: str | None = None`), and BookTrade / internal-transfer rows can legitimately omit it.
- New `parserMessages` info entry `parser.executions_merged` surfaces the count so the user knows what happened.

**ORDER-level duplicate guard**

Symmetric to the cash-transactions guard added in #194 (`isCashSummaryRow`): IBKR Flex Query allows multiple `levelOfDetail` selections on the Trades section. If a user enables both **Executions** (per-fill) and **Orders** (aggregated), each activity is emitted twice and the merge above would silently **double-count** quantity, money and commission because both row types share the same `ibOrderID`.

`filterDuplicateLevelOfDetail()` drops ORDER-level rows whenever EXECUTION rows are also present in the same FlexStatement. Pure ORDER-only exports remain valid input (the filter is a no-op). New `parserMessages` info entry `parser.order_level_duplicates` reports the count.

**Types (`src/types/ibkr.ts`)**

- New optional `Trade.ibOrderID` field (string). Backwards compatible.

### Legal basis

- **Art. 37.2 LIRPF** — FIFO over homogeneous securities. Merging at order level does not change which lots are consumed; the per-lot disposals fall out identically.
- **Art. 14 LIRPF** — devengo by trade date. The `tradeDate` component of the group key preserves per-day granularity required for year-boundary GTC orders.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — **1277 passed** (+7 new: 3-fill VWAP, GTC split, mixed single/multi-fill, empty `ibOrderID` passthrough, OPT `Ep` note preservation, ORDER+EXECUTION drop, ORDER-only no-op)
- [x] Sanity: re-running a real EXECUTION-only Flex Query (40 trade rows, 6 multi-fill orders) produces unchanged capital gains and the expected 6-orders collapse, with the `parser.executions_merged` info message reporting `12 ejecuciones parciales en 6 órdenes`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consolidate IBKR partial-fill executions sharing the same order ID and trade date into a single trade with VWAP-style pricing (with fallback), summed amounts, de-duplicated notes, and the order ID included in mapped output.

* **Bug Fixes**
  * Omit duplicate ORDER-level rows when corresponding EXECUTION-level rows exist.

* **Tests**
  * Added thorough tests for merging, duplicate filtering, VWAP/fallback behavior, and multiple edge cases; parser emits informational counts for merges and duplicates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->