### PR TITLE
fix(dividends): drop foreign-withholding column from Casilla 0029 card (closes #202)

### DIFF
--- a/src/i18n/locales/ca.ts
+++ b/src/i18n/locales/ca.ts
@@ -61,6 +61,7 @@ const ca: TranslationKeys = {
   "table.payments": "Pagaments",
   "casilla.dividends_by_issuer": "Dividends per emissor",
   "casilla.dividends_per_payment": "Pagaments individuals",
+  "casilla.dividends_withholding_note": "La retenció estrangera no es declara aquí. En el formulari «Alta Capital mobiliario» de Renta Web, deixa el camp «Retencions» a 0 — la retenció estrangera es dedueix per separat a la casella 0588 (deducció per doble imposició internacional, Art. 80 LIRPF).",
   "table.casilla": "Casella",
   "table.concept": "Concepte",
   "table.amount_eur": "Import (EUR)",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -60,6 +60,7 @@ const en: TranslationKeys = {
   "table.payments": "Payments",
   "casilla.dividends_by_issuer": "Dividends by issuer",
   "casilla.dividends_per_payment": "Individual payments",
+  "casilla.dividends_withholding_note": "Foreign withholding tax is not declared here. In the AEAT Renta Web \"Alta Capital mobiliario\" form, leave the \"Retenciones\" field at 0 — foreign withholding is deducted separately in box 0588 (deduction for international double taxation, Art. 80 LIRPF).",
   "table.casilla": "Box",
   "table.concept": "Concept",
   "table.amount_eur": "Amount (EUR)",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -63,6 +63,7 @@ const es = {
   "table.payments": "Pagos",
   "casilla.dividends_by_issuer": "Dividendos por emisor",
   "casilla.dividends_per_payment": "Pagos individuales",
+  "casilla.dividends_withholding_note": "La retención extranjera no se declara aquí. En el formulario «Alta Capital mobiliario» de Renta Web, deja el campo «Retenciones» en 0 — la retención extranjera se deduce por separado en la casilla 0588 (deducción por doble imposición internacional, Art. 80 LIRPF).",
   "table.casilla": "Casilla",
   "table.concept": "Concepto",
   "table.amount_eur": "Importe (EUR)",

--- a/src/i18n/locales/eu.ts
+++ b/src/i18n/locales/eu.ts
@@ -61,6 +61,7 @@ const eu: TranslationKeys = {
   "table.payments": "Ordainketak",
   "casilla.dividends_by_issuer": "Dibidenduak jaulkitzaileka",
   "casilla.dividends_per_payment": "Banakako ordainketak",
+  "casilla.dividends_withholding_note": "Atzerriko atxikipena ez da hemen aitortzen. Renta Web-eko «Alta Capital mobiliario» formularioan, utzi «Retenciones» eremua 0 balioan — atzerriko atxikipena bereiz kentzen da 0588 gelaxkan (nazioarteko zergapetze bikoitzaren kenkaria, IRPF Legearen 80. art.).",
   "table.casilla": "Laukia",
   "table.concept": "Kontzeptua",
   "table.amount_eur": "Zenbatekoa (EUR)",

--- a/src/i18n/locales/gl.ts
+++ b/src/i18n/locales/gl.ts
@@ -61,6 +61,7 @@ const gl: TranslationKeys = {
   "table.payments": "Pagamentos",
   "casilla.dividends_by_issuer": "Dividendos por emisor",
   "casilla.dividends_per_payment": "Pagamentos individuais",
+  "casilla.dividends_withholding_note": "A retención estranxeira non se declara aquí. No formulario «Alta Capital mobiliario» de Renta Web, deixa o campo «Retencións» en 0 — a retención estranxeira dedúcese por separado na casilla 0588 (dedución por dobre imposición internacional, Art. 80 LIRPF).",
   "table.casilla": "Casilla",
   "table.concept": "Concepto",
   "table.amount_eur": "Importe (EUR)",

--- a/src/web/casilla-detail.ts
+++ b/src/web/casilla-detail.ts
@@ -80,15 +80,25 @@ function renderDisposalsDetail(
  * certificates), with the individual payments preserved in a collapsible
  * drill-down. Presentation-only: totals reconcile exactly with grossIncome.
  */
-function renderDividendsDetail(entries: DividendEntry[]): string {
+export function renderDividendsDetail(entries: DividendEntry[]): string {
   if (entries.length === 0) return `<p class="muted">${t("casilla.no_operations")}</p>`;
   const groups = groupDividendsByIssuer(entries);
+  // Foreign withholding is intentionally NOT shown here: this card feeds the
+  // Renta Web "Alta Capital mobiliario" form, whose "Retenciones" field is for
+  // Spanish IRPF retentions only (Casillas 0030/0031). Foreign withholding is
+  // recovered solely via Casilla 0588 (Art. 80 LIRPF) and is shown there. A user
+  // pasting it into "Retenciones" would double-count it against 0588. The note
+  // below redirects them; it only renders when there is foreign withholding.
+  const hasWithholding = groups.some((g) => g.withholdingTotalEur.greaterThan(0));
+  const note = hasWithholding
+    ? `<p class="muted detail-note">${esc(t("casilla.dividends_withholding_note"))}</p>`
+    : "";
   return `
     <p class="detail-label">${t("casilla.dividends_by_issuer")} (${groups.length})</p>
     <table class="detail-table">
       <thead><tr>
         <th>ISIN</th><th>${t("table.symbol")}</th><th>${t("table.country")}</th>
-        <th>${t("table.payments")}</th><th>${t("table.gross_eur")}</th><th>${t("table.withholding_eur")}</th>
+        <th>${t("table.payments")}</th><th>${t("table.gross_eur")}</th>
       </tr></thead>
       <tbody>${groups.map((g) => `
         <tr>
@@ -97,21 +107,19 @@ function renderDividendsDetail(entries: DividendEntry[]): string {
           <td>${esc(g.withholdingCountry)}</td>
           <td>${g.paymentCount}</td>
           <td>${fmtEur(g.grossTotalEur)}</td>
-          <td>${fmtEur(g.withholdingTotalEur)}</td>
         </tr>
         <tr class="detail-subrow">
-          <td colspan="6">
+          <td colspan="5">
             <details>
               <summary>${t("casilla.dividends_per_payment")} (${g.paymentCount})</summary>
               <table class="detail-table">
                 <thead><tr>
-                  <th>${t("table.date")}</th><th>${t("table.gross_eur")}</th><th>${t("table.withholding_eur")}</th>
+                  <th>${t("table.date")}</th><th>${t("table.gross_eur")}</th>
                 </tr></thead>
                 <tbody>${g.payments.map((d) => `
                   <tr>
                     <td>${formatDate(d.payDate)}</td>
                     <td>${fmtEur(d.grossAmountEur)}</td>
-                    <td>${fmtEur(d.withholdingTaxEur)}</td>
                   </tr>`).join("")}
                 </tbody>
               </table>
@@ -119,7 +127,8 @@ function renderDividendsDetail(entries: DividendEntry[]): string {
           </td>
         </tr>`).join("")}
       </tbody>
-    </table>`;
+    </table>
+    ${note}`;
 }
 
 /** Render a detail table of interest entries (earned or paid) for a casilla drill-down. */

--- a/src/web/main.ts
+++ b/src/web/main.ts
@@ -978,6 +978,9 @@ function renderDividendsTable(report: TaxSummary) {
       </tbody>
     </table>
     <p class="table-count">${t("results.dividends_count", { count: String(entries.length) })}</p>
+    ${entries.some((d) => d.withholdingTaxEur.greaterThan(0))
+      ? `<p class="muted">${esc(t("casilla.dividends_withholding_note"))}</p>`
+      : ""}
   `;
 }
 

--- a/tests/web/casilla-detail.test.ts
+++ b/tests/web/casilla-detail.test.ts
@@ -19,8 +19,24 @@ import {
   computeCasillaBlocksWithFx,
   combinedNetGainLoss,
 } from "../../src/generators/casillas.js";
+import { renderDividendsDetail } from "../../src/web/casilla-detail.js";
 import Decimal from "decimal.js";
-import type { TaxSummary, FifoDisposal } from "../../src/types/tax.js";
+import type { TaxSummary, FifoDisposal, DividendEntry } from "../../src/types/tax.js";
+
+function makeDividend(overrides: Partial<DividendEntry> = {}): DividendEntry {
+  return {
+    isin: "US0378331005",
+    symbol: "AAPL",
+    description: "APPLE INC dividend",
+    payDate: "20250213",
+    grossAmountEur: new Decimal("24.50"),
+    withholdingTaxEur: new Decimal("3.68"),
+    withholdingCountry: "US",
+    currency: "USD",
+    ecbRate: new Decimal("0.92"),
+    ...overrides,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -272,5 +288,41 @@ describe("combinedNetGainLoss — net gain/loss card value", () => {
     expect(net.toFixed(2)).toBe("-200.00");
     // The net gain/loss card CSS class logic: loss → "loss" class
     expect(net.greaterThanOrEqualTo(0)).toBe(false);
+  });
+});
+
+describe("renderDividendsDetail (Casilla 0029 card)", () => {
+  it("does NOT render a withholding/Retención column", () => {
+    const html = renderDividendsDetail([makeDividend()]);
+    // The per-issuer table header has 5 columns: ISIN, Symbol, Country, Payments, Gross.
+    const headerRow = html.slice(html.indexOf("<thead>"), html.indexOf("</thead>"));
+    expect(headerRow).not.toContain("Retención");
+    expect(headerRow).not.toContain("Retencion");
+    // Gross is still shown; withholding is not. fmtEur renders Spanish "24,50".
+    expect(html).toContain("24,50");
+    expect(html).not.toContain("3,68");
+  });
+
+  it("appends the foreign-withholding redirect note when withholding > 0", () => {
+    const html = renderDividendsDetail([makeDividend({ withholdingTaxEur: new Decimal("3.68") })]);
+    expect(html).toContain("0588");
+    expect(html).toMatch(/Retenciones/); // references the Renta Web field name in the note
+  });
+
+  it("omits the note when there is no foreign withholding (no noise on clean reports)", () => {
+    const html = renderDividendsDetail([makeDividend({ withholdingTaxEur: new Decimal("0") })]);
+    expect(html).not.toContain("0588");
+  });
+
+  it("uses colspan=5 for the per-payment drill-down subrow after dropping the column", () => {
+    const html = renderDividendsDetail([makeDividend()]);
+    expect(html).toContain('colspan="5"');
+    expect(html).not.toContain('colspan="6"');
+  });
+
+  it("renders the empty-state when there are no dividends", () => {
+    const html = renderDividendsDetail([]);
+    expect(html).not.toContain("0588"); // note guarded behind the early return
+    expect(html).not.toContain("<table");
   });
 });


### PR DESCRIPTION
Closes #202. Thanks @lucasfarre for catching this — a sharp fiscal-safety find.

## Problem

The **Casilla 0029** (gross dividends) detail card showed a "Retención EUR" column = the **foreign** withholding tax. That card mirrors the AEAT Renta Web **"Alta Capital mobiliario"** form, whose **"Retenciones"** field is for **Spanish IRPF retentions only** (Casillas 0030/0031). A user pasting the foreign figure there would **double-count** it against **Casilla 0588** — the only valid home for foreign withholding (Art. 80 LIRPF) — overstating the refund and triggering an AEAT mismatch (no Modelo 193 record backs that retention).

Verified against primary sources (AEAT Manual Renta 2024 c05/c18; Art. 79 & 80 LIRPF, BOE-A-2006-20764): foreign-tax deduction (0588) and Spanish retentions are two **independent** subtractions from the cuota, so entering the figure in both double-counts.

## Fix

- **Remove** the withholding column from the 0029 detail card (per-issuer table + per-payment drill-down); `colspan` 6→5.
- **Add a localized redirect note** (info/muted) under the 0029 card **and** the main dividends results table (`main.ts` — which also shows a sortable withholding column, so the same trap exists there). Gated on `Σ withholding > 0` so it stays silent on zero-withholding reports (accumulating ETFs, etc.). New key `casilla.dividends_withholding_note` in **all 5 locales**.
- **Export `renderDividendsDetail`** and unit-test it.

The note (es): *"La retención extranjera no se declara aquí. En el formulario «Alta Capital mobiliario» de Renta Web, deja el campo «Retenciones» en 0 — la retención extranjera se deduce por separado en la casilla 0588 (deducción por doble imposición internacional, Art. 80 LIRPF)."*

## Scope notes
- Foreign withholding stays visible in its **correct home** — the Casilla 0588 detail card (grouped by country) — and in CSV/PDF.
- I extended the issue's scope slightly: the note also lands under the main `main.ts` dividends table, since it has a sortable withholding column that's the most copy-paste-prone surface (a review-panel finding). `table.withholding_eur` is kept (still used by the 0588 card, main table, PDFs).
- **Tax totals unchanged**: 0029 `grossIncome` and 0588 are untouched — presentation-only.

## Test plan
- [x] `npm run typecheck`, `npm run lint`, `npm test` — **1286 pass** (+5: no Retención header, note present iff withholding>0, colspan=5, empty-state).
- [x] `npm run build`
- [ ] Browser smoke-test of the 0029 card — not run in this environment; reuses existing styled patterns, unit-tested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dividends section now organizes holdings by issuer for better readability and navigation
  * Added contextual guidance notes explaining how foreign withholding taxes are handled during dividend processing

* **Internationalization**
  * Extended language support with new dividend withholding tax guidance in Catalan, English, Spanish, Basque, and Galician

<!-- end of auto-generated comment: release notes by coderabbit.ai -->