### PR TITLE
fix(ecb): value crypto income in trade-less years; degrade gracefully on missing resolvable rate

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -21,6 +21,7 @@ import type { Statement } from "../types/broker.js";
 import type { EcbRateMap } from "../types/ecb.js";
 import { fetchEcbRates } from "../engine/ecb.js";
 import { buildManualRateMap, coerceManualQuotes } from "../engine/manual-rates.js";
+import { normalizeDate } from "../engine/dates.js";
 import { generateTaxReport } from "../generators/report.js";
 import { generateModelo720 } from "../generators/modelo720.js";
 import { validateModelo720Records } from "../generators/modelo720-validator.js";
@@ -148,9 +149,16 @@ program
       console.error("  Obteniendo tipos de cambio ECB...");
 
       const years = new Set(merged.trades.map((t) => parseInt(t.tradeDate.slice(0, 4))));
+      // Cash transactions (dividends, interest, crypto reward income) can fall in
+      // a year with NO trades — e.g. USDT Simple Earn interest in a year the user
+      // didn't trade. Fetch their years too, or valuation throws "No ECB rate".
+      for (const c of merged.cashTransactions) {
+        const y = parseInt(normalizeDate(c.dateTime).slice(0, 4));
+        if (Number.isFinite(y)) years.add(y);
+      }
       years.add(opts.year);
-      // Fetch previous year for the earliest trade year so the 10-day lookback
-      // can find late-December rates for early-January trades (e.g. Jan 1-2).
+      // Fetch previous year for the earliest year so the 10-day lookback can find
+      // late-December rates for early-January transactions (e.g. Jan 1-2).
       const minYear = Math.min(...years);
       years.add(minYear - 1);
       const allRates: EcbRateMap = new Map();

--- a/src/engine/fx-fifo.ts
+++ b/src/engine/fx-fifo.ts
@@ -10,7 +10,7 @@ import Decimal from "decimal.js";
 import type { FxLot, FxDisposal, FxTrigger, TaxMessage } from "../types/tax.js";
 import type { Trade, CashTransaction } from "../types/ibkr.js";
 import type { EcbRateMap } from "../types/ecb.js";
-import { getEcbRate, isEcbResolvable } from "./ecb.js";
+import { getEcbRate, isEcbResolvable, lookupRateInMap } from "./ecb.js";
 import { daysBetween, normalizeDate } from "./dates.js";
 
 export interface FxEvent {
@@ -166,13 +166,24 @@ export class FxFifoEngine {
       const amount = new Decimal(tx.amount);
       if (amount.isZero()) continue;
 
+      // Crypto reward income (staking, Simple Earn interest, airdrops, referral)
+      // is valued and taxed entirely on the income path in report.ts; it must
+      // never generate an FX event here. Skip it BEFORE any rate lookup — its
+      // currency may be a coin (e.g. USDT) whose ECB/USD rate was not fetched,
+      // and getEcbRate would otherwise throw and crash the whole report.
+      if (tx.type === "Crypto Reward Income") continue;
+
       // Crypto-denominated income (e.g. Kraken staking, reported in the staked
       // coin) has no ECB rate. It can't generate an FX event — skip it here.
       // report.ts surfaces a warning so the user values it manually.
       if (!isEcbResolvable(tx.currency)) continue;
 
       const date = normalizeDate(tx.settleDate || tx.dateTime);
-      const ecbRate = getEcbRate(rateMap, date, tx.currency);
+      // A resolvable currency whose rate was not fetched (e.g. an FCY income in
+      // a year with no trades) must not throw — skip the event and let report.ts
+      // surface it. lookupRateInMap returns null instead of throwing.
+      const ecbRate = lookupRateInMap(rateMap, date, tx.currency);
+      if (ecbRate === null) continue;
 
       if (tx.type === "Dividends" || tx.type === "Payment In Lieu Of Dividends") {
         events.push({ date, currency: tx.currency, quantity: amount.abs(), ecbRate, trigger: "dividend" });

--- a/src/generators/report.ts
+++ b/src/generators/report.ts
@@ -15,7 +15,7 @@ import { FxFifoEngine } from "../engine/fx-fifo.js";
 import { detectWashSales } from "../engine/wash-sale.js";
 import { calculateDividends } from "../engine/dividends.js";
 import { calculateDoubleTaxation } from "../engine/double-taxation.js";
-import { getEcbRate, isEcbResolvable, lookupRateInMap } from "../engine/ecb.js";
+import { lookupRateInMap } from "../engine/ecb.js";
 import { resolveCryptoTradeValues } from "../engine/crypto-valuation.js";
 import { buildManualRateMap } from "../engine/manual-rates.js";
 import { normalizeDate } from "../engine/dates.js";
@@ -125,10 +125,15 @@ function valueIncomeEur(
     }
   }
 
-  // Fiat/stablecoin or a synthetic rate injected by the crypto-valuation pass.
-  if (isEcbResolvable(t.currency) || lookupRateInMap(resolvedRateMap, date, t.currency) !== null) {
-    const rate = getEcbRate(resolvedRateMap, date, t.currency);
-    return { amountEur: amount.mul(rate).abs(), rate };
+  // A rate present in the resolved map (ECB fiat, a normalized stablecoin like
+  // USDT→USD, or a synthetic crypto rate injected by the valuation pass). We
+  // gate on lookupRateInMap !== null rather than isEcbResolvable() so that a
+  // resolvable currency whose rate was never fetched (e.g. a USDT reward in a
+  // year with no trades) degrades to the manual/skip path below instead of
+  // throwing inside getEcbRate and crashing the whole report.
+  const mapRate = lookupRateInMap(resolvedRateMap, date, t.currency);
+  if (mapRate !== null) {
+    return { amountEur: amount.mul(mapRate).abs(), rate: mapRate };
   }
 
   // A user/EUR_Value manual-rate hint for the coin (never a live price oracle).

--- a/src/web/main.ts
+++ b/src/web/main.ts
@@ -600,9 +600,17 @@ async function processFiles(): Promise<void> {
     currencies.delete("EUR");
 
     const years = new Set(merged.trades.map((tr) => parseInt(tr.tradeDate.slice(0, 4))));
+    // Cash transactions (dividends, interest, crypto reward income) can fall in
+    // a year with NO trades — e.g. USDT Simple Earn interest in a year the user
+    // didn't trade. Their currency's rate must still be fetched for that year,
+    // or valuation throws "No ECB rate found". Add their years too.
+    for (const c of merged.cashTransactions) {
+      const y = parseInt(normalizeDate(c.dateTime).slice(0, 4));
+      if (Number.isFinite(y)) years.add(y);
+    }
     years.add(year);
-    // Fetch previous year for the earliest trade year so the 10-day lookback
-    // can find late-December rates for early-January trades (e.g. Jan 1-2).
+    // Fetch previous year for the earliest year so the 10-day lookback can find
+    // late-December rates for early-January transactions (e.g. Jan 1-2).
     const minYear = Math.min(...years);
     years.add(minYear - 1);
     const allRates: EcbRateMap = new Map();

--- a/tests/generators/report.test.ts
+++ b/tests/generators/report.test.ts
@@ -771,3 +771,58 @@ describe("dividend grouping reconciles with the tax engine (presentation-only)",
     expect(sumGross.toFixed(2)).toBe(split.dividends.grossIncome.toFixed(2));
   });
 });
+
+describe("crypto reward income valuation degrades gracefully when its rate is missing", () => {
+  // Repro for "No ECB rate found for USDT": a USDT-denominated reward whose year
+  // has no ECB rate in the map. USDT normalizes to USD (resolvable), so the old
+  // code entered the throwing getEcbRate branch on isEcbResolvable() alone and
+  // crashed the whole report. It must instead skip+warn (like an unvaluable
+  // coin), never throw.
+  it("does NOT throw when a USDT reward has no USD rate in the map", () => {
+    const statement = makeStatement({
+      cashTransactions: [
+        makeCashTx({
+          transactionID: "earn-1",
+          symbol: "USDT",
+          currency: "USDT",
+          dateTime: "20250115",
+          amount: "50",
+          type: "Crypto Reward Income",
+          taxBucket: "ahorro",
+          rewardQuantity: "50",
+        }),
+      ],
+    });
+    // Rate map has NO USD entry for 2025-01-15 (simulates the unfetched year).
+    const emptyRates: EcbRateMap = new Map();
+    let report!: ReturnType<typeof generateTaxReport>;
+    expect(() => {
+      report = generateTaxReport(statement, emptyRates, 2025);
+    }).not.toThrow();
+    // Unvalued income is excluded from the total and surfaced as a warning.
+    expect(report.interest.earned.toFixed(2)).toBe("0.00");
+    expect(report.messages.some((m) => m.id === "report.crypto_income_unvalued")).toBe(true);
+  });
+
+  it("values the USDT reward once the USD rate IS present (USDT→USD)", () => {
+    const statement = makeStatement({
+      cashTransactions: [
+        makeCashTx({
+          transactionID: "earn-2",
+          symbol: "USDT",
+          currency: "USDT",
+          dateTime: "20250115",
+          amount: "50",
+          type: "Crypto Reward Income",
+          taxBucket: "ahorro",
+          rewardQuantity: "50",
+        }),
+      ],
+    });
+    const rates = makeRateMap({ "2025-01-15": "0.92" }); // USD rate present
+    const report = generateTaxReport(statement, rates, 2025);
+    // 50 USDT × 0.92 EUR/USD = 46.00, taxed as savings-base income (0027).
+    expect(report.interest.earned.toFixed(2)).toBe("46.00");
+    expect(report.messages.some((m) => m.id === "report.crypto_income_unvalued")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Reported on the Telegram channel: a **Binance import crashes with "No ECB rate found for USDT"** on v0.47.0.

USDT normalizes to USD fine — the message is misleading. The real cause: **USD was never fetched for the transaction's calendar year.** A **USDT-denominated reward** (Simple Earn interest, emitted as a `CashTransaction`) sitting in a year with **no trades** falls through a gap, then an unguarded `getEcbRate` throws and crashes the whole report.

Diagnosed via a `/research!` panel (ranked hypotheses against the code); root cause confirmed with a failing test reproducing the exact error string.

## Two compounding bugs, both fixed

1. **Years-to-fetch built from `trades` only** (`web/main.ts`, `cli/index.ts`). The fetch set now also includes `cashTransactions` years (guarded with `Number.isFinite`), so USD **is** fetched for a reward-only year. *(Currencies were already gathered from cashTransactions — only the years set had the gap.)*

2. **Two consumers threw on a resolvable-but-unfetched rate** instead of degrading:
   - `report.ts` `valueIncomeEur`: now gates on `lookupRateInMap !== null` and falls through to the manual / skip-and-warn path (`report.crypto_income_unvalued`) instead of calling the throwing `getEcbRate`.
   - `fx-fifo.ts` `extractCashFxEvents`: skips `Crypto Reward Income` early (it must never create an FX event — it's taxed on the income path) and uses `lookupRateInMap` + null-continue.

Net: a reward in a trade-less year is now **correctly valued** (its year is fetched), and any genuinely missing-but-resolvable rate **degrades gracefully** rather than crashing. Happy-path tax totals unchanged (the returned rate is byte-identical to the old `getEcbRate` path when a rate exists).

## Review
Verified by a code-review pass: APPROVE, behavior-preserving on every happy path, no regression. One **pre-existing, out-of-scope** follow-up noted (modelo720/721/d6 year-end `getEcbRate` on open positions — a separate flow, not on the crashing report path); will log a ticket.

## Test plan
- [x] `npm run typecheck`, `npm run lint`, `npm test` — **1283 pass** (+2: degrade-when-missing reproduces the exact crash; value-when-present USDT→USD = 50×0.92 = 46.00 → Casilla 0027).
- [x] `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability when processing certain transaction types to prevent crashes.
  * Improved FX rate handling for years with only cash activity and no trades.
  * Better graceful degradation when exchange rates are unavailable.
  * Improved crypto reward income valuation robustness.

* **Tests**
  * Added test coverage for crypto reward income valuation with varying exchange rate availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->