### PR TITLE
ci(dependabot): allow github-actions major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,79 +1,75 @@
 version: 2
-
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: npm
+    directory: /
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: weekly
+      day: monday
     open-pull-requests-limit: 10
     commit-message:
-      prefix: "deps"
+      prefix: deps
     labels:
-      - "dependencies"
-      - "automated"
+      - dependencies
+      - automated
     groups:
       minor-and-patch:
         patterns:
-          - "*"
+          - '*'
         update-types:
-          - "minor"
-          - "patch"
+          - minor
+          - patch
       npm-security:
         applies-to: security-updates
         patterns:
-          - "*"
+          - '*'
     ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "monthly"
+      interval: monthly
     open-pull-requests-limit: 10
     commit-message:
-      prefix: "ci"
+      prefix: ci
     labels:
-      - "ci"
-      - "automated"
+      - ci
+      - automated
     groups:
       minor-and-patch:
         patterns:
-          - "*"
+          - '*'
         update-types:
-          - "minor"
-          - "patch"
+          - minor
+          - patch
       actions-security:
         applies-to: security-updates
         patterns:
-          - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: "docker"
-    directory: "/"
+          - '*'
+  - package-ecosystem: docker
+    directory: /
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: weekly
+      day: monday
     open-pull-requests-limit: 10
     commit-message:
-      prefix: "docker"
+      prefix: docker
     labels:
-      - "dependencies"
-      - "automated"
+      - dependencies
+      - automated
     groups:
       minor-and-patch:
         patterns:
-          - "*"
+          - '*'
         update-types:
-          - "minor"
-          - "patch"
+          - minor
+          - patch
       docker-security:
         applies-to: security-updates
         patterns:
-          - "*"
+          - '*'
     ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
Removes the `semver-major` ignore from the `github-actions` ecosystem so action major upgrades stop silently drifting. npm/docker majors remain gated.

Auto-merge enabled; merges on green CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration file formatting for improved readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->