### PR TITLE
fix(fifo): compute FCY stock gains in the share currency, convert at sale date (closes #219)

### DIFF
--- a/src/engine/fifo.ts
+++ b/src/engine/fifo.ts
@@ -165,14 +165,13 @@ export class FifoEngine {
     );
 
     // Parse scrip dividends into timeline events (applied chronologically, not upfront)
-    const scripDivs: { key: string; isin: string; symbol: string; description: string; date: string; quantity: Decimal; pricePerShare: Decimal; costInEur: Decimal; currency: string; ecbRate: Decimal }[] = [];
+    const scripDivs: { key: string; isin: string; symbol: string; description: string; date: string; quantity: Decimal; pricePerShare: Decimal; costInFcy: Decimal; currency: string; ecbRate: Decimal }[] = [];
     for (const ca of (corporateActions ?? []).filter((ca) => ca.type === "SD")) {
       const qty = new Decimal(ca.quantity);
       if (qty.isZero()) continue;
-      const amount = new Decimal(ca.amount).abs();
+      const amount = new Decimal(ca.amount).abs(); // already in ca.currency (FCY)
       const date = normalizeDate(ca.dateTime.slice(0, 8));
       const ecbRate = getEcbRate(rateMap, date, ca.currency);
-      const costInEur = amount.mul(ecbRate);
       scripDivs.push({
         key: ca.isin || ca.symbol,
         isin: ca.isin,
@@ -181,7 +180,7 @@ export class FifoEngine {
         date,
         quantity: qty.abs(),
         pricePerShare: amount.dividedBy(qty.abs()),
-        costInEur,
+        costInFcy: amount,
         currency: ca.currency,
         ecbRate,
       });
@@ -278,7 +277,7 @@ export class FifoEngine {
       // Multiply quantity by ratio, keep total cost the same
       lot.quantity = lot.quantity.mul(ratio);
       lot.pricePerShare = lot.pricePerShare.dividedBy(ratio);
-      // costInEur stays the same — total cost doesn't change on a split
+      // costInFcy stays the same — total cost doesn't change on a split
     }
 
     // Remove sub-share lots after split (fractional remainders become cash-in-lieu)
@@ -291,7 +290,7 @@ export class FifoEngine {
     this.emit({ id: "fifo.split_applied", severity: "info", message: `⚡ Split ${split.isin} ${split.ratio}:1 (${direction}) aplicado (${split.date})`, hint: "Split aplicado a todos los lotes. El coste total se mantiene — solo cambia el número de acciones.", context: { isin: split.isin, date: split.date, ratio: `${split.ratio}:1`, direction } });
   }
 
-  private addScripDividendLot(sd: { key: string; isin: string; symbol: string; description: string; date: string; quantity: Decimal; pricePerShare: Decimal; costInEur: Decimal; currency: string; ecbRate: Decimal }): void {
+  private addScripDividendLot(sd: { key: string; isin: string; symbol: string; description: string; date: string; quantity: Decimal; pricePerShare: Decimal; costInFcy: Decimal; currency: string; ecbRate: Decimal }): void {
     const lot: Lot = {
       id: `LOT-${this.nextLotId++}`,
       isin: sd.isin,
@@ -300,7 +299,7 @@ export class FifoEngine {
       acquireDate: sd.date,
       quantity: sd.quantity,
       pricePerShare: sd.pricePerShare,
-      costInEur: sd.costInEur,
+      costInFcy: sd.costInFcy,
       currency: sd.currency,
       ecbRate: sd.ecbRate,
     };
@@ -328,8 +327,8 @@ export class FifoEngine {
         symbol: merger.newSymbol,
         description: merger.newDescription,
         quantity: newQuantity,
-        pricePerShare: lot.costInEur.dividedBy(newQuantity), // Recalculate per-share cost
-        // costInEur preserved — total cost basis unchanged
+        pricePerShare: lot.costInFcy.dividedBy(newQuantity), // Recalculate per-share cost
+        // costInFcy preserved — total cost basis unchanged (tax-neutral exchange)
       });
     }
 
@@ -354,12 +353,12 @@ export class FifoEngine {
     // For each parent lot: split cost basis proportionally and create new lot for spin-off
     const newLots: Lot[] = [];
     for (const lot of parentLots) {
-      const spinOffCost = lot.costInEur.mul(costFraction);
+      const spinOffCost = lot.costInFcy.mul(costFraction);
       const spinOffQuantity = lot.quantity.mul(ratio);
 
-      // Reduce parent lot cost basis
-      lot.costInEur = lot.costInEur.mul(parentFraction);
-      lot.pricePerShare = lot.costInEur.dividedBy(lot.quantity);
+      // Reduce parent lot cost basis (in FCY)
+      lot.costInFcy = lot.costInFcy.mul(parentFraction);
+      lot.pricePerShare = lot.costInFcy.dividedBy(lot.quantity);
 
       // Create new lot for spin-off entity
       newLots.push({
@@ -370,7 +369,7 @@ export class FifoEngine {
         acquireDate: lot.acquireDate, // Inherit original acquisition date
         quantity: spinOffQuantity,
         pricePerShare: spinOffCost.dividedBy(spinOffQuantity),
-        costInEur: spinOffCost,
+        costInFcy: spinOffCost,
         currency: lot.currency,
         ecbRate: lot.ecbRate,
       });
@@ -384,6 +383,21 @@ export class FifoEngine {
     this.emit({ id: "fifo.spinoff_applied", severity: "info", message: `🔀 Spin-off: ${spinOff.parentIsin} → ${spinOff.newIsin} (ratio ${spinOff.ratio}:1, coste ${(spinOff.costFraction * 100).toFixed(0)}% al spin-off, ${spinOff.date})`, hint: "El coste se reparte proporcionalmente entre la matriz y la empresa escindida.", context: { parentIsin: spinOff.parentIsin, newIsin: spinOff.newIsin, date: spinOff.date, ratio: `${spinOff.ratio}:1` } });
   }
 
+  /**
+   * Homogenize a commission/fee into the trade's (share) currency. If the
+   * commission is already in the share currency (or zero), it's returned as-is.
+   * Otherwise it's converted via the trade-date cross-rate
+   * `commission × rate(commCcy) / rate(shareCcy)` — keeping the lot
+   * single-currency so the FCY gain stays a clean subtraction (DGT V2422-20).
+   */
+  private homogenizeCommission(commission: Decimal, trade: Trade, shareEcbRate: Decimal, rateMap: EcbRateMap): Decimal {
+    if (commission.isZero() || !trade.commissionCurrency || trade.commissionCurrency === trade.currency) {
+      return commission;
+    }
+    const commEcbRate = getEcbRate(rateMap, trade.tradeDate, trade.commissionCurrency);
+    return commission.mul(commEcbRate).dividedBy(shareEcbRate);
+  }
+
   private addLot(trade: Trade, rateMap: EcbRateMap): void {
     const ecbRate = getEcbRate(rateMap, trade.tradeDate, trade.currency);
     const quantity = new Decimal(trade.quantity).abs();
@@ -391,12 +405,12 @@ export class FifoEngine {
     const multiplier = new Decimal(trade.multiplier || "1");
     const commission = new Decimal(trade.commission).abs();
     const taxes = new Decimal(trade.taxes || "0").abs();
-    const baseAmount = quantity.mul(pricePerShare).mul(multiplier).plus(taxes);
-    // Convert commission separately if its currency differs from the trade currency
-    const commissionEcbRate = !commission.isZero() && trade.commissionCurrency && trade.commissionCurrency !== trade.currency
-      ? getEcbRate(rateMap, trade.tradeDate, trade.commissionCurrency)
-      : ecbRate;
-    const costInEur = baseAmount.mul(ecbRate).plus(commission.mul(commissionEcbRate));
+    // Cost basis is kept in the share's currency (FCY). A commission in a
+    // DIFFERENT currency is homogenized to the share currency via the trade-date
+    // cross-rate (rate(commCcy)/rate(shareCcy)), so the lot stays single-currency
+    // and the gain is later a clean FCY subtraction (DGT V2422-20).
+    const commissionFcy = this.homogenizeCommission(commission, trade, ecbRate, rateMap);
+    const costInFcy = quantity.mul(pricePerShare).mul(multiplier).plus(taxes).plus(commissionFcy);
 
     const lot: Lot = {
       id: `LOT-${this.nextLotId++}`,
@@ -406,7 +420,7 @@ export class FifoEngine {
       acquireDate: trade.tradeDate,
       quantity,
       pricePerShare,
-      costInEur,
+      costInFcy,
       currency: trade.currency,
       ecbRate,
       ...(trade.assetCategory === "OPT" || trade.assetCategory === "FOP" || trade.assetCategory === "FSFOP" ? {
@@ -432,18 +446,17 @@ export class FifoEngine {
     const taxes = new Decimal(trade.taxes || "0").abs();
     const pricePerShare = new Decimal(trade.tradePrice);
     const multiplier = new Decimal(trade.multiplier || "1");
-    // Convert commission separately if its currency differs from the trade currency
-    const commissionEcbRate = !commission.isZero() && trade.commissionCurrency && trade.commissionCurrency !== trade.currency
-      ? getEcbRate(rateMap, trade.tradeDate, trade.commissionCurrency)
-      : ecbRate;
+    // Commission homogenized to the share currency (FCY) — same treatment as the
+    // acquisition cost, so proceeds and cost net cleanly in one currency.
+    const commissionFcy = this.homogenizeCommission(commission, trade, ecbRate, rateMap);
 
     const key = lotKey(trade);
     const lots = this.lots.get(key);
     if (!lots || lots.length === 0) {
       // Short sale or missing prior data — warn and record with zero cost basis
       this.emit({ id: "fifo.sell_without_lots", severity: "error", message: `⚠ Venta sin lotes: ${trade.symbol} (${trade.isin}) × ${remaining} el ${normalizeDate(trade.tradeDate)}. Coste base = 0 (posible posición corta o datos previos incompletos).`, hint: "¿Has incluido los años anteriores en tu Flex Query? Selecciona un periodo que cubra desde la primera compra de este valor.", context: { symbol: trade.symbol, isin: trade.isin, date: normalizeDate(trade.tradeDate), quantity: remaining.toString() } });
-      const proceedsBaseEur = remaining.mul(pricePerShare).mul(multiplier).minus(taxes).mul(ecbRate);
-      const proceedsEur = proceedsBaseEur.minus(commission.mul(commissionEcbRate));
+      const proceedsFcy = remaining.mul(pricePerShare).mul(multiplier).minus(taxes).minus(commissionFcy);
+      const proceedsEur = proceedsFcy.mul(ecbRate);
       this.disposals.push({
         isin: trade.isin,
         symbol: trade.symbol,
@@ -451,6 +464,9 @@ export class FifoEngine {
         sellDate: trade.tradeDate,
         acquireDate: trade.tradeDate,
         quantity: remaining,
+        gainLossFcy: proceedsFcy,
+        proceedsFcy,
+        costBasisFcy: new Decimal(0),
         proceedsEur,
         costBasisEur: new Decimal(0),
         gainLossEur: proceedsEur,
@@ -472,16 +488,22 @@ export class FifoEngine {
 
       const consumed = Decimal.min(remaining, lot.quantity);
       const fractionOfSale = consumed.dividedBy(totalSellQuantity);
-      const commissionShare = commission.mul(fractionOfSale);
+      const commissionShareFcy = commissionFcy.mul(fractionOfSale);
       const taxesShare = taxes.mul(fractionOfSale);
 
-      // Proceeds in EUR for this partial disposal
-      const proceedsBaseEur = consumed.mul(pricePerShare).mul(multiplier).minus(taxesShare).mul(ecbRate);
-      const proceedsEur = proceedsBaseEur.minus(commissionShare.mul(commissionEcbRate));
+      // Proceeds and cost are computed IN THE SHARE'S CURRENCY (FCY); the gain
+      // is the FCY difference, converted to EUR at the SALE-date rate only
+      // (DGT V2422-20). No buy-date rate enters the gain — that FX drift is a
+      // separate currency gain handled by the FX engine.
+      const proceedsFcy = consumed.mul(pricePerShare).mul(multiplier).minus(taxesShare).minus(commissionShareFcy);
+      const costBasisFcy = lot.costInFcy.dividedBy(lot.quantity).mul(consumed);
+      const gainLossFcy = proceedsFcy.minus(costBasisFcy);
 
-      // Cost basis in EUR: proportional from lot (cost per unit * consumed quantity)
-      const lotTotalCostPerUnit = lot.costInEur.dividedBy(lot.quantity);
-      const disposalCostEur = lotTotalCostPerUnit.mul(consumed);
+      // EUR presentation: BOTH legs at the sale-date rate so
+      // proceedsEur − costBasisEur === gainLossEur exactly (no re-leaking of FX).
+      const proceedsEur = proceedsFcy.mul(ecbRate);
+      const costBasisEur = costBasisFcy.mul(ecbRate);
+      const gainLossEur = gainLossFcy.mul(ecbRate);
 
       const sellDate = trade.tradeDate;
       const acquireDate = lot.acquireDate;
@@ -494,9 +516,12 @@ export class FifoEngine {
         sellDate,
         acquireDate,
         quantity: consumed,
+        gainLossFcy,
+        proceedsFcy,
+        costBasisFcy,
         proceedsEur,
-        costBasisEur: disposalCostEur,
-        gainLossEur: proceedsEur.minus(disposalCostEur),
+        costBasisEur,
+        gainLossEur,
         holdingPeriodDays: holdingDays,
         currency: trade.currency,
         sellEcbRate: ecbRate,
@@ -513,9 +538,9 @@ export class FifoEngine {
         } : {}),
       });
 
-      // Reduce lot
+      // Reduce lot (in FCY)
       lot.quantity = lot.quantity.minus(consumed);
-      lot.costInEur = lot.costInEur.minus(disposalCostEur);
+      lot.costInFcy = lot.costInFcy.minus(costBasisFcy);
 
       if (lot.quantity.isZero()) {
         lots.shift();
@@ -528,10 +553,10 @@ export class FifoEngine {
       // Remaining shares with no lots — short sale or data gap
       this.emit({ id: "fifo.insufficient_lots", severity: "error", message: `⚠ Lotes insuficientes: ${trade.symbol} (${trade.isin}) × ${remaining} el ${normalizeDate(trade.tradeDate)}. Coste base = 0.`, hint: "El Flex Query no cubre todas las compras previas de este valor. Amplía el periodo de consulta.", context: { symbol: trade.symbol, isin: trade.isin, date: normalizeDate(trade.tradeDate), quantity: remaining.toString() } });
       const fractionOfSale = remaining.dividedBy(totalSellQuantity);
-      const commissionShare = commission.mul(fractionOfSale);
+      const commissionShareFcy = commissionFcy.mul(fractionOfSale);
       const taxesShare = taxes.mul(fractionOfSale);
-      const proceedsBaseEur = remaining.mul(pricePerShare).mul(multiplier).minus(taxesShare).mul(ecbRate);
-      const proceedsEur = proceedsBaseEur.minus(commissionShare.mul(commissionEcbRate));
+      const proceedsFcy = remaining.mul(pricePerShare).mul(multiplier).minus(taxesShare).minus(commissionShareFcy);
+      const proceedsEur = proceedsFcy.mul(ecbRate);
       this.disposals.push({
         isin: trade.isin,
         symbol: trade.symbol,
@@ -539,6 +564,9 @@ export class FifoEngine {
         sellDate: trade.tradeDate,
         acquireDate: trade.tradeDate,
         quantity: remaining,
+        gainLossFcy: proceedsFcy,
+        proceedsFcy,
+        costBasisFcy: new Decimal(0),
         proceedsEur,
         costBasisEur: new Decimal(0),
         gainLossEur: proceedsEur,
@@ -559,11 +587,10 @@ export class FifoEngine {
     const multiplier = new Decimal(trade.multiplier || "1");
     const commission = new Decimal(trade.commission).abs();
     const taxes = new Decimal(trade.taxes || "0").abs();
-    const baseAmount = quantity.mul(pricePerShare).mul(multiplier).minus(taxes);
-    const commissionEcbRate = !commission.isZero() && trade.commissionCurrency && trade.commissionCurrency !== trade.currency
-      ? getEcbRate(rateMap, trade.tradeDate, trade.commissionCurrency)
-      : ecbRate;
-    const proceedsInEur = baseAmount.mul(ecbRate).minus(commission.mul(commissionEcbRate));
+    const commissionFcy = this.homogenizeCommission(commission, trade, ecbRate, rateMap);
+    // Short opens by SELLING: store the proceeds received, in the share currency
+    // (FCY). The gain is computed in FCY at close and converted at the close date.
+    const proceedsInFcy = quantity.mul(pricePerShare).mul(multiplier).minus(taxes).minus(commissionFcy);
 
     const lot: Lot = {
       id: `LOT-${this.nextLotId++}`,
@@ -573,7 +600,7 @@ export class FifoEngine {
       acquireDate: trade.tradeDate,
       quantity,
       pricePerShare,
-      costInEur: proceedsInEur,
+      costInFcy: proceedsInFcy,
       currency: trade.currency,
       ecbRate,
       isShort: true,
@@ -593,9 +620,7 @@ export class FifoEngine {
     const taxes = new Decimal(trade.taxes || "0").abs();
     const pricePerShare = new Decimal(trade.tradePrice);
     const multiplier = new Decimal(trade.multiplier || "1");
-    const commissionEcbRate = !commission.isZero() && trade.commissionCurrency && trade.commissionCurrency !== trade.currency
-      ? getEcbRate(rateMap, trade.tradeDate, trade.commissionCurrency)
-      : ecbRate;
+    const commissionFcy = this.homogenizeCommission(commission, trade, ecbRate, rateMap);
 
     const key = lotKey(trade);
     const lots = this.shortLots.get(key);
@@ -610,14 +635,18 @@ export class FifoEngine {
       const lot = lots[0]!;
       const consumed = Decimal.min(remaining, lot.quantity);
       const fractionOfBuy = consumed.dividedBy(totalBuyQuantity);
-      const commissionShare = commission.mul(fractionOfBuy);
+      const commissionShareFcy = commissionFcy.mul(fractionOfBuy);
       const taxesShare = taxes.mul(fractionOfBuy);
 
-      const closeCostBaseEur = consumed.mul(pricePerShare).mul(multiplier).plus(taxesShare).mul(ecbRate);
-      const closeCostEur = closeCostBaseEur.plus(commissionShare.mul(commissionEcbRate));
+      // Short close: gain = open proceeds − close cost, both in the share
+      // currency (FCY); convert the difference at the close-date rate only.
+      const closeCostFcy = consumed.mul(pricePerShare).mul(multiplier).plus(taxesShare).plus(commissionShareFcy);
+      const openProceedsFcy = lot.costInFcy.dividedBy(lot.quantity).mul(consumed);
+      const gainLossFcy = openProceedsFcy.minus(closeCostFcy);
 
-      const lotProceedsPerUnit = lot.costInEur.dividedBy(lot.quantity);
-      const openProceedsEur = lotProceedsPerUnit.mul(consumed);
+      const proceedsEur = openProceedsFcy.mul(ecbRate);
+      const costBasisEur = closeCostFcy.mul(ecbRate);
+      const gainLossEur = gainLossFcy.mul(ecbRate);
 
       const acquireDate = lot.acquireDate;
       const holdingDays = daysBetween(acquireDate, trade.tradeDate);
@@ -629,9 +658,12 @@ export class FifoEngine {
         sellDate: trade.tradeDate,
         acquireDate,
         quantity: consumed,
-        proceedsEur: openProceedsEur,
-        costBasisEur: closeCostEur,
-        gainLossEur: openProceedsEur.minus(closeCostEur),
+        gainLossFcy,
+        proceedsFcy: openProceedsFcy,
+        costBasisFcy: closeCostFcy,
+        proceedsEur,
+        costBasisEur,
+        gainLossEur,
         holdingPeriodDays: holdingDays,
         currency: trade.currency,
         sellEcbRate: ecbRate,
@@ -642,7 +674,7 @@ export class FifoEngine {
       });
 
       lot.quantity = lot.quantity.minus(consumed);
-      lot.costInEur = lot.costInEur.minus(openProceedsEur);
+      lot.costInFcy = lot.costInFcy.minus(openProceedsFcy);
 
       if (lot.quantity.isZero()) {
         lots.shift();
@@ -731,8 +763,9 @@ export class FifoEngine {
       while (remaining.greaterThan(0) && longLots.length > 0) {
         const lot = longLots[0]!;
         const consumed = Decimal.min(remaining, lot.quantity);
-        const costPerUnit = lot.costInEur.dividedBy(lot.quantity);
-        const costBasis = costPerUnit.mul(consumed);
+        const costPerUnitFcy = lot.costInFcy.dividedBy(lot.quantity);
+        const costBasisFcy = costPerUnitFcy.mul(consumed);
+        const costBasisEur = costBasisFcy.mul(ecbRate);
 
         this.disposals.push({
           isin: ex.isin,
@@ -741,9 +774,12 @@ export class FifoEngine {
           sellDate: date,
           acquireDate: lot.acquireDate,
           quantity: consumed,
+          gainLossFcy: costBasisFcy.negated(),
+          proceedsFcy: new Decimal(0),
+          costBasisFcy,
           proceedsEur: new Decimal(0),
-          costBasisEur: costBasis,
-          gainLossEur: costBasis.negated(),
+          costBasisEur,
+          gainLossEur: costBasisEur.negated(),
           holdingPeriodDays: daysBetween(lot.acquireDate, date),
           currency: ex.currency,
           sellEcbRate: ecbRate,
@@ -759,7 +795,7 @@ export class FifoEngine {
         });
 
         lot.quantity = lot.quantity.minus(consumed);
-        lot.costInEur = lot.costInEur.minus(costBasis);
+        lot.costInFcy = lot.costInFcy.minus(costBasisFcy);
         if (lot.quantity.isZero()) longLots.shift();
         remaining = remaining.minus(consumed);
       }
@@ -775,8 +811,9 @@ export class FifoEngine {
       while (remaining.greaterThan(0) && shortLots.length > 0) {
         const lot = shortLots[0]!;
         const consumed = Decimal.min(remaining, lot.quantity);
-        const proceedsPerUnit = lot.costInEur.dividedBy(lot.quantity);
-        const proceedsEur = proceedsPerUnit.mul(consumed);
+        const proceedsPerUnitFcy = lot.costInFcy.dividedBy(lot.quantity);
+        const proceedsFcy = proceedsPerUnitFcy.mul(consumed);
+        const proceedsEur = proceedsFcy.mul(ecbRate);
 
         this.disposals.push({
           isin: ex.isin,
@@ -785,6 +822,9 @@ export class FifoEngine {
           sellDate: date,
           acquireDate: lot.acquireDate,
           quantity: consumed,
+          gainLossFcy: proceedsFcy,
+          proceedsFcy,
+          costBasisFcy: new Decimal(0),
           proceedsEur,
           costBasisEur: new Decimal(0),
           gainLossEur: proceedsEur,
@@ -804,7 +844,7 @@ export class FifoEngine {
         });
 
         lot.quantity = lot.quantity.minus(consumed);
-        lot.costInEur = lot.costInEur.minus(proceedsEur);
+        lot.costInFcy = lot.costInFcy.minus(proceedsFcy);
         if (lot.quantity.isZero()) shortLots.shift();
         remaining = remaining.minus(consumed);
       }
@@ -841,13 +881,15 @@ export class FifoEngine {
       while (remaining.greaterThan(0) && longLots.length > 0) {
         const lot = longLots[0]!;
         const consumed = Decimal.min(remaining, lot.quantity);
-        const costPerUnit = lot.costInEur.dividedBy(lot.quantity);
-        const optionPremiumEur = costPerUnit.mul(consumed);
+        const costPerUnitFcy = lot.costInFcy.dividedBy(lot.quantity);
+        const optionPremiumFcy = costPerUnitFcy.mul(consumed);
 
         if (ex.putCall === "C") {
-          // Call buyer: acquires shares at strike + premium (DGT V0137-23)
-          const baseShareCost = priceForUnderlying.mul(consumed).mul(sharesPerContract).mul(ecbRate);
-          const totalCost = baseShareCost.plus(optionPremiumEur);
+          // Call buyer: acquires shares at strike + premium (DGT V0137-23). Cost
+          // is kept in the share currency (FCY); strike and premium share that
+          // currency, so the lot stays single-currency.
+          const baseShareCostFcy = priceForUnderlying.mul(consumed).mul(sharesPerContract);
+          const totalCostFcy = baseShareCostFcy.plus(optionPremiumFcy);
           const underlyingLot: Lot = {
             id: `LOT-${this.nextLotId++}`,
             isin: ex.underlyingIsin,
@@ -856,7 +898,7 @@ export class FifoEngine {
             acquireDate: date,
             quantity: consumed.mul(sharesPerContract),
             pricePerShare: priceForUnderlying,
-            costInEur: totalCost,
+            costInFcy: totalCostFcy,
             currency: ex.currency,
             ecbRate,
           };
@@ -864,13 +906,14 @@ export class FifoEngine {
           this.lots.get(underlyingKey)!.push(underlyingLot);
         } else {
           // Put buyer exercising: sells shares at strike, premium reduces proceeds
-          const shareProceeds = priceForUnderlying.mul(consumed).mul(sharesPerContract).mul(ecbRate);
-          const netProceeds = shareProceeds.minus(optionPremiumEur);
-          this.consumeLotsForExercise(underlyingKey, consumed.mul(sharesPerContract), netProceeds, date, ecbRate, ex);
+          // (all in FCY; consumeLotsForExercise converts at the exercise date).
+          const shareProceedsFcy = priceForUnderlying.mul(consumed).mul(sharesPerContract);
+          const netProceedsFcy = shareProceedsFcy.minus(optionPremiumFcy);
+          this.consumeLotsForExercise(underlyingKey, consumed.mul(sharesPerContract), netProceedsFcy, date, ecbRate, ex);
         }
 
         lot.quantity = lot.quantity.minus(consumed);
-        lot.costInEur = lot.costInEur.minus(optionPremiumEur);
+        lot.costInFcy = lot.costInFcy.minus(optionPremiumFcy);
         if (lot.quantity.isZero()) longLots.shift();
         remaining = remaining.minus(consumed);
       }
@@ -887,18 +930,19 @@ export class FifoEngine {
       while (remaining.greaterThan(0) && shortLots.length > 0) {
         const lot = shortLots[0]!;
         const consumed = Decimal.min(remaining, lot.quantity);
-        const proceedsPerUnit = lot.costInEur.dividedBy(lot.quantity);
-        const optionPremiumEur = proceedsPerUnit.mul(consumed);
+        const proceedsPerUnitFcy = lot.costInFcy.dividedBy(lot.quantity);
+        const optionPremiumFcy = proceedsPerUnitFcy.mul(consumed);
 
         // Call writer assigned: SELL shares at strike, premium adds to proceeds
-        // Put writer assigned: BUY shares at strike, premium reduces cost
+        // Put writer assigned: BUY shares at strike, premium reduces cost.
+        // All amounts in FCY; conversion happens at the exercise date downstream.
         if (ex.putCall === "C") {
-          const shareProceeds = priceForUnderlying.mul(consumed).mul(sharesPerContract).mul(ecbRate);
-          const netProceeds = shareProceeds.plus(optionPremiumEur);
-          this.consumeLotsForExercise(underlyingKey, consumed.mul(sharesPerContract), netProceeds, date, ecbRate, ex);
+          const shareProceedsFcy = priceForUnderlying.mul(consumed).mul(sharesPerContract);
+          const netProceedsFcy = shareProceedsFcy.plus(optionPremiumFcy);
+          this.consumeLotsForExercise(underlyingKey, consumed.mul(sharesPerContract), netProceedsFcy, date, ecbRate, ex);
         } else {
-          const baseShareCost = priceForUnderlying.mul(consumed).mul(sharesPerContract).mul(ecbRate);
-          const totalCost = baseShareCost.minus(optionPremiumEur);
+          const baseShareCostFcy = priceForUnderlying.mul(consumed).mul(sharesPerContract);
+          const totalCostFcy = baseShareCostFcy.minus(optionPremiumFcy);
           const underlyingLot: Lot = {
             id: `LOT-${this.nextLotId++}`,
             isin: ex.underlyingIsin,
@@ -907,7 +951,7 @@ export class FifoEngine {
             acquireDate: date,
             quantity: consumed.mul(sharesPerContract),
             pricePerShare: priceForUnderlying,
-            costInEur: totalCost,
+            costInFcy: totalCostFcy,
             currency: ex.currency,
             ecbRate,
           };
@@ -916,7 +960,7 @@ export class FifoEngine {
         }
 
         lot.quantity = lot.quantity.minus(consumed);
-        lot.costInEur = lot.costInEur.minus(optionPremiumEur);
+        lot.costInFcy = lot.costInFcy.minus(optionPremiumFcy);
         if (lot.quantity.isZero()) shortLots.shift();
         remaining = remaining.minus(consumed);
       }
@@ -926,8 +970,8 @@ export class FifoEngine {
       this.emit({ id: "fifo.option_exercise_no_lots", severity: "warning", message: `⚠ Ejercicio/asignación sin lotes de opción: ${ex.symbol} × ${quantity} el ${date}. Coste de prima = 0.`, hint: "Ejercicio registrado con prima = 0 porque no se encontró la compra de la opción. Amplía el periodo del Flex Query.", context: { symbol: ex.symbol, date, quantity: quantity.toString() } });
       // Still process underlying position even without option lot data
       if ((ex.action === "Exercise" && ex.putCall === "C") || (ex.action === "Assignment" && ex.putCall === "P")) {
-        // Call exercise / Put assignment: acquire shares at strike
-        const shareCost = strike.mul(quantity).mul(sharesPerContract).mul(ecbRate);
+        // Call exercise / Put assignment: acquire shares at strike (cost in FCY)
+        const shareCostFcy = strike.mul(quantity).mul(sharesPerContract);
         const underlyingLot: Lot = {
           id: `LOT-${this.nextLotId++}`,
           isin: ex.underlyingIsin,
@@ -936,27 +980,28 @@ export class FifoEngine {
           acquireDate: date,
           quantity: totalShares,
           pricePerShare: strike,
-          costInEur: shareCost,
+          costInFcy: shareCostFcy,
           currency: ex.currency,
           ecbRate,
         };
         if (!this.lots.has(underlyingKey)) this.lots.set(underlyingKey, []);
         this.lots.get(underlyingKey)!.push(underlyingLot);
       } else {
-        // Put exercise / Call assignment: sell shares at strike
-        const shareProceeds = strike.mul(quantity).mul(sharesPerContract).mul(ecbRate);
-        this.consumeLotsForExercise(underlyingKey, totalShares, shareProceeds, date, ecbRate, ex);
+        // Put exercise / Call assignment: sell shares at strike (proceeds in FCY)
+        const shareProceedsFcy = strike.mul(quantity).mul(sharesPerContract);
+        this.consumeLotsForExercise(underlyingKey, totalShares, shareProceedsFcy, date, ecbRate, ex);
       }
     }
   }
 
   private consumeLotsForExercise(
-    underlyingKey: string, shares: Decimal, proceedsEur: Decimal,
+    underlyingKey: string, shares: Decimal, proceedsFcy: Decimal,
     date: string, ecbRate: Decimal, ex: OptionExercise,
   ): void {
     const lots = this.lots.get(underlyingKey);
     if (!lots || lots.length === 0) {
       this.emit({ id: "fifo.exercise_no_underlying_lots", severity: "warning", message: `⚠ Ejercicio de opción sin lotes del subyacente: ${ex.underlyingSymbol} × ${shares} el ${date}. Coste base = 0.`, hint: "Asignación de PUT registrada con coste base = 0 del subyacente. El Flex Query puede no cubrir la adquisición original.", context: { symbol: ex.underlyingSymbol, date, quantity: shares.toString() } });
+      const proceedsEur = proceedsFcy.mul(ecbRate);
       this.disposals.push({
         isin: ex.underlyingIsin,
         symbol: ex.underlyingSymbol,
@@ -964,6 +1009,9 @@ export class FifoEngine {
         sellDate: date,
         acquireDate: date,
         quantity: shares,
+        gainLossFcy: proceedsFcy,
+        proceedsFcy,
+        costBasisFcy: new Decimal(0),
         proceedsEur,
         costBasisEur: new Decimal(0),
         gainLossEur: proceedsEur,
@@ -988,9 +1036,10 @@ export class FifoEngine {
       const lot = lots[0]!;
       const consumed = Decimal.min(remaining, lot.quantity);
       const fraction = consumed.dividedBy(shares);
-      const partialProceeds = proceedsEur.mul(fraction);
-      const costPerUnit = lot.costInEur.dividedBy(lot.quantity);
-      const costBasis = costPerUnit.mul(consumed);
+      const partialProceedsFcy = proceedsFcy.mul(fraction);
+      const costBasisFcy = lot.costInFcy.dividedBy(lot.quantity).mul(consumed);
+      const partialProceedsEur = partialProceedsFcy.mul(ecbRate);
+      const costBasisEur = costBasisFcy.mul(ecbRate);
 
       this.disposals.push({
         isin: ex.underlyingIsin,
@@ -999,9 +1048,12 @@ export class FifoEngine {
         sellDate: date,
         acquireDate: lot.acquireDate,
         quantity: consumed,
-        proceedsEur: partialProceeds,
-        costBasisEur: costBasis,
-        gainLossEur: partialProceeds.minus(costBasis),
+        gainLossFcy: partialProceedsFcy.minus(costBasisFcy),
+        proceedsFcy: partialProceedsFcy,
+        costBasisFcy,
+        proceedsEur: partialProceedsEur,
+        costBasisEur,
+        gainLossEur: partialProceedsEur.minus(costBasisEur),
         holdingPeriodDays: daysBetween(lot.acquireDate, date),
         currency: ex.currency,
         sellEcbRate: ecbRate,
@@ -1017,7 +1069,7 @@ export class FifoEngine {
       });
 
       lot.quantity = lot.quantity.minus(consumed);
-      lot.costInEur = lot.costInEur.minus(costBasis);
+      lot.costInFcy = lot.costInFcy.minus(costBasisFcy);
       if (lot.quantity.isZero()) lots.shift();
       remaining = remaining.minus(consumed);
     }
@@ -1025,7 +1077,8 @@ export class FifoEngine {
     if (remaining.greaterThan(0)) {
       this.emit({ id: "fifo.insufficient_underlying_lots", severity: "warning", message: `⚠ Lotes insuficientes del subyacente: ${ex.underlyingSymbol} × ${remaining} el ${date}. Coste base = 0.`, hint: "No hay suficientes lotes del subyacente para cubrir la asignación completa.", context: { symbol: ex.underlyingSymbol, date, quantity: remaining.toString() } });
       const fraction = remaining.dividedBy(shares);
-      const partialProceeds = proceedsEur.mul(fraction);
+      const partialProceedsFcy = proceedsFcy.mul(fraction);
+      const partialProceedsEur = partialProceedsFcy.mul(ecbRate);
       this.disposals.push({
         isin: ex.underlyingIsin,
         symbol: ex.underlyingSymbol,
@@ -1033,9 +1086,12 @@ export class FifoEngine {
         sellDate: date,
         acquireDate: date,
         quantity: remaining,
-        proceedsEur: partialProceeds,
+        gainLossFcy: partialProceedsFcy,
+        proceedsFcy: partialProceedsFcy,
+        costBasisFcy: new Decimal(0),
+        proceedsEur: partialProceedsEur,
         costBasisEur: new Decimal(0),
-        gainLossEur: partialProceeds,
+        gainLossEur: partialProceedsEur,
         holdingPeriodDays: 0,
         currency: ex.currency,
         sellEcbRate: ecbRate,

--- a/src/generators/report.ts
+++ b/src/generators/report.ts
@@ -44,6 +44,11 @@ function splitDisposal(d: FifoDisposal, n: number): FifoDisposal {
     proceedsEur: d.proceedsEur.div(n),
     costBasisEur: d.costBasisEur.div(n),
     gainLossEur: d.gainLossEur.div(n),
+    // The FCY figures must split too, or a >1-titulares declaration over-counts
+    // them by ×n once any consumer reads them.
+    proceedsFcy: d.proceedsFcy.div(n),
+    costBasisFcy: d.costBasisFcy.div(n),
+    gainLossFcy: d.gainLossFcy.div(n),
   };
 }
 

--- a/src/i18n/locales/ca.ts
+++ b/src/i18n/locales/ca.ts
@@ -71,6 +71,7 @@ const ca: TranslationKeys = {
   "casilla.acquisition_value": "Valor d'adquisició (total transmissions)",
   "casilla.listed_transmission_value": "Valor de transmissió (accions negociades)",
   "casilla.listed_acquisition_value": "Valor d'adquisició (accions negociades)",
+  "casilla.acquisition_sale_rate_note": "El valor d'adquisició es mostra al tipus de canvi del BCE de la data de VENDA, de manera que transmissió − adquisició coincideix exactament amb el guany o la pèrdua (DGT V2422-20: el guany es calcula en la moneda de l'acció i només la diferència es converteix a euros). En valors en moneda estrangera aquest import difereix del cost històric en euros de la data de compra i pot no coincidir amb xifres desades en versions anteriors.",
   "casilla.other_transmission_value": "Valor de transmissió (altres elements: opcions/cripto/fons/divisa)",
   "casilla.other_acquisition_value": "Valor d'adquisició (altres elements: opcions/cripto/fons/divisa)",
   "casilla.fx_transmission_value": "Valor de transmissió FX (moneda estrangera)",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -70,6 +70,7 @@ const en: TranslationKeys = {
   "casilla.acquisition_value": "Acquisition value (all disposals)",
   "casilla.listed_transmission_value": "Transmission value (listed shares)",
   "casilla.listed_acquisition_value": "Acquisition value (listed shares)",
+  "casilla.acquisition_sale_rate_note": "The acquisition value is shown at the ECB rate on the SALE date, so transmission − acquisition equals the gain or loss exactly (DGT V2422-20: the gain is computed in the share's currency and only the difference is converted to euros). For foreign-currency holdings this differs from the historical euro cost at the purchase date and may not match figures saved in earlier versions.",
   "casilla.other_transmission_value": "Transmission value (other elements: options/crypto/funds/FX)",
   "casilla.other_acquisition_value": "Acquisition value (other elements: options/crypto/funds/FX)",
   "casilla.fx_transmission_value": "FX transmission value (foreign currency)",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -74,6 +74,7 @@ const es = {
   "casilla.acquisition_value": "Valor de adquisición (total transmisiones)",
   "casilla.listed_transmission_value": "Valor de transmisión (acciones negociadas)",
   "casilla.listed_acquisition_value": "Valor de adquisición (acciones negociadas)",
+  "casilla.acquisition_sale_rate_note": "El valor de adquisición se muestra al tipo de cambio del BCE de la fecha de VENTA, de modo que transmisión − adquisición coincide exactamente con la ganancia o pérdida (DGT V2422-20: la ganancia se calcula en la moneda de la acción y solo la diferencia se convierte a euros). En valores en moneda extranjera este importe difiere del coste histórico en euros de la fecha de compra y puede no coincidir con cifras guardadas en versiones anteriores.",
   "casilla.other_transmission_value": "Valor de transmisión (otros elementos: opciones/cripto/fondos/divisa)",
   "casilla.other_acquisition_value": "Valor de adquisición (otros elementos: opciones/cripto/fondos/divisa)",
   "casilla.fx_transmission_value": "Valor de transmisión FX (moneda extranjera)",

--- a/src/i18n/locales/eu.ts
+++ b/src/i18n/locales/eu.ts
@@ -71,6 +71,7 @@ const eu: TranslationKeys = {
   "casilla.acquisition_value": "Eskuratze-balioa (transmisio guztiak)",
   "casilla.listed_transmission_value": "Transmisio-balioa (negoziatutako akzioak)",
   "casilla.listed_acquisition_value": "Eskuratze-balioa (negoziatutako akzioak)",
+  "casilla.acquisition_sale_rate_note": "Eskuratze-balioa SALMENTA-dataren BCE kanbio-tasan erakusten da, eskualdaketa − eskuratzea irabazi edo galerarekin zehazki bat etor dadin (DGT V2422-20: irabazia akzioaren monetan kalkulatzen da eta diferentzia bakarrik bihurtzen da eurotara). Atzerriko monetako baloreetan zenbateko hau erosketa-datako euro-kostu historikotik desberdina da eta baliteke aurreko bertsioetan gordetako zifrekin bat ez etortzea.",
   "casilla.other_transmission_value": "Transmisio-balioa (beste elementuak: opzioak/kripto/funtsak/dibisa)",
   "casilla.other_acquisition_value": "Eskuratze-balioa (beste elementuak: opzioak/kripto/funtsak/dibisa)",
   "casilla.fx_transmission_value": "FX transmisio-balioa (atzerriko moneta)",

--- a/src/i18n/locales/gl.ts
+++ b/src/i18n/locales/gl.ts
@@ -71,6 +71,7 @@ const gl: TranslationKeys = {
   "casilla.acquisition_value": "Valor de adquisición (total transmisións)",
   "casilla.listed_transmission_value": "Valor de transmisión (accións negociadas)",
   "casilla.listed_acquisition_value": "Valor de adquisición (accións negociadas)",
+  "casilla.acquisition_sale_rate_note": "O valor de adquisición móstrase ao tipo de cambio do BCE da data de VENDA, de xeito que transmisión − adquisición coincide exactamente coa ganancia ou perda (DGT V2422-20: a ganancia calcúlase na moeda da acción e só a diferenza se converte a euros). En valores en moeda estranxeira este importe difire do custo histórico en euros da data de compra e pode non coincidir con cifras gardadas en versións anteriores.",
   "casilla.other_transmission_value": "Valor de transmisión (outros elementos: opcións/cripto/fondos/divisa)",
   "casilla.other_acquisition_value": "Valor de adquisición (outros elementos: opcións/cripto/fondos/divisa)",
   "casilla.fx_transmission_value": "Valor de transmisión FX (moeda estranxeira)",

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -61,8 +61,18 @@ export interface Lot {
   acquireDate: string;
   quantity: Decimal;
   pricePerShare: Decimal;
-  costInEur: Decimal;
+  /**
+   * Total acquisition cost in the lot's OWN currency (FCY), commission and taxes
+   * included (a foreign-currency commission is homogenized to this currency at
+   * the trade-date cross-rate). Kept in FCY — NOT EUR — so the gain is computed
+   * in the share's currency and only the difference is converted to EUR at the
+   * disposal-date rate (DGT V2422-20 / V0152-26). Storing it in EUR at the
+   * buy-date rate would leak the currency's FX drift into the stock gain.
+   */
+  costInFcy: Decimal;
   currency: string;
+  /** ECB rate at acquisition — informational only (audit column); never used to
+   *  compute the gain, which converts the FCY difference at the disposal date. */
   ecbRate: Decimal;
   /** True for short lots (opened via SELL+O) */
   isShort?: boolean;
@@ -86,15 +96,30 @@ export interface FifoDisposal {
   sellDate: string;
   acquireDate: string;
   quantity: Decimal;
+  /**
+   * Gain/loss computed IN THE SHARE'S CURRENCY (proceedsFcy − costBasisFcy), the
+   * fiscally-correct base per DGT V2422-20 before EUR conversion.
+   */
+  gainLossFcy: Decimal;
+  /** Transmission value in the share's currency. */
+  proceedsFcy: Decimal;
+  /** Acquisition value in the share's currency (commission/taxes homogenized). */
+  costBasisFcy: Decimal;
+  /**
+   * EUR figures. ALL derived at the DISPOSAL-date ECB rate so that
+   * proceedsEur − costBasisEur === gainLossEur exactly and no FX drift leaks into
+   * the stock gain. proceedsEur/costBasisEur are therefore the sale-date EUR
+   * presentation of the FCY values, NOT the historical buy-date EUR cost.
+   */
   proceedsEur: Decimal;
   costBasisEur: Decimal;
   gainLossEur: Decimal;
   holdingPeriodDays: number;
   /** Original currency of the trade */
   currency: string;
-  /** ECB rate (EUR per 1 FCY) used for the sale */
+  /** ECB rate (EUR per 1 FCY) at the sale — used to convert the FCY gain. */
   sellEcbRate: Decimal;
-  /** ECB rate (EUR per 1 FCY) used for the acquisition */
+  /** ECB rate (EUR per 1 FCY) at acquisition — informational/audit only. */
   acquireEcbRate: Decimal;
   /** Asset category (STK, OPT, FUND, etc.) */
   assetCategory: string;

--- a/src/web/casilla-detail.ts
+++ b/src/web/casilla-detail.ts
@@ -56,6 +56,13 @@ function renderDisposalsDetail(
 ): string {
   if (disposals.length === 0) return `<p class="muted">${t("casilla.no_operations")}</p>`;
   const dateHeader = mode === "acquisition" ? t("table.buy_date") : t("table.sell_date");
+  // The acquisition value (0331/1637) is shown at the SALE-date ECB rate so that
+  // transmisión − adquisición equals the gain exactly (DGT V2422-20). For a
+  // foreign-currency holding this differs from the historical buy-date EUR cost,
+  // and from acquisition figures saved in earlier app versions / prior snapshots.
+  const note = mode === "acquisition"
+    ? `<p class="detail-note">${esc(t("casilla.acquisition_sale_rate_note"))}</p>`
+    : "";
   return `
     <p class="detail-label">${esc(label)} (${disposals.length})</p>
     <table class="detail-table">
@@ -72,7 +79,8 @@ function renderDisposalsDetail(
           <td>${fmtEur(mode === "acquisition" ? d.costBasisEur : d.proceedsEur)}</td>
         </tr>`).join("")}
       </tbody>
-    </table>`;
+    </table>
+    ${note}`;
 }
 
 /**

--- a/tests/engine/corporate-actions.test.ts
+++ b/tests/engine/corporate-actions.test.ts
@@ -103,8 +103,9 @@ describe("Corporate Actions in FIFO Engine", () => {
       engine.processTrades(trades, rateMap, corporateActions);
 
       const newLots = engine.getRemainingLots().get("US2222222222")!;
-      // Cost = 100 * 50 + 10 commission = 5010 EUR (rate = 1)
-      expect(newLots[0]!.costInEur.toFixed(2)).toBe("5010.00");
+      // Cost basis (in FCY) preserved through the tax-neutral merger:
+      // 100 * 50 + 10 commission = 5010 USD
+      expect(newLots[0]!.costInFcy.toFixed(2)).toBe("5010.00");
     });
 
     it("should apply merger ratio to quantity", () => {
@@ -251,9 +252,9 @@ describe("Corporate Actions in FIFO Engine", () => {
       const parentLots = engine.getRemainingLots().get("US1111111111")!;
       const spinLots = engine.getRemainingLots().get("US3333333333")!;
 
-      // Total original cost = 100 * 100 = 10000
-      const parentCost = parentLots[0]!.costInEur.toNumber();
-      const spinCost = spinLots[0]!.costInEur.toNumber();
+      // Total original cost (in FCY) = 100 * 100 = 10000
+      const parentCost = parentLots[0]!.costInFcy.toNumber();
+      const spinCost = spinLots[0]!.costInFcy.toNumber();
 
       // Total cost must be preserved
       expect(parentCost + spinCost).toBeCloseTo(10000, 2);

--- a/tests/engine/fifo.test.ts
+++ b/tests/engine/fifo.test.ts
@@ -1210,4 +1210,42 @@ describe("FCY-denominated stock gain (DGT V2422-20 / V0152-26, issue #219)", () 
     expect(d.gainLossFcy.toFixed(2)).toBe("300.00");
     expect(d.gainLossEur.toFixed(2)).toBe("330.00");
   });
+
+  it("converts every FIFO lot's FCY cost at the SINGLE sale-date rate", () => {
+    // Two lots bought at very different rates (0.80, 1.20); both must convert at
+    // the ONE sale-date rate (1.00), never at their own buy rates — the crux of
+    // V2422-20. Old method would mix per-lot buy rates into the EUR cost.
+    const rates = makeRateMap({ "2025-01-10": "0.80", "2025-03-15": "1.20", "2025-09-20": "1.00" });
+    const engine = new FifoEngine();
+    const ds = engine.processTrades(
+      [
+        makeTrade({ tradeID: "1", tradeDate: "2025-01-10", quantity: "5", tradePrice: "100", buySell: "BUY" }),
+        makeTrade({ tradeID: "2", tradeDate: "2025-03-15", quantity: "5", tradePrice: "100", buySell: "BUY" }),
+        makeTrade({ tradeID: "3", tradeDate: "2025-09-20", quantity: "-10", tradePrice: "150", buySell: "SELL" }),
+      ],
+      rates, [], [],
+    );
+    expect(ds).toHaveLength(2);
+    for (const d of ds) {
+      expect(d.costBasisFcy.toFixed(2)).toBe("500.00"); // 5 × 100 USD
+      expect(d.costBasisEur.toFixed(2)).toBe("500.00"); // × 1.00 sale rate (NOT 0.80/1.20)
+      expect(d.proceedsFcy.toFixed(2)).toBe("750.00");
+      expect(d.gainLossEur.toFixed(2)).toBe("250.00"); // 250 USD × 1.00
+    }
+  });
+
+  it("converts an FCY LOSS at the sale-date rate (not the buy rate)", () => {
+    // Buy 10 @100 USD (1000 USD), sell 10 @70 USD (700 USD) → −300 USD; rate 0.90→1.10.
+    const rates = makeRateMap({ "2025-03-15": "0.90", "2025-09-20": "1.10" });
+    const d = new FifoEngine().processTrades(
+      [
+        makeTrade({ buySell: "BUY", openCloseIndicator: "O", tradeDate: "2025-03-15", quantity: "10", tradePrice: "100", currency: "USD" }),
+        makeTrade({ buySell: "SELL", openCloseIndicator: "C", tradeDate: "2025-09-20", quantity: "10", tradePrice: "70", currency: "USD" }),
+      ],
+      rates, [], [],
+    )[0]!;
+    expect(d.gainLossFcy.toFixed(2)).toBe("-300.00");
+    // −300 × 1.10 = −330. Old buy/sell-mixed method gave 770−900 = −130 → fails on revert.
+    expect(d.gainLossEur.toFixed(2)).toBe("-330.00");
+  });
 });

--- a/tests/engine/fifo.test.ts
+++ b/tests/engine/fifo.test.ts
@@ -59,12 +59,13 @@ describe("FifoEngine", () => {
     expect(disposals).toHaveLength(1);
     const d = disposals[0]!;
 
-    // Cost: 10 * 100 USD * 0.92 = 920 EUR
-    expect(d.costBasisEur.toFixed(2)).toBe("920.00");
+    // Cost in USD (1000) converted at the SALE-date rate (DGT V2422-20):
+    // 10 * 100 USD * 0.91 = 910 EUR
+    expect(d.costBasisEur.toFixed(2)).toBe("910.00");
     // Proceeds: 10 * 120 USD * 0.91 = 1092 EUR
     expect(d.proceedsEur.toFixed(2)).toBe("1092.00");
-    // Gain: 1092 - 920 = 172 EUR
-    expect(d.gainLossEur.toFixed(2)).toBe("172.00");
+    // Gain: 1092 - 910 = 182 EUR (gain computed in USD = 200, × 0.91 sale rate)
+    expect(d.gainLossEur.toFixed(2)).toBe("182.00");
   });
 
   it("should consume lots in FIFO order", () => {
@@ -147,11 +148,12 @@ describe("FifoEngine", () => {
     const disposals = engine.processTrades(trades, rates);
 
     expect(disposals).toHaveLength(1);
-    // Cost: 5 × 3.00 × 100 × 0.92 = 1380.00 EUR
-    expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("1380.00");
+    // Cost in USD (1500) converted at the SALE-date rate: 5 × 3.00 × 100 × 0.91 = 1365.00 EUR
+    expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("1365.00");
     // Proceeds: 5 × 5.00 × 100 × 0.91 = 2275.00 EUR
     expect(disposals[0]!.proceedsEur.toFixed(2)).toBe("2275.00");
-    expect(disposals[0]!.gainLossEur.toFixed(2)).toBe("895.00");
+    // Gain in USD = 1000, × 0.91 sale rate = 910.00 EUR
+    expect(disposals[0]!.gainLossEur.toFixed(2)).toBe("910.00");
   });
 
   it("should group options by symbol when ISIN is blank", () => {
@@ -185,8 +187,8 @@ describe("FifoEngine", () => {
     const disposals = engine.processTrades(trades, rates);
 
     expect(disposals).toHaveLength(1);
-    // Cost from call lot: 5 × 3.00 × 100 × 0.92 = 1380.00
-    expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("1380.00");
+    // Cost from call lot in USD (1500) converted at the SALE-date rate (0.91): 5 × 3.00 × 100 × 0.91 = 1365.00
+    expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("1365.00");
     expect(engine.warnings).toHaveLength(0);
   });
 
@@ -222,8 +224,9 @@ describe("FifoEngine", () => {
     // After split: 10 shares → 100 shares at 100/share → costPerShare = 100
     // Sell 50 × $110 × 0.91 = $5005 EUR
     expect(disposals[0]!.proceedsEur.toFixed(2)).toBe("5005.00");
-    // Cost: 50/100 of original cost (10 × 1000 × 0.92 = 9200), so 4600
-    expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("4600.00");
+    // Cost in USD: 50/100 of original 10000 USD = 5000 USD, converted at the
+    // SALE-date rate (0.91): 5000 × 0.91 = 4550.00 EUR
+    expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("4550.00");
     // Split application generates an informational warning
     expect(engine.warnings).toHaveLength(1);
     expect(engine.warnings[0]).toContain("Split");
@@ -263,19 +266,21 @@ describe("FifoEngine", () => {
     const disposals = engine.processTrades(trades, rates);
 
     expect(disposals).toHaveLength(1);
-    // Buy cost: (100 × 50 + 10) × 0.92 = 4609.20 EUR for 100 shares
-    // Cost per share: 4609.20 / 100 = 46.092
-    // Disposal cost: 30 × 46.092 = 1382.76
-    expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("1382.76");
+    // Buy cost in USD: 100 × 50 + 10 = 5010 USD for 100 shares
+    // Cost per share: 5010 / 100 = 50.1 USD
+    // Disposal cost in USD: 30 × 50.1 = 1503 USD, converted at the SALE-date rate
+    // (0.91): 1503 × 0.91 = 1367.73 EUR
+    expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("1367.73");
     // Proceeds: (30 × 60 - 3) × 0.91 = 1635.27
     expect(disposals[0]!.proceedsEur.toFixed(2)).toBe("1635.27");
 
-    // Remaining lot should have 70 shares with proportional cost
+    // Remaining lot should have 70 shares with proportional cost (in FCY/USD)
     const remaining = engine.getRemainingLots();
     const lots = remaining.get("US0378331005")!;
     expect(lots).toHaveLength(1);
     expect(lots[0]!.quantity.toNumber()).toBe(70);
-    expect(lots[0]!.costInEur.toFixed(2)).toBe("3226.44");
+    // 70 × 50.1 = 3507.00 USD
+    expect(lots[0]!.costInFcy.toFixed(2)).toBe("3507.00");
   });
 
   it("should apply reverse split correctly", () => {
@@ -301,8 +306,9 @@ describe("FifoEngine", () => {
 
     expect(disposals).toHaveLength(1);
     // After 1:10 reverse split: 100 shares → 10 shares at $100/share
-    // Sell 5 of 10 → cost = 5/10 * (100*10*0.92) = 460
-    expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("460.00");
+    // Sell 5 of 10 → cost in USD = 5/10 * (100*10) = 500 USD, converted at the
+    // SALE-date rate (0.91): 500 × 0.91 = 455.00 EUR
+    expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("455.00");
     // Proceeds: 5 × $200 × 0.91 = 910
     expect(disposals[0]!.proceedsEur.toFixed(2)).toBe("910.00");
 
@@ -337,9 +343,10 @@ describe("FifoEngine", () => {
     const totalSold = disposals.reduce((sum, d) => sum.plus(d.quantity), new Decimal(0));
     expect(totalSold.toString()).toBe("12");
 
-    // Total cost: 920.00 (buy: 10×100×0.92) + 180.00 (scrip: 200×0.90)
+    // Cost basis is converted at the SALE-date rate (0.91, DGT V2422-20):
+    // buy 10 × 100 USD = 1000 USD × 0.91 = 910.00; scrip 2 shares = 200 USD × 0.91 = 182.00
     const totalCost = disposals.reduce((sum, d) => sum.plus(d.costBasisEur), new Decimal(0));
-    expect(totalCost.toFixed(2)).toBe("1100.00");
+    expect(totalCost.toFixed(2)).toBe("1092.00");
     expect(engine.warnings.some((w) => w.includes("Scrip dividend"))).toBe(true);
   });
 
@@ -475,8 +482,9 @@ describe("FifoEngine", () => {
     const disposals = engine.processTrades(trades, rates);
 
     expect(disposals).toHaveLength(1);
-    // Cost: (10 × 100 + 5 + 2) × 0.92 = 1007 × 0.92 = 926.44
-    expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("926.44");
+    // Cost in USD: 10 × 100 + 5 + 2 = 1007 USD, converted at the SALE-date rate
+    // (0.91): 1007 × 0.91 = 916.37 EUR
+    expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("916.37");
     // Proceeds: (10 × 120 - 5 - 3) × 0.91 = 1192 × 0.91 = 1084.72
     expect(disposals[0]!.proceedsEur.toFixed(2)).toBe("1084.72");
   });
@@ -629,14 +637,14 @@ describe("FifoEngine", () => {
       expect(disposals).toHaveLength(1);
       const d = disposals[0]!;
 
-      // Cost: 10 × 100 USD × 0.92 EUR/USD = 920.00 EUR
-      expect(d.costBasisEur.toFixed(2)).toBe("920.00");
+      // Cost in USD (1000) converted at the SALE-date rate (DGT V2422-20):
+      // 10 × 100 USD × 0.88 EUR/USD = 880.00 EUR
+      expect(d.costBasisEur.toFixed(2)).toBe("880.00");
       // Proceeds: 10 × 110 USD × 0.88 EUR/USD = 968.00 EUR
       expect(d.proceedsEur.toFixed(2)).toBe("968.00");
-      // Gain: 968 - 920 = 48.00 EUR
-      // Note: USD gained 10% in price but EUR/USD dropped from 0.92 to 0.88,
-      // so the EUR gain is smaller than the USD gain would suggest
-      expect(d.gainLossEur.toFixed(2)).toBe("48.00");
+      // Gain: the USD stock gain (100 USD) converted at the sale-date rate:
+      // 100 × 0.88 = 88.00 EUR. FX drift on the cost is a SEPARATE currency gain.
+      expect(d.gainLossEur.toFixed(2)).toBe("88.00");
 
       // ECB rates in disposal should reflect the USD rates used
       expect(d.acquireEcbRate.toFixed(4)).toBe("0.9200");
@@ -681,12 +689,13 @@ describe("FifoEngine", () => {
       expect(disposals).toHaveLength(1);
       const d = disposals[0]!;
 
-      // Cost: 10 × 25 GBP × 1.15 EUR/GBP = 287.50 EUR
-      expect(d.costBasisEur.toFixed(2)).toBe("287.50");
+      // Cost in GBP (250) converted at the SALE-date rate (DGT V2422-20):
+      // 10 × 25 GBP × 1.13 EUR/GBP = 282.50 EUR
+      expect(d.costBasisEur.toFixed(2)).toBe("282.50");
       // Proceeds: 10 × 28 GBP × 1.13 EUR/GBP = 316.40 EUR
       expect(d.proceedsEur.toFixed(2)).toBe("316.40");
-      // Gain: 316.40 - 287.50 = 28.90 EUR
-      expect(d.gainLossEur.toFixed(2)).toBe("28.90");
+      // Gain: GBP stock gain (30 GBP) × sale-date rate 1.13 = 33.90 EUR
+      expect(d.gainLossEur.toFixed(2)).toBe("33.90");
       expect(d.currency).toBe("GBP");
     });
 
@@ -723,17 +732,21 @@ describe("FifoEngine", () => {
       expect(disposals).toHaveLength(1);
       const d = disposals[0]!;
 
-      // Cost: 10 × 100 × 0.92 = 920.00 EUR
-      expect(d.costBasisEur.toFixed(2)).toBe("920.00");
+      // Under DGT V2422-20 the stock gain is computed in USD (1000 − 1000 = 0)
+      // and converted at the sale-date rate, so the STOCK gain is exactly 0.
+      // The FX move (0.92 → 0.95) is a SEPARATE currency gain handled by the FX
+      // engine — it no longer leaks into the stock gain.
+      // Cost: 10 × 100 × 0.95 (sale-date rate) = 950.00 EUR
+      expect(d.costBasisEur.toFixed(2)).toBe("950.00");
       // Proceeds: 10 × 100 × 0.95 = 950.00 EUR
       expect(d.proceedsEur.toFixed(2)).toBe("950.00");
-      // Gain is purely from FX: 950 - 920 = 30.00 EUR
-      expect(d.gainLossEur.toFixed(2)).toBe("30.00");
+      // Stock gain is exactly 0 (FX gain is tracked separately).
+      expect(d.gainLossEur.toFixed(2)).toBe("0.00");
     });
   });
 
   describe("Commission in different currency", () => {
-    it("should convert commission separately when commissionCurrency differs from trade currency", () => {
+    it("should homogenize commission into the share currency when commissionCurrency differs from trade currency", () => {
       const rates: EcbRateMap = new Map();
       rates.set("2025-03-15", new Map([["USD", "0.92"], ["GBP", "1.15"]]));
       rates.set("2025-09-20", new Map([["USD", "0.88"], ["GBP", "1.12"]]));
@@ -766,9 +779,12 @@ describe("FifoEngine", () => {
 
       expect(disposals).toHaveLength(1);
       const d = disposals[0]!;
-      // BUY cost: 10×100×0.92 + 5×1.15 = 920 + 5.75 = 925.75
-      expect(d.costBasisEur.toFixed(2)).toBe("925.75");
-      // SELL proceeds: 10×110×0.88 - 5×1.12 = 968 - 5.60 = 962.40
+      // BUY cost in USD: 10×100 + commission homogenized to USD via the trade-date
+      // cross-rate (5 GBP × 1.15/0.92 = 6.25 USD) = 1006.25 USD. Converted at the
+      // SALE-date rate (0.88, DGT V2422-20): 1006.25 × 0.88 = 885.50 EUR
+      expect(d.costBasisEur.toFixed(2)).toBe("885.50");
+      // SELL proceeds in USD: 10×110 − commission homogenized to USD
+      // (5 GBP × 1.12/0.88 = 6.3636 USD) = 1093.6364 USD. × 0.88 = 962.40 EUR
       expect(d.proceedsEur.toFixed(2)).toBe("962.40");
     });
   });
@@ -905,12 +921,14 @@ describe("FifoEngine", () => {
       expect(disposals).toHaveLength(1);
       const d = disposals[0]!;
       expect(d.isShort).toBe(true);
-      // proceeds = premium received = 10 * 150 * 0.92 = 1380
-      expect(d.proceedsEur.toFixed(2)).toBe("1380.00");
-      // cost = buy-to-close = 10 * 140 * 0.91 = 1274
+      // Gain computed in the share currency (USD), converted at the CLOSE-date
+      // rate (DGT V2422-20): gain_usd = 10*150 - 10*140 = 100 USD; ×0.91 = 91.
+      expect(d.gainLossFcy.toFixed(2)).toBe("100.00");
+      // Both legs displayed at the close-date rate (0.91): proceeds 1500×0.91,
+      // cost 1400×0.91, so proceeds − cost === gain exactly.
+      expect(d.proceedsEur.toFixed(2)).toBe("1365.00");
       expect(d.costBasisEur.toFixed(2)).toBe("1274.00");
-      // gain = 1380 - 1274 = 106
-      expect(d.gainLossEur.toFixed(2)).toBe("106.00");
+      expect(d.gainLossEur.toFixed(2)).toBe("91.00");
     });
 
     it("should handle short sale at a loss", () => {
@@ -932,12 +950,13 @@ describe("FifoEngine", () => {
       expect(disposals).toHaveLength(1);
       const d = disposals[0]!;
       expect(d.isShort).toBe(true);
-      // proceeds = 10 * 100 * 0.92 = 920
-      expect(d.proceedsEur.toFixed(2)).toBe("920.00");
-      // cost = 10 * 130 * 0.91 = 1183
+      // Short gain computed in USD, converted at the CLOSE-date rate (0.91):
+      // open proceeds = 10 * 100 * 0.91 = 910
+      expect(d.proceedsEur.toFixed(2)).toBe("910.00");
+      // close cost = 10 * 130 * 0.91 = 1183
       expect(d.costBasisEur.toFixed(2)).toBe("1183.00");
-      // loss = 920 - 1183 = -263
-      expect(d.gainLossEur.toFixed(2)).toBe("-263.00");
+      // loss in USD = 1000 - 1300 = -300, × 0.91 = -273.00
+      expect(d.gainLossEur.toFixed(2)).toBe("-273.00");
     });
 
     it("should consume short lots in FIFO order", () => {
@@ -965,10 +984,11 @@ describe("FifoEngine", () => {
       expect(disposals).toHaveLength(2);
       // First disposal consumes the Jan short lot
       expect(disposals[0]!.acquireDate).toBe("2025-01-10");
-      expect(disposals[0]!.proceedsEur.toFixed(2)).toBe("450.00"); // 5*100*0.90
+      // Open proceeds converted at the CLOSE-date rate (0.91): 5*100*0.91
+      expect(disposals[0]!.proceedsEur.toFixed(2)).toBe("455.00");
       // Second disposal consumes the Mar short lot
       expect(disposals[1]!.acquireDate).toBe("2025-03-15");
-      expect(disposals[1]!.proceedsEur.toFixed(2)).toBe("506.00"); // 5*110*0.92
+      expect(disposals[1]!.proceedsEur.toFixed(2)).toBe("500.50"); // 5*110*0.91
     });
 
     it("should fall back to addLot when BUY+C has no short lots", () => {
@@ -1033,11 +1053,13 @@ describe("FifoEngine", () => {
       expect(disposals).toHaveLength(1);
       const d = disposals[0]!;
       expect(d.isShort).toBe(true);
-      // proceeds = 1 * 5 * 100 * 0.92 = 460
-      expect(d.proceedsEur.toFixed(2)).toBe("460.00");
-      // cost = 1 * 2 * 100 * 0.91 = 182
+      // Short gain computed in USD, converted at the CLOSE-date rate (0.91):
+      // open proceeds = 1 * 5 * 100 * 0.91 = 455
+      expect(d.proceedsEur.toFixed(2)).toBe("455.00");
+      // close cost = 1 * 2 * 100 * 0.91 = 182
       expect(d.costBasisEur.toFixed(2)).toBe("182.00");
-      expect(d.gainLossEur.toFixed(2)).toBe("278.00");
+      // gain in USD = 500 - 200 = 300, × 0.91 = 273.00
+      expect(d.gainLossEur.toFixed(2)).toBe("273.00");
     });
 
     it("should handle short option expiring worthless (BUY+C at price 0)", () => {
@@ -1061,12 +1083,13 @@ describe("FifoEngine", () => {
       expect(disposals).toHaveLength(1);
       const d = disposals[0]!;
       expect(d.isShort).toBe(true);
-      // proceeds = 1 * 3.50 * 100 * 0.92 = 322.00
-      expect(d.proceedsEur.toFixed(2)).toBe("322.00");
-      // cost = 1 * 0 * 100 * 0.91 = 0
+      // Short gain converted at the CLOSE-date rate (0.91, DGT V2422-20):
+      // open proceeds = 1 * 3.50 * 100 * 0.91 = 318.50
+      expect(d.proceedsEur.toFixed(2)).toBe("318.50");
+      // close cost = 1 * 0 * 100 * 0.91 = 0
       expect(d.costBasisEur.toFixed(2)).toBe("0.00");
-      // gain = full premium
-      expect(d.gainLossEur.toFixed(2)).toBe("322.00");
+      // gain = full premium in USD (350) × 0.91 = 318.50
+      expect(d.gainLossEur.toFixed(2)).toBe("318.50");
     });
   });
 
@@ -1094,8 +1117,9 @@ describe("FifoEngine", () => {
       expect(disposals).toHaveLength(1);
       expect(disposals[0]!.acquireDate).toBe("2025-01-10");
       expect(disposals[0]!.quantity.toString()).toBe("10");
-      // Cost basis = January lot: 10 × 100 × 0.90 = 900.00 (not the 200-priced same-day buy)
-      expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("900.00");
+      // Cost basis = January lot in USD (1000), converted at the SALE-date rate
+      // (0.91, DGT V2422-20): 10 × 100 × 0.91 = 910.00 (not the 200-priced same-day buy)
+      expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("910.00");
 
       // The same-day BUY lot remains untouched (10 @ 200)
       const remaining = engine.getRemainingLots().get("US0378331005") ?? [];
@@ -1126,13 +1150,64 @@ describe("FifoEngine", () => {
       const engine = new FifoEngine();
       engine.processTrades(trades, rates, corporateActions);
 
-      // Original total cost: 25 × 10 × 0.92 = 230.00 EUR
+      // Original total cost in USD (FCY): 25 × 10 = 250.00 USD
       const remaining = engine.getRemainingLots().get("US1234567890") ?? [];
       // 2.5 shares → 2 whole shares survive, 0.5 becomes cash-in-lieu
       expect(remaining).toHaveLength(1);
       expect(remaining[0]!.quantity.toString()).toBe("2.5");
-      // Total cost basis must be fully conserved on the surviving lot (230.00)
-      expect(remaining[0]!.costInEur.toFixed(2)).toBe("230.00");
+      // Total cost basis (in FCY/USD) must be fully conserved on the surviving lot
+      expect(remaining[0]!.costInFcy.toFixed(2)).toBe("250.00");
     });
+  });
+});
+
+describe("FCY-denominated stock gain (DGT V2422-20 / V0152-26, issue #219)", () => {
+  it("yields 0 EUR gain when a USD stock is sold flat in USD despite an FX rate change", () => {
+    // The V2422-20 worked example: buy 10 GOOG @120 USD (1200 USD), sell 10 @120
+    // USD (1200 USD). Stock P&L in USD = 0 → EUR gain MUST be 0, even though the
+    // USD/EUR rate moved 1.3 → 1.5 between buy and sell. The FX move is a SEPARATE
+    // currency gain (Art. 33, handled by the FX engine), not a stock gain.
+    const rates = makeRateMap({
+      "2025-10-08": "1.30", // buy date
+      "2025-10-15": "1.50", // sell date (rate moved, must NOT leak into stock gain)
+    });
+    const engine = new FifoEngine();
+    engine.processTrades(
+      [
+        makeTrade({ symbol: "GOOG", isin: "US02079K1079", buySell: "BUY", openCloseIndicator: "O",
+          tradeDate: "2025-10-08", quantity: "10", tradePrice: "120", currency: "USD" }),
+        makeTrade({ symbol: "GOOG", isin: "US02079K1079", buySell: "SELL", openCloseIndicator: "C",
+          tradeDate: "2025-10-15", quantity: "10", tradePrice: "120", currency: "USD" }),
+      ],
+      rates, [], [],
+    );
+    const disposals = engine.getDisposals();
+    expect(disposals).toHaveLength(1);
+    const d = disposals[0]!;
+    // Gain in the share currency is exactly 0 → EUR gain is exactly 0.
+    expect(d.gainLossFcy.toFixed(2)).toBe("0.00");
+    expect(d.gainLossEur.toFixed(2)).toBe("0.00");
+    // proceeds and cost are presented at the SAME (sale-date) rate, so
+    // proceedsEur - costBasisEur === gainLossEur exactly.
+    expect(d.proceedsEur.minus(d.costBasisEur).toFixed(2)).toBe("0.00");
+    expect(d.proceedsEur.toFixed(2)).toBe("1800.00"); // 1200 USD × 1.50
+    expect(d.costBasisEur.toFixed(2)).toBe("1800.00"); // 1200 USD × 1.50 (sale-date rate)
+  });
+
+  it("converts a real USD stock gain at the sale-date rate (not the buy-date rate)", () => {
+    // Buy 10 @100 USD (1000 USD), sell 10 @130 USD (1300 USD) → +300 USD stock gain.
+    // Convert the DIFFERENCE at the sale-date rate: 300 × 1.10 = 330 EUR.
+    const rates = makeRateMap({ "2025-03-15": "0.90", "2025-09-20": "1.10" });
+    const engine = new FifoEngine();
+    engine.processTrades(
+      [
+        makeTrade({ buySell: "BUY", openCloseIndicator: "O", tradeDate: "2025-03-15", quantity: "10", tradePrice: "100", currency: "USD" }),
+        makeTrade({ buySell: "SELL", openCloseIndicator: "C", tradeDate: "2025-09-20", quantity: "10", tradePrice: "130", currency: "USD" }),
+      ],
+      rates, [], [],
+    );
+    const d = engine.getDisposals()[0]!;
+    expect(d.gainLossFcy.toFixed(2)).toBe("300.00");
+    expect(d.gainLossEur.toFixed(2)).toBe("330.00");
   });
 });

--- a/tests/engine/multi-currency.test.ts
+++ b/tests/engine/multi-currency.test.ts
@@ -55,15 +55,17 @@ describe("Multi-currency commission handling", () => {
 
     expect(disposals).toHaveLength(1);
     const d = disposals[0]!;
-    // Cost: (10 * 100 + 5) * 0.92 = 1005 * 0.92 = 924.60 EUR
-    expect(d.costBasisEur.toFixed(2)).toBe("924.60");
+    // Cost in USD (1005) converted at the SALE-date rate (DGT V2422-20):
+    // (10 * 100 + 5) * 0.91 = 1005 * 0.91 = 914.55 EUR
+    expect(d.costBasisEur.toFixed(2)).toBe("914.55");
     // Proceeds: (10 * 120 - 5) * 0.91 = 1195 * 0.91 = 1087.45 EUR
     expect(d.proceedsEur.toFixed(2)).toBe("1087.45");
-    expect(d.gainLossEur.toFixed(2)).toBe("162.85");
+    // Gain in USD = 190, × 0.91 = 172.90 EUR
+    expect(d.gainLossEur.toFixed(2)).toBe("172.90");
   });
 
-  it("should convert commission separately when commissionCurrency differs from trade currency", () => {
-    // USD stock, GBP commission — commission must use GBP ECB rate
+  it("should homogenize commission into the share currency when commissionCurrency differs from trade currency", () => {
+    // USD stock, GBP commission — commission homogenized to USD via the trade-date cross-rate
     const rates: EcbRateMap = new Map();
     rates.set("2025-03-15", new Map([["USD", "0.9200"], ["GBP", "1.1500"]]));
     rates.set("2025-09-20", new Map([["USD", "0.9100"], ["GBP", "1.1300"]]));
@@ -84,11 +86,15 @@ describe("Multi-currency commission handling", () => {
 
     expect(disposals).toHaveLength(1);
     const d = disposals[0]!;
-    // Buy cost: (10 * 100) * 0.92 + 5 * 1.15 = 920 + 5.75 = 925.75 EUR
-    expect(d.costBasisEur.toFixed(2)).toBe("925.75");
-    // Sell proceeds: (10 * 120) * 0.91 - 5 * 1.13 = 1092 - 5.65 = 1086.35 EUR
+    // Buy cost in USD: 10*100 + commission homogenized to USD via the trade-date
+    // cross-rate (5 GBP × 1.15/0.92 = 6.25 USD) = 1006.25 USD. Converted at the
+    // SALE-date rate (0.91, DGT V2422-20): 1006.25 * 0.91 = 915.69 EUR
+    expect(d.costBasisEur.toFixed(2)).toBe("915.69");
+    // Sell proceeds in USD: 10*120 − commission homogenized to USD
+    // (5 GBP × 1.13/0.91 = 6.2088 USD) = 1193.7912 USD. × 0.91 = 1086.35 EUR
     expect(d.proceedsEur.toFixed(2)).toBe("1086.35");
-    expect(d.gainLossEur.toFixed(2)).toBe("160.60");
+    // Gain = 1086.35 − 915.69 = 170.66 EUR
+    expect(d.gainLossEur.toFixed(2)).toBe("170.66");
   });
 
   it("should skip commission rate lookup when commission is zero", () => {
@@ -114,8 +120,8 @@ describe("Multi-currency commission handling", () => {
 
     expect(disposals).toHaveLength(1);
     const d = disposals[0]!;
-    // No commission, so just qty * price * rate
-    expect(d.costBasisEur.toFixed(2)).toBe("920.00");
+    // No commission — cost in USD (1000) converted at the SALE-date rate (0.91): 910.00
+    expect(d.costBasisEur.toFixed(2)).toBe("910.00");
     expect(d.proceedsEur.toFixed(2)).toBe("1092.00");
   });
 
@@ -141,11 +147,15 @@ describe("Multi-currency commission handling", () => {
 
     expect(disposals).toHaveLength(1);
     const d = disposals[0]!;
-    // Buy cost: (10 * 100) * 0.92 + 10 * 1.00 = 920 + 10 = 930.00 EUR
-    expect(d.costBasisEur.toFixed(2)).toBe("930.00");
-    // Sell proceeds: (10 * 120) * 0.91 - 8 * 1.00 = 1092 - 8 = 1084.00 EUR
+    // Buy cost in USD: 10*100 + commission homogenized to USD via the trade-date
+    // cross-rate (10 EUR × 1.00/0.92 = 10.8696 USD) = 1010.8696 USD. Converted at
+    // the SALE-date rate (0.91, DGT V2422-20): 1010.8696 * 0.91 = 919.89 EUR
+    expect(d.costBasisEur.toFixed(2)).toBe("919.89");
+    // Sell proceeds in USD: 10*120 − (8 EUR × 1.00/0.91 = 8.7912 USD) = 1191.2088 USD
+    // × 0.91 = 1084.00 EUR
     expect(d.proceedsEur.toFixed(2)).toBe("1084.00");
-    expect(d.gainLossEur.toFixed(2)).toBe("154.00");
+    // Gain = 1084.00 − 919.89 = 164.11 EUR
+    expect(d.gainLossEur.toFixed(2)).toBe("164.11");
   });
 
   it("should handle multiple trades with mixed commission currencies", () => {
@@ -179,15 +189,19 @@ describe("Multi-currency commission handling", () => {
     expect(disposals).toHaveLength(2);
 
     const d1 = disposals[0]!;
-    // Lot 1 cost: (5 * 80) * 0.90 + 4 * 0.90 = 360 + 3.60 = 363.60 EUR
-    expect(d1.costBasisEur.toFixed(2)).toBe("363.60");
-    // Sell proceeds for 5 shares (fraction 5/10 = 0.5): (5 * 110) * 0.91 - 3 * 1.00 = 500.50 - 3.00 = 497.50
+    // Lot 1 cost in USD: 5*80 + 4 USD commission = 404 USD, converted at the
+    // SALE-date rate (0.91, DGT V2422-20): 404 * 0.91 = 367.64 EUR
+    expect(d1.costBasisEur.toFixed(2)).toBe("367.64");
+    // Sell proceeds for 5 shares (fraction 5/10 = 0.5): proceeds in USD =
+    // 5*110 − (3 EUR × 1.00/0.91 = 3.2967 USD) = 546.7033 USD × 0.91 = 497.50
     expect(d1.proceedsEur.toFixed(2)).toBe("497.50");
 
     const d2 = disposals[1]!;
-    // Lot 2 cost: (5 * 100) * 0.92 + 3 * 1.13 = 460 + 3.39 = 463.39 EUR
-    expect(d2.costBasisEur.toFixed(2)).toBe("463.39");
-    // Sell proceeds for 5 shares (fraction 5/10 = 0.5): (5 * 110) * 0.91 - 3 * 1.00 = 500.50 - 3.00 = 497.50
+    // Lot 2 cost in USD: 5*100 + commission homogenized to USD
+    // (3 GBP × 1.13/0.92 = 3.6848 USD) = 503.6848 USD. Converted at the
+    // SALE-date rate (0.91): 503.6848 * 0.91 = 458.35 EUR
+    expect(d2.costBasisEur.toFixed(2)).toBe("458.35");
+    // Sell proceeds for 5 shares (fraction 5/10 = 0.5): same as d1 = 497.50
     expect(d2.proceedsEur.toFixed(2)).toBe("497.50");
   });
 });

--- a/tests/engine/options-v0137-23.test.ts
+++ b/tests/engine/options-v0137-23.test.ts
@@ -118,10 +118,11 @@ describe("Options taxation — DGT V0137-23 (Art. 37.1.m LIRPF)", () => {
       expect(d.putCall).toBe("C");
       expect(d.strike).toBe("200");
       expect(d.proceedsEur.toFixed(2)).toBe("0.00");
-      // Cost = 1 contract × $5.50 × 100 multiplier × 0.92 + $1.50 commission × 0.92
-      // = 550 * 0.92 + 1.50 * 0.92 = 506.00 + 1.38 = 507.38
-      expect(d.costBasisEur.toFixed(2)).toBe("507.38");
-      expect(d.gainLossEur.toFixed(2)).toBe("-507.38");
+      // Premium cost in USD (FCY): 1 × 5.50 × 100 + 1.50 commission = 551.50 USD.
+      // On expiration the premium is converted at the EXPIRATION-date rate
+      // (2025-03-21 = 0.94, DGT V2422-20): 551.50 × 0.94 = 518.41 EUR
+      expect(d.costBasisEur.toFixed(2)).toBe("518.41");
+      expect(d.gainLossEur.toFixed(2)).toBe("-518.41");
     });
 
     it("writer: option expires worthless → full premium gain", () => {
@@ -145,10 +146,12 @@ describe("Options taxation — DGT V0137-23 (Art. 37.1.m LIRPF)", () => {
       expect(d.assetCategory).toBe("OPT");
       expect(d.optionScenario).toBe("expiration");
       expect(d.isShort).toBe(true);
-      // Writer received premium: 1 × 5.50 × 100 × 0.92 - 1.50 × 0.92 = 506.00 - 1.38 = 504.62
-      expect(d.proceedsEur.toFixed(2)).toBe("504.62");
+      // Writer's premium received in USD (FCY): 1 × 5.50 × 100 − 1.50 = 548.50 USD.
+      // Converted at the EXPIRATION-date rate (2025-03-21 = 0.94, DGT V2422-20):
+      // 548.50 × 0.94 = 515.59 EUR
+      expect(d.proceedsEur.toFixed(2)).toBe("515.59");
       expect(d.costBasisEur.toFixed(2)).toBe("0.00");
-      expect(d.gainLossEur.toFixed(2)).toBe("504.62");
+      expect(d.gainLossEur.toFixed(2)).toBe("515.59");
     });
   });
 
@@ -179,8 +182,9 @@ describe("Options taxation — DGT V0137-23 (Art. 37.1.m LIRPF)", () => {
       expect(d.putCall).toBe("C");
       // Proceeds: 1 × 8.00 × 100 × 0.94 - 1.50 × 0.94 = 752.00 - 1.41 = 750.59
       expect(d.proceedsEur.toFixed(2)).toBe("750.59");
-      // Cost: 507.38 (as calculated above)
-      expect(d.costBasisEur.toFixed(2)).toBe("507.38");
+      // Cost: premium in USD (551.50) converted at the SALE-date rate (0.94,
+      // DGT V2422-20): 551.50 × 0.94 = 518.41 EUR
+      expect(d.costBasisEur.toFixed(2)).toBe("518.41");
       expect(d.gainLossEur.greaterThan(0)).toBe(true);
     });
 
@@ -211,9 +215,10 @@ describe("Options taxation — DGT V0137-23 (Art. 37.1.m LIRPF)", () => {
       const d = disposals[0]!;
       expect(d.isShort).toBe(true);
       expect(d.assetCategory).toBe("OPT");
-      // Writer opened at $5.50: proceeds = 504.62 (premium received minus commission)
-      // Writer closed at $3.00: cost = 1 × 3.00 × 100 × 0.93 + 1.50 × 0.93 = 279.00 + 1.395 = 280.395
-      expect(d.proceedsEur.toFixed(2)).toBe("504.62");
+      // Writer opened at $5.50: open proceeds in USD = 5.50 × 100 − 1.50 = 548.50 USD.
+      // Short close converts at the CLOSE-date rate (2025-02-01 = 0.93, DGT V2422-20):
+      // 548.50 × 0.93 = 510.11 EUR. Close cost in USD = 3.00 × 100 + 1.50 = 301.50 USD.
+      expect(d.proceedsEur.toFixed(2)).toBe("510.11");
       expect(d.gainLossEur.greaterThan(0)).toBe(true);
     });
   });
@@ -234,9 +239,10 @@ describe("Options taxation — DGT V0137-23 (Art. 37.1.m LIRPF)", () => {
       expect(lots).toHaveLength(1);
       expect(lots![0]!.quantity.toString()).toBe("100");
       expect(lots![0]!.pricePerShare.toString()).toBe("200");
-      // Cost > bare strike cost (18800) because premium is integrated
-      const bareStrikeCost = new Decimal("18800");
-      expect(lots![0]!.costInEur.greaterThan(bareStrikeCost)).toBe(true);
+      // Cost (now in FCY/USD) > bare strike cost in USD (100 × 200 = 20000)
+      // because the premium is integrated.
+      const bareStrikeCost = new Decimal("20000");
+      expect(lots![0]!.costInFcy.greaterThan(bareStrikeCost)).toBe(true);
     });
 
     it("call buyer exercises → uses STRIKE for share cost, ignores market price", () => {
@@ -256,11 +262,11 @@ describe("Options taxation — DGT V0137-23 (Art. 37.1.m LIRPF)", () => {
       expect(lots).toHaveLength(1);
       // Share price = strike ($200), NOT market price ($220)
       expect(lots![0]!.pricePerShare.toString()).toBe("200");
-      // Base cost at strike: 100 × $200 × 0.94 = 18800, plus integrated premium
-      const bareStrikeCost = new Decimal("18800");
-      expect(lots![0]!.costInEur.greaterThan(bareStrikeCost)).toBe(true);
-      // Must be well below the market-priced cost (100 × $220 × 0.94 = 20680)
-      expect(lots![0]!.costInEur.lessThan(new Decimal("20680"))).toBe(true);
+      // Base cost at strike in USD (FCY): 100 × $200 = 20000, plus integrated premium
+      const bareStrikeCost = new Decimal("20000");
+      expect(lots![0]!.costInFcy.greaterThan(bareStrikeCost)).toBe(true);
+      // Must be well below the market-priced cost in USD (100 × $220 = 22000)
+      expect(lots![0]!.costInFcy.lessThan(new Decimal("22000"))).toBe(true);
     });
 
     it("put buyer exercises → no OPT disposal, premium reduces sale proceeds", () => {
@@ -294,7 +300,9 @@ describe("Options taxation — DGT V0137-23 (Art. 37.1.m LIRPF)", () => {
       // Proceeds < bare strike proceeds (18800) because premium is subtracted
       const bareStrikeProceeds = new Decimal("18800");
       expect(disposals[0]!.proceedsEur.lessThan(bareStrikeProceeds)).toBe(true);
-      expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("16560.92");
+      // Stock cost basis in USD: 100 × 180 + 1 commission = 18001 USD. Converted at
+      // the EXERCISE-date rate (2025-03-21 = 0.94, DGT V2422-20): 18001 × 0.94 = 16920.94 EUR
+      expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("16920.94");
     });
 
     it("call writer assigned → no OPT disposal, premium adds to sale proceeds", () => {
@@ -356,9 +364,10 @@ describe("Options taxation — DGT V0137-23 (Art. 37.1.m LIRPF)", () => {
       expect(lots).toHaveLength(1);
       expect(lots![0]!.quantity.toString()).toBe("100");
       expect(lots![0]!.pricePerShare.toString()).toBe("200");
-      // Cost < bare strike cost (18800) because writer's premium reduces it
-      const bareStrikeCost = new Decimal("18800");
-      expect(lots![0]!.costInEur.lessThan(bareStrikeCost)).toBe(true);
+      // Cost (now in FCY/USD) < bare strike cost in USD (100 × 200 = 20000)
+      // because the writer's premium reduces it.
+      const bareStrikeCost = new Decimal("20000");
+      expect(lots![0]!.costInFcy.lessThan(bareStrikeCost)).toBe(true);
     });
   });
 

--- a/tests/engine/phase5-assets.test.ts
+++ b/tests/engine/phase5-assets.test.ts
@@ -170,12 +170,13 @@ describe("Phase 5 — Bonds (BOND)", () => {
     expect(disposals).toHaveLength(1);
     const d = disposals[0]!;
 
-    // Cost: 10 * 98 * 1 * 0.92 = 901.60 EUR
-    expect(d.costBasisEur.toFixed(2)).toBe("901.60");
+    // Cost in USD (980) converted at the SALE-date rate (DGT V2422-20):
+    // 10 * 98 * 1 * 0.91 = 891.80 EUR
+    expect(d.costBasisEur.toFixed(2)).toBe("891.80");
     // Proceeds: 10 * 102 * 1 * 0.91 = 928.20 EUR
     expect(d.proceedsEur.toFixed(2)).toBe("928.20");
-    // Gain: 928.20 - 901.60 = 26.60 EUR
-    expect(d.gainLossEur.toFixed(2)).toBe("26.60");
+    // Gain in USD = 40, × 0.91 = 36.40 EUR
+    expect(d.gainLossEur.toFixed(2)).toBe("36.40");
     expect(d.assetCategory).toBe("BOND");
   });
 
@@ -362,12 +363,13 @@ describe("Phase 5 — Options (OPT)", () => {
     expect(disposals).toHaveLength(1);
     const d = disposals[0]!;
 
-    // Cost: 5 * 3.00 * 100 * 0.92 = 1,380.00 EUR
-    expect(d.costBasisEur.toFixed(2)).toBe("1380.00");
+    // Cost in USD (1500) converted at the SALE-date rate (DGT V2422-20):
+    // 5 * 3.00 * 100 * 0.91 = 1,365.00 EUR
+    expect(d.costBasisEur.toFixed(2)).toBe("1365.00");
     // Proceeds: 5 * 5.00 * 100 * 0.91 = 2,275.00 EUR
     expect(d.proceedsEur.toFixed(2)).toBe("2275.00");
-    // Gain: 2275 - 1380 = 895.00 EUR
-    expect(d.gainLossEur.toFixed(2)).toBe("895.00");
+    // Gain in USD = 1000, × 0.91 = 910.00 EUR
+    expect(d.gainLossEur.toFixed(2)).toBe("910.00");
     expect(d.assetCategory).toBe("OPT");
   });
 
@@ -507,12 +509,15 @@ describe("Phase 5 — Multi-divisa (cross-currency)", () => {
     expect(disposals).toHaveLength(1);
     const d = disposals[0]!;
 
-    // Buy cost: (100 * 25 * 1 * 1.15) + (10 * 0.92) = 2875.00 + 9.20 = 2884.20 EUR
-    expect(d.costBasisEur.toFixed(2)).toBe("2884.20");
-    // Sell proceeds: (100 * 28 * 1 * 1.13) - (10 * 0.91) = 3164.00 - 9.10 = 3154.90 EUR
+    // Buy cost in GBP: 100*25 + commission homogenized to GBP via the trade-date
+    // cross-rate (10 USD × 0.92/1.15 = 8.0 GBP) = 2508 GBP. Converted at the
+    // SALE-date rate (1.13, DGT V2422-20): 2508 * 1.13 = 2834.04 EUR
+    expect(d.costBasisEur.toFixed(2)).toBe("2834.04");
+    // Sell proceeds in GBP: 100*28 − (10 USD × 0.91/1.13 = 8.0531 GBP) = 2791.9469 GBP
+    // × 1.13 = 3154.90 EUR
     expect(d.proceedsEur.toFixed(2)).toBe("3154.90");
-    // Gain: 3154.90 - 2884.20 = 270.70 EUR
-    expect(d.gainLossEur.toFixed(2)).toBe("270.70");
+    // Gain = 3154.90 − 2834.04 = 320.86 EUR
+    expect(d.gainLossEur.toFixed(2)).toBe("320.86");
 
     // ECB rates should reflect trade currency (GBP), not commission currency
     expect(d.acquireEcbRate.toFixed(4)).toBe("1.1500");
@@ -628,8 +633,9 @@ describe("Phase 5 — Short positions", () => {
 
     // First disposal: 10 shares consumed from lot
     expect(disposals[0]!.quantity.toNumber()).toBe(10);
-    // Cost: 10 * 100 * 0.92 = 920.00 EUR
-    expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("920.00");
+    // Cost in USD (1000) converted at the SALE-date rate (DGT V2422-20):
+    // 10 * 100 * 0.91 = 910.00 EUR
+    expect(disposals[0]!.costBasisEur.toFixed(2)).toBe("910.00");
     // Proceeds: (10 * 120) * 0.91 * (10/25) share... actually full per consumed
     // Proceeds: 10/25 fraction of total: (10 * 120 * 0.91) = 1092 * (10/25)...
     // No: proceeds per consumed = consumed * price * mult * ecbRate - commShare

--- a/tests/generators/modelo720.test.ts
+++ b/tests/generators/modelo720.test.ts
@@ -100,8 +100,8 @@ describe("Modelo 720 Generator", () => {
     const positions = [makePosition()];
     const lots: Map<string, Lot[]> = new Map([
       ["US78462F1030", [
-        { id: "1", isin: "US78462F1030", symbol: "SPY", description: "", acquireDate: "20230115", quantity: new Decimal(50), pricePerShare: new Decimal(380), costInEur: new Decimal(17480), currency: "USD", ecbRate: new Decimal("0.92") },
-        { id: "2", isin: "US78462F1030", symbol: "SPY", description: "", acquireDate: "20240601", quantity: new Decimal(50), pricePerShare: new Decimal(420), costInEur: new Decimal(19320), currency: "USD", ecbRate: new Decimal("0.92") },
+        { id: "1", isin: "US78462F1030", symbol: "SPY", description: "", acquireDate: "20230115", quantity: new Decimal(50), pricePerShare: new Decimal(380), costInFcy: new Decimal(19000), currency: "USD", ecbRate: new Decimal("0.92") },
+        { id: "2", isin: "US78462F1030", symbol: "SPY", description: "", acquireDate: "20240601", quantity: new Decimal(50), pricePerShare: new Decimal(420), costInFcy: new Decimal(21000), currency: "USD", ecbRate: new Decimal("0.92") },
       ]],
     ]);
     const result = generateModelo720(positions, rateMap, baseConfig, lots);

--- a/tests/generators/report-crypto.test.ts
+++ b/tests/generators/report-crypto.test.ts
@@ -120,8 +120,11 @@ describe("generateTaxReport — crypto↔crypto permutas", () => {
     expect(report.capitalGains.disposals).toHaveLength(1);
     // Proceeds: 100 × 0.0006 BTC × 62000 EUR/BTC = 3720 EUR
     expect(report.capitalGains.transmissionValue.toFixed(2)).toBe("3720.00");
-    // Cost: 100 × 0.0005 BTC × 60000 EUR/BTC = 3000 EUR
-    expect(report.capitalGains.acquisitionValue.toFixed(2)).toBe("3000.00");
-    expect(report.capitalGains.netGainLoss.toFixed(2)).toBe("720.00");
+    // Cost in BTC (FCY): 100 × 0.0005 = 0.05 BTC. Under DGT V2422-20 the cost is
+    // converted at the SALE-date BTC rate (62000 EUR/BTC), not the buy-date rate:
+    // 0.05 × 62000 = 3100 EUR
+    expect(report.capitalGains.acquisitionValue.toFixed(2)).toBe("3100.00");
+    // Gain in BTC = 0.01 BTC, × 62000 = 620.00 EUR
+    expect(report.capitalGains.netGainLoss.toFixed(2)).toBe("620.00");
   });
 });

--- a/tests/generators/report.test.ts
+++ b/tests/generators/report.test.ts
@@ -517,6 +517,14 @@ describe("generateTaxReport", () => {
         .toBe(solo.capitalGains.disposals[0]!.proceedsEur.div(2).toFixed(2));
       expect(split.capitalGains.disposals[0]!.quantity.toFixed(2))
         .toBe(solo.capitalGains.disposals[0]!.quantity.div(2).toFixed(2));
+      // FCY figures must split too (or a >1-titulares declaration over-counts
+      // them by ×n once any surface reads the FCY fields).
+      expect(split.capitalGains.disposals[0]!.proceedsFcy.toFixed(2))
+        .toBe(solo.capitalGains.disposals[0]!.proceedsFcy.div(2).toFixed(2));
+      expect(split.capitalGains.disposals[0]!.costBasisFcy.toFixed(2))
+        .toBe(solo.capitalGains.disposals[0]!.costBasisFcy.div(2).toFixed(2));
+      expect(split.capitalGains.disposals[0]!.gainLossFcy.toFixed(2))
+        .toBe(solo.capitalGains.disposals[0]!.gainLossFcy.div(2).toFixed(2));
     });
 
     it("should emit an info message about shared titularity when titulares > 1", () => {

--- a/tests/generators/report.test.ts
+++ b/tests/generators/report.test.ts
@@ -125,9 +125,11 @@ describe("generateTaxReport", () => {
     expect(report.year).toBe(2025);
     // Proceeds: 10 × 120 × 0.91 = 1092
     expect(report.capitalGains.transmissionValue.toFixed(2)).toBe("1092.00");
-    // Cost: 10 × 100 × 0.92 = 920
-    expect(report.capitalGains.acquisitionValue.toFixed(2)).toBe("920.00");
-    expect(report.capitalGains.netGainLoss.toFixed(2)).toBe("172.00");
+    // Cost in USD (1000) converted at the SALE-date rate (DGT V2422-20):
+    // 10 × 100 × 0.91 = 910
+    expect(report.capitalGains.acquisitionValue.toFixed(2)).toBe("910.00");
+    // Gain in USD = 200, × 0.91 = 182.00 EUR
+    expect(report.capitalGains.netGainLoss.toFixed(2)).toBe("182.00");
     expect(report.capitalGains.disposals).toHaveLength(1);
     expect(report.capitalGains.blockedLosses.toFixed(2)).toBe("0.00");
   });
@@ -259,9 +261,10 @@ describe("generateTaxReport", () => {
     expect(report.fxGains.transmissionValue.toFixed(2)).toBe("0.00");
     expect(report.fxGains.acquisitionValue.toFixed(2)).toBe("0.00");
     expect(report.fxGains.netGainLoss.toFixed(2)).toBe("0.00");
-    // Capital gains still computed normally
+    // Capital gains still computed normally — gain in USD (200) converted at the
+    // SALE-date rate (0.91, DGT V2422-20): 200 × 0.91 = 182.00 EUR
     expect(report.capitalGains.disposals).toHaveLength(1);
-    expect(report.capitalGains.netGainLoss.toFixed(2)).toBe("172.00");
+    expect(report.capitalGains.netGainLoss.toFixed(2)).toBe("182.00");
   });
 
   it("should produce non-zero FX gains when skipFx is false with manual CASH trades", () => {


### PR DESCRIPTION
Closes #219. Thanks @elmasvital — outstanding analysis, with a worked DGT benchmark and a reproducing CSV. Verified your reading against the primary sources (I fetched the raw consultas): you're exactly right.

## Problem

Capital gains on a **foreign-currency asset** were computed by converting the **cost at the buy-date** ECB rate and the **proceeds at the sell-date** rate, then subtracting. That leaks the currency's FX drift into the *stock* gain.

**DGT V2422-20** (re-affirmed by **V0152-26**, 2026) is explicit: *"debiendo efectuarse dicho cálculo **en la moneda en que se encuentren denominadas las acciones** y efectuar la conversión **de la diferencia resultante** a euros al tipo de cambio vigente en la fecha … de la alteración patrimonial."* The FX move on the currency is a **separate** patrimonial element (Art. 33), already handled by DeclaRenta's independent FX FIFO engine — so the old behavior double-treated it.

### Benchmark (your CSV)
Buy 10 GOOG @120 USD, sell 10 @120 USD, with USD/EUR moving 1.3→1.5:
- **Stock gain in USD = 1200 − 1200 = 0 → EUR gain = 0.** ✓ (matches V2422-20's own worked example verbatim)
- Before this fix: a phantom **~−123 EUR** (pure FX drift mislabeled as a stock result).

## Fix

`src/engine/fifo.ts` + `src/types/tax.ts`:
- `Lot.costInEur` → **`costInFcy`**: cost basis stored in the asset's own currency. A commission in a different currency is homogenized to the share currency via the trade-date cross-rate.
- `FifoDisposal` gains `gainLossFcy` / `proceedsFcy` / `costBasisFcy`.
- **Every** disposal path — long, short, option (expiration/exercise/premium integration), corporate actions (scrip-div/merger/spin-off), missing-lot, and crypto permutas — computes `gainLossFcy = proceedsFcy − costBasisFcy`, then converts all EUR figures at the **disposal-date** rate. `proceedsEur − costBasisEur === gainLossEur` holds by construction (single shared rate), so FX drift can never re-enter the stock gain.
- Crypto reward lots (currency EUR → rate 1) and EUR-native assets are numerically unchanged. `acquireEcbRate` retained as an audit-only column.

### 0331 display
Per your guidance and V2422-20: the acquisition value (0331) is shown at the **sale-date** rate so `0328 − 0331 == gain` exactly — the only internally consistent presentation.

## Scope / monodivisa
Per your own scoping (*"dejaré para otro las conversiones de moneda"*), this PR covers **only the buy/sell stock leg**. The FX-conversion leg — including the citation nit (the divisa element is **Art. 33 + DGT V2466-08**, not Art. 37.1.l as currently labelled) — is deferred to a follow-up. **Monodivisa mode** is unaffected and actually benefits: the stock figure is now FX-clean regardless of the toggle.

## Test plan
- [x] V2422-20 benchmark added (gain = 0) + a real-gain-converted-at-sale-rate case.
- [x] ~40 existing fixtures (fifo / multi-currency / options-v0137-23 / phase5 / report / corporate-actions / modelo720) recomputed to the correct new values.
- [x] `npm run typecheck`, `npm run lint`, `npm test` — **1308 pass**. `npm run build` clean.
- [x] Independent code-review pass: APPROVE, EUR-additivity invariant verified across all paths, commission cross-rate direction correct, no buy-date rate leaks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected gain/loss calculations for multi-currency transactions to use sale-date exchange rates instead of acquisition-date rates, ensuring accurate foreign exchange treatment.
  * Fixed option premium integration with underlying lot cost basis to properly track gains/losses across option exercises and expirations.
  * Improved corporate action (splits, mergers, spin-offs) cost basis preservation in foreign currencies.

* **Refactor**
  * Restructured cost-basis engine to internally track all calculations in the share's currency first, converting to EUR only at point of disposal for greater accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->