### PR TITLE
chore(test): raise vitest testTimeout to 20s to de-flake PDF suites

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,13 @@ export default defineConfig({
   test: {
     include: ["tests/**/*.test.ts"],
     globals: false,
+    // The PDF suites (jsPDF/PDFKit) do a CPU-heavy cold-start font/module init on
+    // their first generate call (~13s wall-clock cold). On a loaded shared CI
+    // runner that first call can exceed vitest's 5s default, flaking the run and
+    // blocking the release (e.g. pdf-web "returns a Blob" timed out at 5000ms on
+    // main while passing on the PR branch and locally). Real tests finish in ms;
+    // a 20s floor only ever absorbs cold-start/contention, never masks a hang.
+    testTimeout: 20_000,
     define: {
       __APP_VERSION__: JSON.stringify("test"),
       __COMMIT_HASH__: JSON.stringify("test"),


### PR DESCRIPTION
## Problem

The `test` job failed on the **main** push for #222 (blocking the v0.48.6 Pages deploy) with:

> `FAIL tests/generators/pdf-web.test.ts > generatePdfWebReport > returns a Blob with application/pdf type` — **Test timed out in 5000ms.**

1323/1324 passed; only this one PDF test timed out. It **passed on the PR branch** (`27218341550`) and **passes locally every run** (13/13).

## Root cause — flakiness, not a real failure

The PDF suites (jsPDF/PDFKit) do a CPU-heavy **cold-start** font/module init on their first `generatePdfWebReport` call. Measured locally: the first run of the file takes **~13s wall-clock**, subsequent runs ~2s. On a loaded shared self-hosted runner, that cold first call can exceed vitest's **5000ms default per-test timeout** → spurious failure.

## Fix

Raise `testTimeout` to **20s** globally in `vitest.config.ts`. Real tests finish in milliseconds, so the higher floor only ever absorbs cold-start/contention — it never masks a genuine hang, and no assertion is weakened.

```ts
test: {
  ...
  testTimeout: 20_000,
}
```

Full suite: **1324/1324** local.

> Note: the merged #222 code itself is correct and already green on re-run — this just hardens the inherently-heavy PDF tests so a cold-start stall can't block a release again.