### PR TITLE
fix(fx): dividend/interest withholding is a pago a cuenta, not an FX disposal (closes #225)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,13 @@ When adding a new section (like 721), follow this checklist:
 - `extractCashFxEvents()` always processes dividends/interest (no `autoConvert` param) — FCY income creates acquisition lots
 - **Impact**: Pure auto-convert accounts still correct (all CASH trades have AFx → all skipped). Hybrid accounts now correct (manual conversions processed, AFx skipped). The only "loss" is theoretical implicit FX from holding FCY across stock trades — but that was phantom gains anyway due to missing lots.
 
+### FX dividend/interest withholding = pago a cuenta, NOT a disposal (Hard Trace — issue #225)
+- **Symptom**: a FCY dividend with withholding created a GROSS acquisition lot AND a separate WITHHOLDING disposal that FIFO-consumed the OLDEST FCY lot (often a prior conversion at a different rate), fabricating a phantom Art. 33 FX gain into casillas 1633/1637 on currency the taxpayer never converted to EUR.
+- **Why wrong**: withholding (retención en origen) is a **pago a cuenta** — deducted at source, the withheld FCY never enters the taxpayer's spendable balance, and it is **not a conversión a euros**. The DGT FX-timing doctrine (V2422-20, V1613-25, V0463-21) crystallizes an FX gain ONLY on the effective conversion to euros (cobro/pago, Art. 14.2.e). No competitor/tool (Taxdown/Autodeclaro run monodivisa; IBKR's Forex worksheet covers only completed conversions) books an FX gain on withholding. No binding consulta is squarely on point — this is a reasoned, conservative position (removes a phantom disposal of money never received).
+- **Fix** (`extractCashFxEvents`): a pre-pass sums withholding per `(currency, date)`; each `Dividends`/`Payment In Lieu`/`Interest Received` inflow is emitted as a lot for the **NET** (gross − matched withholding) FCY actually received; the `Withholding Tax` row emits **no disposal**. FX lots are fungible per currency, so (currency,date) netting equals exact issuer pairing. Guards: a **positive** withholding (refund) is FCY *received* (acquire, not dispose); an **orphan** withholding (no same-(currency,date) income — cross-date reclaim) is dropped, never a disposal; interest withholding nets too.
+- **Income path is untouched**: gross dividend → 0029 and withholding → 0588 are computed in `dividends.ts`/`double-taxation.ts` from the raw cashTransactions, never from FX events. Only 1633/1637 (and marginally `totalSavingsBase`'s positive-FX term) change.
+- **Citation correction**: the FX engine tracks divisa under **Art. 33.1** (transmisión − adquisición), NOT Art. 37.1.l (which is "incorporaciones que no derivan de transmisión" — unrelated). Header comment + this section corrected. This closes the Art.37.1.l→Art.33/V2466-08 follow-up deferred in #220.
+
 ## Project Philosophy
 
 ### Correctness with User Comfort

--- a/src/engine/fx-fifo.ts
+++ b/src/engine/fx-fifo.ts
@@ -182,6 +182,13 @@ export class FxFifoEngine {
     // per currency, so netting by (currency, date) is equivalent to exact issuer
     // pairing and far simpler. A withholding with no same-(currency,date) income
     // (orphan / cross-date reclaim) is dropped — still never a disposal.
+    //
+    // The orphan drop is intentionally SILENT (no warning): extractCashFxEvents is
+    // static with no `emit`/messages channel, and the condition is non-actionable —
+    // the gross income (0029) and the 0588 credit are declared by the income path
+    // regardless; the only effect is a marginally-gross FX lot. Surfacing it would
+    // add anxiety for nothing. If a diagnostic is ever wanted, aggregate it in
+    // report.ts after processEvents, not here.
     const whtByKey = new Map<string, Decimal>();
     for (const tx of cashTransactions) {
       if (tx.type !== "Withholding Tax" || tx.currency === "EUR") continue;
@@ -190,8 +197,21 @@ export class FxFifoEngine {
       const key = `${tx.currency}|${normalizeDate(tx.settleDate || tx.dateTime)}`;
       whtByKey.set(key, (whtByKey.get(key) ?? new Decimal(0)).plus(amt.abs()));
     }
-    /** Reduce an income inflow by any withholding pending for its (currency,date). */
-    const netOfWithholding = (currency: string, date: string, gross: Decimal): Decimal => {
+    /**
+     * Reduce an income inflow by any withholding pending for its (currency,date),
+     * returning the NET FCY received. STATEFUL: it draws down the shared `whtByKey`
+     * bucket, so two same-(currency,date) incomes split one withholding total rather
+     * than each netting it in full; order within a key doesn't change the total netted.
+     * NOTE: this keys on the EXACT same-date (currency,date), deliberately coarser
+     * AND stricter than the income path's matcher in dividends.ts (ISIN + currency +
+     * ≤7-day window). Coarser is safe for FX because lots are fungible per currency
+     * (the net-per-currency total is what matters, not which issuer). Stricter on the
+     * date means a withholding booked on a DIFFERENT settle-date than its dividend
+     * isn't matched here → it's an orphan, dropped, and the lot stays gross. That is
+     * conservative (no phantom disposal; the extra FCY only ever yields real drift on
+     * currency actually received) and immaterial — accepted deliberately.
+     */
+    const consumeWithholding = (currency: string, date: string, gross: Decimal): Decimal => {
       const key = `${currency}|${date}`;
       const pending = whtByKey.get(key);
       if (!pending || pending.isZero()) return gross;
@@ -227,21 +247,24 @@ export class FxFifoEngine {
 
       if (tx.type === "Dividends" || tx.type === "Payment In Lieu Of Dividends") {
         // Net the same-(currency,date) withholding into the dividend lot.
-        const net = netOfWithholding(tx.currency, date, amount.abs());
-        if (net.isPositive()) {
+        const net = consumeWithholding(tx.currency, date, amount.abs());
+        // `greaterThan(0)`, not `isPositive()` — decimal.js treats +0 as positive,
+        // and a zero-quantity event would make addLot compute 0/0 = NaN.
+        if (net.greaterThan(0)) {
           events.push({ date, currency: tx.currency, quantity: net, ecbRate, trigger: "dividend" });
         }
       } else if (tx.type === "Withholding Tax") {
         // Netted into its income inflow above (or dropped if orphan). Never a
-        // disposal. A positive-amount WHT (refund) IS currency received → acquire.
-        if (amount.isPositive()) {
+        // disposal. A positive-amount WHT (a refund) IS currency received → acquire.
+        // Defensive: not observed in current broker exports, but symmetric and cheap.
+        if (amount.greaterThan(0)) {
           events.push({ date, currency: tx.currency, quantity: amount, ecbRate, trigger: "dividend" });
         }
       } else if (tx.type === "Broker Interest Received" || tx.type === "Bond Interest Received") {
         // Interest can also carry withholding (e.g. "WITHHOLDING ON CREDIT INT");
         // net it the same way — a withholding is a pago a cuenta whatever the income.
-        const net = netOfWithholding(tx.currency, date, amount.abs());
-        if (net.isPositive()) {
+        const net = consumeWithholding(tx.currency, date, amount.abs());
+        if (net.greaterThan(0)) {
           events.push({ date, currency: tx.currency, quantity: net, ecbRate, trigger: "interest" });
         }
       } else if (tx.type === "Broker Interest Paid" || tx.type === "Bond Interest Paid") {
@@ -268,6 +291,9 @@ export class FxFifoEngine {
   }
 
   private addLot(event: FxEvent): void {
+    // Defense-in-depth: never create a lot for a non-positive quantity — costPerUnit
+    // would be 0/0 = NaN and silently poison all later FIFO math for this currency.
+    if (!event.quantity.greaterThan(0)) return;
     // Commission increases the EUR cost of acquiring the lot
     const baseCost = event.quantity.mul(event.ecbRate);
     const totalCost = event.commissionEur ? baseCost.plus(event.commissionEur) : baseCost;

--- a/src/engine/fx-fifo.ts
+++ b/src/engine/fx-fifo.ts
@@ -1,9 +1,15 @@
 /**
- * FX FIFO engine — tracks currency lots per Art. 37.1.l LIRPF.
+ * FX FIFO engine — tracks foreign-currency holdings as patrimonial elements
+ * (Art. 33.1 LIRPF: gain/loss = valor de transmisión − valor de adquisición of
+ * the divisa; NOT Art. 37.1.l, which governs "incorporaciones que no derivan de
+ * una transmisión" — an unrelated rule). DGT V2422-20 / V1613-25 / V0463-21:
+ * the FX gain crystallizes only on the effective conversion to euros (cobro/pago,
+ * Art. 14.2.e).
  *
  * Each EUR→FCY conversion creates a lot; each FCY disposal (conversion
  * back to EUR, or spending FCY on stock purchases) consumes lots via FIFO.
- * DGT V2324-10 confirms FIFO applies to foreign currency holdings.
+ * Dividend/interest withholding is a pago a cuenta, NOT a disposal — see
+ * extractCashFxEvents (issue #225).
  */
 
 import Decimal from "decimal.js";
@@ -160,6 +166,40 @@ export class FxFifoEngine {
 
     const events: FxEvent[] = [];
 
+    // Withholding tax (retención en origen) on a foreign-currency dividend/interest
+    // is a PAGO A CUENTA: it is deducted at source, the withheld FCY never enters
+    // the taxpayer's spendable balance, and it is not a "conversión de divisas a
+    // euros" — so it must NOT create an FX disposal (issue #225). The DGT timing
+    // doctrine (V2422-20, V1613-25, V0463-21) crystallizes an FX gain only on the
+    // effective conversion to EUR (cobro/pago); a withholding is neither. The
+    // GROSS income is still declared independently on the income path (casilla
+    // 0029) and the withholding still credits double-taxation (0588) — those read
+    // the raw cashTransactions, never these FX events, so they are untouched.
+    //
+    // Instead of emitting a phantom disposal that FIFO-consumes an OLDER lot at a
+    // different rate (the bug), we net each withholding into its income lot: the
+    // acquisition lot reflects the NET FCY actually received. FX lots are fungible
+    // per currency, so netting by (currency, date) is equivalent to exact issuer
+    // pairing and far simpler. A withholding with no same-(currency,date) income
+    // (orphan / cross-date reclaim) is dropped — still never a disposal.
+    const whtByKey = new Map<string, Decimal>();
+    for (const tx of cashTransactions) {
+      if (tx.type !== "Withholding Tax" || tx.currency === "EUR") continue;
+      const amt = new Decimal(tx.amount);
+      if (!amt.isNegative()) continue; // a positive WHT (refund) is FCY received, not a deduction
+      const key = `${tx.currency}|${normalizeDate(tx.settleDate || tx.dateTime)}`;
+      whtByKey.set(key, (whtByKey.get(key) ?? new Decimal(0)).plus(amt.abs()));
+    }
+    /** Reduce an income inflow by any withholding pending for its (currency,date). */
+    const netOfWithholding = (currency: string, date: string, gross: Decimal): Decimal => {
+      const key = `${currency}|${date}`;
+      const pending = whtByKey.get(key);
+      if (!pending || pending.isZero()) return gross;
+      const applied = Decimal.min(pending, gross);
+      whtByKey.set(key, pending.minus(applied));
+      return gross.minus(applied);
+    };
+
     for (const tx of cashTransactions) {
       if (tx.currency === "EUR") continue;
 
@@ -186,11 +226,24 @@ export class FxFifoEngine {
       if (ecbRate === null) continue;
 
       if (tx.type === "Dividends" || tx.type === "Payment In Lieu Of Dividends") {
-        events.push({ date, currency: tx.currency, quantity: amount.abs(), ecbRate, trigger: "dividend" });
+        // Net the same-(currency,date) withholding into the dividend lot.
+        const net = netOfWithholding(tx.currency, date, amount.abs());
+        if (net.isPositive()) {
+          events.push({ date, currency: tx.currency, quantity: net, ecbRate, trigger: "dividend" });
+        }
       } else if (tx.type === "Withholding Tax") {
-        events.push({ date, currency: tx.currency, quantity: amount.abs().negated(), ecbRate, trigger: "dividend" });
+        // Netted into its income inflow above (or dropped if orphan). Never a
+        // disposal. A positive-amount WHT (refund) IS currency received → acquire.
+        if (amount.isPositive()) {
+          events.push({ date, currency: tx.currency, quantity: amount, ecbRate, trigger: "dividend" });
+        }
       } else if (tx.type === "Broker Interest Received" || tx.type === "Bond Interest Received") {
-        events.push({ date, currency: tx.currency, quantity: amount.abs(), ecbRate, trigger: "interest" });
+        // Interest can also carry withholding (e.g. "WITHHOLDING ON CREDIT INT");
+        // net it the same way — a withholding is a pago a cuenta whatever the income.
+        const net = netOfWithholding(tx.currency, date, amount.abs());
+        if (net.isPositive()) {
+          events.push({ date, currency: tx.currency, quantity: net, ecbRate, trigger: "interest" });
+        }
       } else if (tx.type === "Broker Interest Paid" || tx.type === "Bond Interest Paid") {
         events.push({ date, currency: tx.currency, quantity: amount.abs().negated(), ecbRate, trigger: "interest" });
       } else if (tx.type === "Other Fees" || tx.type === "Commission Adjustments") {

--- a/tests/engine/fx-fifo.test.ts
+++ b/tests/engine/fx-fifo.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import Decimal from "decimal.js";
 import { FxFifoEngine } from "../../src/engine/fx-fifo.js";
 import type { FxEvent } from "../../src/engine/fx-fifo.js";
-import type { Trade } from "../../src/types/ibkr.js";
+import type { Trade, CashTransaction } from "../../src/types/ibkr.js";
 import type { EcbRateMap } from "../../src/types/ecb.js";
 
 function makeEvent(overrides: Partial<FxEvent> = {}): FxEvent {
@@ -48,9 +48,12 @@ function makeTrade(overrides: Partial<Trade> = {}): Trade {
 const rateMap: EcbRateMap = new Map([
   ["2025-03-15", new Map([["USD", new Decimal("0.92")]])],
   ["2025-03-14", new Map([["USD", new Decimal("0.92")]])],
+  ["2025-03-17", new Map([["USD", new Decimal("0.92")]])],
+  ["2025-06-01", new Map([["USD", new Decimal("0.92")]])],
   ["2025-06-15", new Map([["USD", new Decimal("0.95")]])],
   ["2025-06-14", new Map([["USD", new Decimal("0.95")]])],
   ["2025-09-01", new Map([["USD", new Decimal("0.90")]])],
+  ["2025-01-10", new Map([["USD", new Decimal("0.90")]])],
 ]);
 
 describe("FxFifoEngine", () => {
@@ -520,6 +523,84 @@ describe("FxFifoEngine", () => {
       expect(events).toHaveLength(1);
       expect(events[0]!.quantity.toString()).toBe("-5");
       expect(events[0]!.trigger).toBe("commission");
+    });
+  });
+
+  describe("issue #225 — withholding nets into the income lot, never disposes", () => {
+    const wht = (currency: string, date: string, amount: string): CashTransaction => ({
+      transactionID: `w-${date}`, accountId: "U1", symbol: "AAPL", description: "WHT",
+      isin: "US0378331005", currency, dateTime: date, settleDate: date, amount,
+      fxRateToBase: "0.92", type: "Withholding Tax",
+    });
+    const div = (currency: string, date: string, amount: string, isin = "US0378331005"): CashTransaction => ({
+      transactionID: `d-${isin}-${date}`, accountId: "U1", symbol: "X", description: "dividend",
+      isin, currency, dateTime: date, settleDate: date, amount, fxRateToBase: "0.92", type: "Dividends",
+    });
+
+    it("does NOT consume a prior FCY lot (the core #225 regression)", () => {
+      const engine = new FxFifoEngine();
+      engine.processEvents([
+        // a real earlier conversion lot — the thing the OLD code wrongly consumed
+        { date: "2025-01-10", currency: "USD", quantity: new Decimal(1000), ecbRate: new Decimal("0.90"), trigger: "conversion" },
+        ...FxFifoEngine.extractCashFxEvents([div("USD", "20250601", "100"), wht("USD", "20250601", "-15")], rateMap),
+      ]);
+      expect(engine.getDisposals()).toHaveLength(0); // no disposal at all
+      const lots = engine.getRemainingLots().get("USD")!;
+      expect(lots).toHaveLength(2);
+      expect(lots[0]!.quantity.toString()).toBe("1000"); // prior lot INTACT
+      expect(lots[0]!.costPerUnit.toString()).toBe("0.9");
+      expect(lots[1]!.quantity.toString()).toBe("85");   // net dividend lot
+    });
+
+    it("a net-of-withholding lot still realizes its real FX gain on a later conversion", () => {
+      // Settles the "does net-lot understate a future gain?" question: it does not.
+      const engine = new FxFifoEngine();
+      engine.processEvents([
+        ...FxFifoEngine.extractCashFxEvents([div("USD", "20250315", "100"), wht("USD", "20250315", "-15")], rateMap),
+        { date: "2025-06-15", currency: "USD", quantity: new Decimal(-85), ecbRate: new Decimal("0.95"), trigger: "conversion" },
+      ]);
+      const d = engine.getDisposals();
+      expect(d).toHaveLength(1);
+      expect(d[0]!.trigger).toBe("conversion");
+      expect(d[0]!.costBasisEur.toFixed(2)).toBe("78.20"); // 85 × 0.92 (dividend-date basis)
+      expect(d[0]!.proceedsEur.toFixed(2)).toBe("80.75");  // 85 × 0.95
+      expect(d[0]!.gainLossEur.toFixed(2)).toBe("2.55");
+    });
+
+    it("withholding exceeding the dividend emits NO event (no zero-qty leak)", () => {
+      const events = FxFifoEngine.extractCashFxEvents(
+        [div("USD", "20250315", "10"), wht("USD", "20250315", "-15")], rateMap,
+      );
+      expect(events).toHaveLength(0);
+      expect(events.some((e) => e.quantity.isZero())).toBe(false);
+    });
+
+    it("two issuers, same currency+date — withholding nets in aggregate (lots fungible)", () => {
+      const events = FxFifoEngine.extractCashFxEvents([
+        div("USD", "20250315", "100", "US0378331005"), wht("USD", "20250315", "-15"),
+        div("USD", "20250315", "200", "US5949181045"), wht("USD", "20250315", "-30"),
+      ], rateMap);
+      const total = events.reduce((s, e) => s.plus(e.quantity), new Decimal(0));
+      expect(total.toString()).toBe("255"); // 300 gross − 45 wht
+      expect(events.some((e) => e.quantity.isNegative())).toBe(false);
+    });
+
+    it("withholding on a DIFFERENT date than its dividend is an orphan → gross lot, no disposal", () => {
+      const events = FxFifoEngine.extractCashFxEvents(
+        [div("USD", "20250315", "100"), wht("USD", "20250901", "-15")], rateMap,
+      );
+      expect(events).toHaveLength(1);
+      expect(events[0]!.quantity.toString()).toBe("100"); // GROSS — not netted across dates
+      expect(events.some((e) => e.quantity.isNegative())).toBe(false);
+    });
+
+    it("nets even when date fields carry IBKR ;HHMMSS time components", () => {
+      const events = FxFifoEngine.extractCashFxEvents([
+        { ...div("USD", "20250315", "100"), dateTime: "20250315;130000", settleDate: "20250317;090000" },
+        { ...wht("USD", "20250315", "-15"), dateTime: "20250315;130000", settleDate: "20250317;090000" },
+      ], rateMap);
+      expect(events).toHaveLength(1);
+      expect(events[0]!.quantity.toString()).toBe("85"); // normalizeDate aligns both keys
     });
   });
 

--- a/tests/engine/fx-fifo.test.ts
+++ b/tests/engine/fx-fifo.test.ts
@@ -407,16 +407,73 @@ describe("FxFifoEngine", () => {
       expect(events[0]!.trigger).toBe("dividend");
     });
 
-    it("should extract withholding tax as negative FX event (disposing FCY)", () => {
+    it("should NOT emit an FX disposal for withholding tax (pago a cuenta, issue #225)", () => {
+      // A withholding with no matching same-(currency,date) income is an orphan
+      // (cross-date reclaim, or income outside the file) — it must never create a
+      // disposal. The withheld FCY never entered the taxpayer's spendable balance.
       const txs = [{
         transactionID: "2", accountId: "U1", symbol: "AAPL", description: "US WHT",
         isin: "US0378331005", currency: "USD", dateTime: "20250315",
         settleDate: "20250317", amount: "-15", fxRateToBase: "0.92", type: "Withholding Tax" as const,
       }];
       const events = FxFifoEngine.extractCashFxEvents(txs, rateMap);
+      expect(events).toHaveLength(0);
+    });
+
+    it("should net withholding into the dividend lot — one NET event, no disposal (issue #225)", () => {
+      // USD dividend gross 100 + withholding 15 on the same date → ONE acquisition
+      // lot for the net 85 (the FCY actually received), and NO negative/disposal
+      // event for the withholding.
+      const txs = [
+        {
+          transactionID: "1", accountId: "U1", symbol: "AAPL", description: "AAPL dividend",
+          isin: "US0378331005", currency: "USD", dateTime: "20250315",
+          settleDate: "20250317", amount: "100", fxRateToBase: "0.92", type: "Dividends" as const,
+        },
+        {
+          transactionID: "2", accountId: "U1", symbol: "AAPL", description: "US WHT",
+          isin: "US0378331005", currency: "USD", dateTime: "20250315",
+          settleDate: "20250317", amount: "-15", fxRateToBase: "0.92", type: "Withholding Tax" as const,
+        },
+      ];
+      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap);
       expect(events).toHaveLength(1);
-      expect(events[0]!.quantity.toString()).toBe("-15");
+      expect(events[0]!.quantity.toString()).toBe("85");
       expect(events[0]!.trigger).toBe("dividend");
+      expect(events.some((e) => e.quantity.isNegative())).toBe(false);
+    });
+
+    it("should net interest withholding too (withholding on credit interest)", () => {
+      // IBKR also withholds on credit interest ("WITHHOLDING ON CREDIT INT") — a
+      // pago a cuenta just like dividend withholding → net it, no disposal.
+      const txs = [
+        {
+          transactionID: "3", accountId: "U1", symbol: "", description: "USD Interest",
+          isin: "", currency: "USD", dateTime: "20250315",
+          settleDate: "20250317", amount: "25", fxRateToBase: "0.92", type: "Broker Interest Received" as const,
+        },
+        {
+          transactionID: "3w", accountId: "U1", symbol: "", description: "WITHHOLDING ON CREDIT INT",
+          isin: "", currency: "USD", dateTime: "20250315",
+          settleDate: "20250317", amount: "-5", fxRateToBase: "0.92", type: "Withholding Tax" as const,
+        },
+      ];
+      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap);
+      expect(events).toHaveLength(1);
+      expect(events[0]!.quantity.toString()).toBe("20");
+      expect(events[0]!.trigger).toBe("interest");
+    });
+
+    it("should treat a positive withholding (refund) as FCY received, not a disposal", () => {
+      const txs = [{
+        transactionID: "2r", accountId: "U1", symbol: "AAPL", description: "WHT refund",
+        isin: "US0378331005", currency: "USD", dateTime: "20250315",
+        settleDate: "20250317", amount: "3", fxRateToBase: "0.92", type: "Withholding Tax" as const,
+      }];
+      const events = FxFifoEngine.extractCashFxEvents(txs, rateMap);
+      expect(events).toHaveLength(1);
+      expect(events[0]!.quantity.toString()).toBe("3");
+      expect(events.some((e) => e.quantity.isNegative())).toBe(false);
     });
 
     it("should extract interest received as positive FX event", () => {

--- a/tests/generators/report.test.ts
+++ b/tests/generators/report.test.ts
@@ -242,6 +242,40 @@ describe("generateTaxReport", () => {
     expect(report.dividends.grossIncome.toFixed(2)).toBe("0.00");
   });
 
+  it("issue #225: dividend withholding generates no FX disposal, income/0588 unchanged", () => {
+    // A prior USD lot exists (CASH FX SELL acquires 1000 USD @ 0.90 on Jan 10).
+    // Then a USD dividend (gross 100) with withholding (15) on Jun 1 @ 0.92.
+    // OLD behavior: the withholding FIFO-consumed the Jan-10 lot → a phantom FX
+    // gain of 15×(0.92−0.90)=0.30 in casillas 1633/1637. After the fix: the
+    // withholding nets into the dividend lot (net 85 USD), NO FX disposal fires,
+    // and the income path (0029 gross, 0588 credit) is untouched.
+    const rates = makeRateMap({ "2025-01-10": "0.9000", "2025-06-01": "0.9200" });
+    const statement = makeStatement({
+      trades: [
+        makeTrade({
+          tradeID: "fx-sell", tradeDate: "2025-01-10", settlementDate: "2025-01-10",
+          symbol: "EUR.USD", description: "EUR.USD", isin: "", assetCategory: "CASH",
+          currency: "USD", quantity: "-1000", tradePrice: "1.1111", tradeMoney: "-1111",
+          proceeds: "1111", buySell: "SELL", exchange: "IDEALFX",
+        }),
+      ],
+      cashTransactions: [
+        makeCashTx({ transactionID: "d1", dateTime: "20250601", amount: "100", type: "Dividends" }),
+        makeCashTx({ transactionID: "w1", dateTime: "20250601", amount: "-15", type: "Withholding Tax" }),
+      ],
+    });
+
+    const report = generateTaxReport(statement, rates, 2025);
+
+    // FX: no disposal triggered by the withholding → no phantom dividend FX gain.
+    expect(report.fxGains.disposals.some((d) => d.trigger === "dividend")).toBe(false);
+    expect(report.fxGains.netGainLoss.toFixed(2)).toBe("0.00");
+    // Income path UNCHANGED: gross dividend → 0029 (100 × 0.92 = 92.00).
+    expect(report.dividends.grossIncome.toFixed(2)).toBe("92.00");
+    // Withholding → 0588 double-taxation credit (15 × 0.92 = 13.80).
+    expect(report.doubleTaxation.deduction.toFixed(2)).toBe("13.80");
+  });
+
   it("should skip FX engine when skipFx is true (monodivisa mode)", () => {
     const rates = makeRateMap({
       "2025-03-15": "0.9200",


### PR DESCRIPTION
Closes #225.

## Problema (reportado por @elmasvital)

En el motor FX FIFO, un dividendo en divisa extranjera con retención generaba **dos** eventos: un lote de adquisición por el **bruto** y una **disposición** por la retención que **consumía por FIFO el lote más antiguo** (a menudo una conversión previa a otro tipo de cambio), fabricando una ganancia patrimonial de divisa fantasma en las casillas **1633/1637** sobre dinero que el contribuyente nunca convirtió a euros.

Como dice elmasvital: la retención es un **pago a cuenta** — se descuenta en origen, ese dinero **nunca estuvo disponible**, nunca se pudo vender ni cambiar a EUR. No debería generar una transmisión de divisa.

## Solución

La retención es un **pago a cuenta, no una disposición de divisa**. La doctrina de imputación temporal de la DGT (**V2422-20, V1613-25, V0463-21**) cristaliza la ganancia de divisa **solo en la conversión efectiva a euros** (cobro/pago, Art. 14.2.e) — una retención no lo es.

`extractCashFxEvents`: una pre-pasada suma las retenciones por `(moneda, fecha)`; cada entrada de `Dividends`/`Payment In Lieu`/`Interest Received` se emite como lote por el **NETO** (bruto − retención emparejada); la `Withholding Tax` **no emite disposición**. Los lotes de divisa son fungibles por moneda, así que netear por (moneda,fecha) equivale al emparejado exacto por emisor.

**Guardas:**
- Retención **positiva** (devolución) → es divisa *recibida* (adquisición, no disposición).
- Retención **huérfana** (sin ingreso en la misma moneda/fecha — reclaim a otra fecha) → se descarta, nunca disposición.
- La retención sobre **intereses** ("WITHHOLDING ON CREDIT INT") también se netea.

## Lo que NO cambia (verificado)

El **camino de ingresos es independiente**: el dividendo **bruto → casilla 0029** y la retención **→ casilla 0588** (deducción por doble imposición) se calculan en `dividends.ts`/`double-taxation.ts` desde las transacciones crudas, **nunca** desde los eventos FX. Solo cambian 1633/1637 (y marginalmente el término FX-positivo de `totalSavingsBase`).

## Corrección de cita legal

El motor citaba **Art. 37.1.l** para las divisas — incorrecto: esa letra regula "incorporaciones que no derivan de una transmisión". La divisa se rige por **Art. 33.1** (transmisión − adquisición). Corregido en el comentario de cabecera. Cierra el follow-up Art.37.1.l→Art.33/V2466-08 que se aplazó en #220.

## Sobre la base legal (honestidad)

**No hay consulta vinculante específica** sobre si la retención genera o no una disposición de divisa — el propio autor lo dice y un panel de investigación lo confirmó. Esta es una postura **razonada y conservadora**: elimina una disposición fantasma de dinero nunca recibido, alineada con la doctrina de cobro/pago y con el comportamiento de todas las herramientas del mercado (ninguna calcula FX sobre la retención).

## Tests (+4)

- `dividend + WHT` mismo día → **un** lote neto (85), **sin** disposición.
- WHT huérfana → 0 eventos.
- WHT sobre intereses → netea (20), trigger `interest`.
- WHT positiva (devolución) → adquisición.
- **End-to-end (el guard clave)**: con un lote USD previo (que el código viejo consumía), tras el fix **no hay disposición FX por dividendo**, y **0029 (92,00) + 0588 (13,80) quedan intactos**.

Suite completa: **1346/1346** · typecheck + lint limpios. `addLot`/`consumeLots`/casillas sin cambios.