### PR TITLE
feat(scalable): parse cash/savings-account interest → Casilla 0027

### DIFF
--- a/docs/casillas.md
+++ b/docs/casillas.md
@@ -35,12 +35,14 @@
 |---------|----------|------------------------|------------------|
 | **0029** | Ingresos íntegros (dividendos brutos) | Σ dividendo_bruto × tipo_ECB_fecha_pago | Art. 25.1.a LIRPF |
 | **—** | Intereses pagados al broker (margen, **no deducible** — informativo) | Σ intereses_pagados_al_broker × tipo_ECB | Art. 26.1.a LIRPF (solo admite gastos de administración y custodia) |
-| **0033** | Intereses de cuentas y depósitos | Σ intereses_recibidos × tipo_ECB | Art. 25.2 LIRPF |
+| **0027** | Intereses de cuentas, depósitos y activos financieros en general | Σ intereses_recibidos × tipo_ECB | Art. 25.2 LIRPF |
 
 **Notas:**
 - Los dividendos incluyen tanto dividendos ordinarios como "Payment In Lieu of Dividends" (dividendos sustitutivos en operaciones de préstamo de valores).
 - Las retenciones extranjeras NO se deducen aquí — se declaran en la casilla 0588.
 - La conversión a EUR usa el tipo de cambio ECB oficial del día de pago (DGT V0583-16, PGC NRV 11a).
+- Los gastos genuinos de administración y depósito de valores negociables (cuando el bróker los detalla) sí son deducibles en la **Casilla 0037** (Art. 26.1.a LIRPF); la casilla 0027 recoge ingresos íntegros, nunca gastos.
+- Las cuotas de suscripción del bróker (p. ej. planes de trading de tarifa plana) NO son «gastos de administración y depósito de valores negociables», por lo que no son deducibles.
 
 ## Deducciones
 

--- a/src/parsers/scalable.ts
+++ b/src/parsers/scalable.ts
@@ -10,6 +10,7 @@
 
 import type { BrokerParser, Statement } from "../types/broker.js";
 import type { Trade, CashTransaction } from "../types/ibkr.js";
+import type { TaxMessage } from "../types/tax.js";
 import Decimal from "decimal.js";
 import {
   parseCsvLine,
@@ -97,6 +98,7 @@ function parseScalableCsv(lines: string[], delimiter: string): Statement {
 
   const trades: Trade[] = [];
   const cashTransactions: CashTransaction[] = [];
+  let interestWithholdingRows = 0;
 
   for (let i = 1; i < lines.length; i++) {
     const line = lines[i]!.trim();
@@ -135,7 +137,13 @@ function parseScalableCsv(lines: string[], delimiter: string): Statement {
       //   zero     → no economic event → skip
       const signed = new Decimal(amount);
       if (signed.isZero()) continue;
-      // NOTE: foreign withholding on interest (Casilla 0588) is not yet handled — Scalable cash interest to non-residents is typically paid gross; follow-up if a real file shows otherwise.
+      // Withholding on interest (Casilla 0588) is not yet wired. Scalable cash
+      // interest to non-residents is normally paid gross (no retención), so the
+      // `amount` is the gross/íntegro figure that belongs in 0027. If a real
+      // file ever carries a non-zero `tax` on an interest row we surface an info
+      // message rather than silently ignoring it (the gross/net and 0588-credit
+      // handling would then be a follow-up — see the parserMessages below).
+      if (parseFloat(parseNumber(tax)) !== 0) interestWithholdingRows++;
       cashTransactions.push({
         transactionID: reference || `scalable-int-${tradeDate}-${i}`,
         accountId: "",
@@ -233,6 +241,16 @@ function parseScalableCsv(lines: string[], delimiter: string): Statement {
     });
   }
 
+  const parserMessages: TaxMessage[] = interestWithholdingRows > 0
+    ? [{
+        id: "scalable.interest_withholding_detected",
+        severity: "info" as const,
+        message: `Se detectó una retención en ${interestWithholdingRows} fila(s) de intereses de Scalable Capital. El interés se ha declarado íntegro en la casilla 0027.`,
+        hint: "La deducción por doble imposición (casilla 0588) sobre intereses aún no se calcula automáticamente. Revisa la retención en tu certificado fiscal y, si procede, decláralo manualmente. Los intereses de cuenta a no residentes suelen pagarse sin retención.",
+        context: { count: String(interestWithholdingRows) },
+      }]
+    : [];
+
   return {
     accountId: "",
     fromDate: "",
@@ -243,6 +261,7 @@ function parseScalableCsv(lines: string[], delimiter: string): Statement {
     corporateActions: [],
     openPositions: [],
     securitiesInfo: [],
+    ...(parserMessages.length > 0 ? { parserMessages } : {}),
   };
 }
 

--- a/src/parsers/scalable.ts
+++ b/src/parsers/scalable.ts
@@ -78,6 +78,10 @@ function resolveColumns(headers: string[]): ScalableColumns {
 const DIVIDEND_TYPES = ["distribution", "dividend", "dividendo", "ausschüttung"];
 const SELL_TYPES = ["sell", "venta", "verkauf"];
 const BUY_TYPES = ["buy", "savings plan", "compra", "sparplan", "kauf"];
+// Cash/savings-account interest (KKT-Abschluss). "interes" matches both EN
+// "interest" and ES "intereses"; "zins" matches DE "zinsen". None of the
+// dividend/buy/sell type tokens contain these substrings, so there is no clash.
+const INTEREST_TYPES = ["interes", "zins"];
 
 // ---------------------------------------------------------------------------
 // Parser
@@ -117,6 +121,36 @@ function parseScalableCsv(lines: string[], delimiter: string): Statement {
     const tax = toFiniteDecimalString(fields[cols.tax] ?? "0");
     const currency = (fields[cols.currency] ?? "EUR").trim();
     const reference = (fields[cols.reference] ?? "").trim();
+
+    // Cash/savings-account interest (KKT-Abschluss). Match ONLY the `type`
+    // column (already lowercased above) with a tight keyword set — matching the
+    // description risks sweeping a security named "…Interest…ETF". This branch
+    // MUST stay ABOVE the `if (!isin) continue` guard below: interest rows carry
+    // no ISIN, so the guard would silently drop them before classification.
+    if (INTEREST_TYPES.some((k) => type.includes(k))) {
+      // Sign decides the IRPF treatment (split downstream by type, abs()'d):
+      //   positive → interest credited → Casilla 0027 (Art. 25.2 LIRPF)
+      //   negative → cash-account charge → "intereses pagados al broker"
+      //              (Art. 26.1.a, informational only, not deductible)
+      //   zero     → no economic event → skip
+      const signed = new Decimal(amount);
+      if (signed.isZero()) continue;
+      // NOTE: foreign withholding on interest (Casilla 0588) is not yet handled — Scalable cash interest to non-residents is typically paid gross; follow-up if a real file shows otherwise.
+      cashTransactions.push({
+        transactionID: reference || `scalable-int-${tradeDate}-${i}`,
+        accountId: "",
+        symbol: "CASH",
+        description: description || "Interest - Scalable Capital",
+        isin: "",
+        currency: currency || "EUR",
+        dateTime: tradeDate,
+        settleDate: tradeDate,
+        amount,
+        fxRateToBase: "1",
+        type: signed.isPositive() ? "Broker Interest Received" : "Broker Interest Paid",
+      });
+      continue;
+    }
 
     if (!isin) continue;
 

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -12,7 +12,7 @@ Anonymized sample files for broker parser tests. All data is fake (dummy ISINs, 
 | `coinbase-sample.csv` | Coinbase | CSV (v1) | 1 BTC buy, 1 BTC sell, 1 ETH staking income |
 | `coinbase-v2-sample.csv` | Coinbase | CSV (v2 with preamble) | Send, Convert, Receive, Buy, Sell, Staking Income |
 | `etoro-sample.csv` | eToro | CSV (text) | 2 closed positions (buy+loss), 1 dividend |
-| `scalable-sample.csv` | Scalable Capital | CSV (semicolon, EU numbers) | 1 buy, 1 sell, 1 distribution |
+| `scalable-sample.csv` | Scalable Capital | CSV (semicolon, EU numbers) | 1 buy, 1 sell, 1 distribution, 1 interest |
 | `freedom24-sample.json` | Freedom24 | JSON (nested report) | 2 trades (buy+sell), 1 dividend with WHT |
 | `kraken-trades-sample.csv` | Kraken | CSV (double-quoted) | 1 BTC buy, 1 ETH sell |
 | `kraken-ledgers-sample.csv` | Kraken | CSV (double-quoted) | 2 staking entries (ETH, DOT) |

--- a/tests/fixtures/scalable-sample.csv
+++ b/tests/fixtures/scalable-sample.csv
@@ -2,3 +2,4 @@ date;time;status;reference;description;assetType;type;isin;shares;price;amount;f
 2024-03-15;09:15;Executed;REF001;Acme World ETF;Security;Buy;XX0000000001;10;110,25;-1102,50;-0,99;0;EUR
 2024-06-20;14:30;Executed;REF002;Acme World ETF;Security;Sell;XX0000000001;-5;120,00;600,00;-0,99;0;EUR
 2024-09-01;08:00;Executed;REF003;Acme World ETF;Security;Distribution;XX0000000001;0;0;15,50;0;-2,33;EUR
+2024-12-31;23:59;Executed;REF004;KKT-Abschluss;Cash;Interest;;0;0;7,45;0;0;EUR

--- a/tests/integration/scalable-interest-e2e.test.ts
+++ b/tests/integration/scalable-interest-e2e.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { scalableParser } from "../../src/parsers/scalable.js";
+import { generateTaxReport } from "../../src/generators/report.js";
+import type { EcbRateMap } from "../../src/types/ecb.js";
+
+// ===========================================================================
+// End-to-end: a Scalable Capital cash/savings-account interest row drives the
+// WHOLE pipeline (scalableParser.parse → generateTaxReport) and lands in the
+// interest block → Casilla 0027 (Art. 25.2 LIRPF). Issue #48: a Scalable user's
+// cash-account interest was in the CSV but silently dropped (the `if (!isin)
+// continue` guard ran before classification). A NEGATIVE interest row is a
+// cash-account charge → Casilla informational "intereses pagados al broker".
+//
+// EUR figures are pinned exactly. The interest is in EUR, so it auto-resolves
+// at rate 1 — but we still pass an in-memory rate map (built like the other
+// integration tests), and NO network fetch ever happens.
+// ===========================================================================
+
+const HEADER =
+  "date;time;status;reference;description;assetType;type;isin;shares;price;amount;fee;tax;currency";
+
+/** Build an in-memory ECB rate map (date → currency → "EUR per 1 FCY"). */
+function makeRateMap(rates: Record<string, Record<string, string>>): EcbRateMap {
+  const map: EcbRateMap = new Map();
+  for (const [date, currencies] of Object.entries(rates)) {
+    map.set(date, new Map(Object.entries(currencies)));
+  }
+  return map;
+}
+
+describe("issue #48 e2e: Scalable cash interest → Casilla 0027", () => {
+  // EUR rows resolve at 1; the map is passed only to match the real call shape.
+  const rates = makeRateMap({ "2024-12-31": { USD: "1.05" } });
+
+  it("a positive EUR interest row of 7,45 lands in interest.earned (0027)", () => {
+    const csv = [
+      HEADER,
+      "2024-12-31;23:59;Executed;REF100;KKT-Abschluss;Cash;Interest;;0;0;7,45;0;0;EUR",
+    ].join("\n");
+    const statement = scalableParser.parse(csv);
+    // IMPORTANT: signature is (statement, rateMap, year) — rate map is the 2nd arg.
+    const report = generateTaxReport(statement, rates, 2024);
+
+    expect(report.interest.earned.toFixed(2)).toBe("7.45");
+    expect(report.interest.paid.toFixed(2)).toBe("0.00");
+    const earned = report.interest.entries.filter((e) => e.type === "earned");
+    expect(earned).toHaveLength(1);
+  });
+
+  it("a negative interest row increments interest.paid (intereses pagados al broker)", () => {
+    const csv = [
+      HEADER,
+      "2024-12-31;23:59;Executed;REF101;KKT-Abschluss;Cash;Interest;;0;0;-4,20;0;0;EUR",
+    ].join("\n");
+    const statement = scalableParser.parse(csv);
+    const report = generateTaxReport(statement, rates, 2024);
+
+    // valueIncomeEur abs()'s the amount; the earned/paid split is by type.
+    expect(report.interest.paid.toFixed(2)).toBe("4.20");
+    expect(report.interest.earned.toFixed(2)).toBe("0.00");
+    const paid = report.interest.entries.filter((e) => e.type === "paid");
+    expect(paid).toHaveLength(1);
+  });
+
+  it("a mixed CSV (positive + negative interest) splits earned vs paid correctly", () => {
+    const csv = [
+      HEADER,
+      "2024-03-31;23:59;Executed;REF102;KKT-Abschluss;Cash;Interest;;0;0;7,45;0;0;EUR",
+      "2024-12-31;23:59;Executed;REF103;KKT-Abschluss;Cash;Interest;;0;0;-1,30;0;0;EUR",
+    ].join("\n");
+    const statement = scalableParser.parse(csv);
+    const report = generateTaxReport(statement, rates, 2024);
+
+    expect(report.interest.earned.toFixed(2)).toBe("7.45");
+    expect(report.interest.paid.toFixed(2)).toBe("1.30");
+  });
+});

--- a/tests/integration/scalable-interest-e2e.test.ts
+++ b/tests/integration/scalable-interest-e2e.test.ts
@@ -74,4 +74,17 @@ describe("issue #48 e2e: Scalable cash interest → Casilla 0027", () => {
     expect(report.interest.earned.toFixed(2)).toBe("7.45");
     expect(report.interest.paid.toFixed(2)).toBe("1.30");
   });
+
+  it("a non-EUR (USD) interest row is converted to EUR at the ECB rate for 0027", () => {
+    // 100 USD interest on 2024-12-31, ECB rate 1.05 EUR/USD → 105.00 EUR in 0027.
+    // Proves the FCY conversion path (the EUR cases short-circuit at rate 1).
+    const csv = [
+      HEADER,
+      "2024-12-31;23:59;Executed;REF104;KKT-Abschluss;Cash;Interest;;0;0;100,00;0;0;USD",
+    ].join("\n");
+    const statement = scalableParser.parse(csv);
+    const report = generateTaxReport(statement, rates, 2024);
+
+    expect(report.interest.earned.toFixed(2)).toBe("105.00");
+  });
 });

--- a/tests/parsers/scalable.test.ts
+++ b/tests/parsers/scalable.test.ts
@@ -318,6 +318,33 @@ describe("scalableParser", () => {
       );
       expect(interest).toHaveLength(0);
     });
+
+    it("should declare interest gross and surface an info message when a tax/withholding is present", () => {
+      const csv = [
+        HEADER,
+        "2024-12-31;23:59;Executed;REF015;KKT-Abschluss;Cash;Interest;;0;0;100,00;0;-19,00;EUR",
+      ].join("\n");
+      const result = scalableParser.parse(csv);
+      const interest = result.cashTransactions.filter((t) => t.type === "Broker Interest Received");
+      expect(interest).toHaveLength(1);
+      // The gross amount is declared in 0027 (no silent net-of-withholding understatement).
+      expect(interest[0]!.amount).toBe("100");
+      // A non-zero tax column is surfaced as an info message, never silently dropped.
+      const msg = result.parserMessages?.find((m) => m.id === "scalable.interest_withholding_detected");
+      expect(msg).toBeDefined();
+      expect(msg!.severity).toBe("info");
+      expect(msg!.context?.count).toBe("1");
+    });
+
+    it("should NOT emit a withholding message when interest rows have no tax", () => {
+      const csv = [
+        HEADER,
+        "2024-12-31;23:59;Executed;REF016;KKT-Abschluss;Cash;Interest;;0;0;12,50;0;0;EUR",
+      ].join("\n");
+      const result = scalableParser.parse(csv);
+      const msg = result.parserMessages?.find((m) => m.id === "scalable.interest_withholding_detected");
+      expect(msg).toBeUndefined();
+    });
   });
 
   describe("error handling", () => {

--- a/tests/parsers/scalable.test.ts
+++ b/tests/parsers/scalable.test.ts
@@ -223,6 +223,103 @@ describe("scalableParser", () => {
     });
   });
 
+  describe("parse interest", () => {
+    const HEADER =
+      "date;time;status;reference;description;assetType;type;isin;shares;price;amount;fee;tax;currency";
+
+    it("should emit a positive interest row as Broker Interest Received (Casilla 0027)", () => {
+      const csv = [
+        HEADER,
+        "2024-12-31;23:59;Executed;REF010;KKT-Abschluss;Cash;Interest;;0;0;12,50;0;0;EUR",
+      ].join("\n");
+      const result = scalableParser.parse(csv);
+      const interest = result.cashTransactions.filter(
+        (t) => t.type === "Broker Interest Received" || t.type === "Broker Interest Paid",
+      );
+      expect(interest).toHaveLength(1);
+      const row = interest[0]!;
+      expect(row.type).toBe("Broker Interest Received");
+      // Amount is normalized through Decimal (toFiniteDecimalString): "12,50" → "12.5".
+      expect(row.amount).toBe("12.5");
+      expect(row.isin).toBe("");
+      expect(row.symbol).toBe("CASH");
+      // No ISIN → must not be parsed as a trade.
+      expect(result.trades).toHaveLength(0);
+    });
+
+    it("should emit a negative interest row as Broker Interest Paid", () => {
+      const csv = [
+        HEADER,
+        "2024-12-31;23:59;Executed;REF011;KKT-Abschluss;Cash;Interest;;0;0;-3,20;0;0;EUR",
+      ].join("\n");
+      const result = scalableParser.parse(csv);
+      const interest = result.cashTransactions.filter(
+        (t) => t.type === "Broker Interest Received" || t.type === "Broker Interest Paid",
+      );
+      expect(interest).toHaveLength(1);
+      expect(interest[0]!.type).toBe("Broker Interest Paid");
+      expect(interest[0]!.amount).toBe("-3.2");
+    });
+
+    it("should recognize German 'Zinsen'", () => {
+      const csv = [
+        HEADER,
+        "2024-12-31;23:59;Executed;REF012;KKT-Abschluss;Cash;Zinsen;;0;0;5,00;0;0;EUR",
+      ].join("\n");
+      const result = scalableParser.parse(csv);
+      expect(result.cashTransactions.filter((t) => t.type === "Broker Interest Received")).toHaveLength(1);
+    });
+
+    it("should recognize Spanish 'Intereses'", () => {
+      const csv = [
+        HEADER,
+        "2024-12-31;23:59;Ejecutada;REF013;Liquidación de cuenta;Cash;Intereses;;0;0;8,00;0;0;EUR",
+      ].join("\n");
+      const result = scalableParser.parse(csv);
+      expect(result.cashTransactions.filter((t) => t.type === "Broker Interest Received")).toHaveLength(1);
+    });
+
+    it("should skip a zero-amount interest row", () => {
+      const csv = [
+        HEADER,
+        "2024-12-31;23:59;Executed;REF014;KKT-Abschluss;Cash;Interest;;0;0;0;0;0;EUR",
+      ].join("\n");
+      const result = scalableParser.parse(csv);
+      const interest = result.cashTransactions.filter(
+        (t) => t.type === "Broker Interest Received" || t.type === "Broker Interest Paid",
+      );
+      expect(interest).toHaveLength(0);
+    });
+
+    it("should not change the trade count when interest is mixed into a multi-row CSV", () => {
+      const csv = [
+        HEADER,
+        "2024-03-15;09:15;Executed;REF001;Acme World ETF;Security;Buy;IE00BK5BQT80;10;110,25;-1102,50;-0,99;0;EUR",
+        "2024-06-20;14:30;Executed;REF002;Acme World ETF;Security;Sell;IE00BK5BQT80;-5;120,00;600,00;-0,99;0;EUR",
+        "2024-12-31;23:59;Executed;REF004;KKT-Abschluss;Cash;Interest;;0;0;7,45;0;0;EUR",
+      ].join("\n");
+      const result = scalableParser.parse(csv);
+      // The interest row must not be counted as a trade.
+      expect(result.trades).toHaveLength(2);
+      expect(result.cashTransactions.filter((t) => t.type === "Broker Interest Received")).toHaveLength(1);
+    });
+
+    it("should NOT sweep a security whose description contains 'interest' but is a Buy", () => {
+      const csv = [
+        HEADER,
+        "2024-03-15;09:15;Executed;REF020;Global Interest Rate ETF;Security;Buy;IE00BK5BQT80;10;100,00;-1000,00;0;0;EUR",
+      ].join("\n");
+      const result = scalableParser.parse(csv);
+      // Matched on the `type` column only → parsed as a TRADE, never as interest.
+      expect(result.trades).toHaveLength(1);
+      expect(result.trades[0]!.buySell).toBe("BUY");
+      const interest = result.cashTransactions.filter(
+        (t) => t.type === "Broker Interest Received" || t.type === "Broker Interest Paid",
+      );
+      expect(interest).toHaveLength(0);
+    });
+  });
+
   describe("error handling", () => {
     it("should throw on empty input", () => {
       expect(() => scalableParser.parse("")).toThrow("vacío");


### PR DESCRIPTION
## What

Teaches the **Scalable Capital** CSV parser to recognize **cash/savings-account interest** rows (`KKT-Abschluss`), which were previously dropped silently. Requested in #48 by a Scalable user whose cash-account interest is present in the export but not captured.

## Why it was missing

Interest rows carry **no ISIN**, and the parser's `if (!isin) continue;` guard ran *before* any classification — so every interest row died before it could be recognized.

## The change (surgical, parser-only)

- New `INTEREST_TYPES = ["interes", "zins"]` matched on the **`type` column only** (covers EN `interest`, ES `intereses`, DE `zinsen`). Matching `type` — not the free-text description — avoids sweeping a security named e.g. "Global Interest Rate ETF".
- The interest branch is inserted **above** the no-ISIN guard (with a comment explaining why it must stay there).
- **Sign decides the IRPF treatment** (the downstream split in `report.ts` is by `CashTransaction.type`; the amount is `abs()`'d):
  - positive → `Broker Interest Received` → **Casilla 0027** (Art. 25.2 LIRPF, base del ahorro)
  - negative → `Broker Interest Paid` → informational, non-deductible (Art. 26.1.a)
  - zero → skipped
- Emits a `CashTransaction` mirroring the existing Trade Republic / Lightyear / Trading 212 / eToro interest precedent (`symbol: "CASH"`, `isin: ""`). **No engine or renderer changes** — the entire 0027 pipeline already existed; the parser just never fed it.

### Intentionally NOT done
- **PRIME subscription / fee rows** stay skipped (no ISIN). A flat broker subscription is **not** a "gasto de administración y depósito de valores negociables" under Art. 26.1.a, so it is **not IRPF-deductible** — see the issue thread for the full reasoning. No fee-deduction code added.
- **Foreign withholding on interest** (Casilla 0588) is out of scope — Scalable cash interest to non-residents is typically paid gross. Flagged with a code comment for a future follow-up if a real file shows otherwise.

## Docs fix (bundled)

`docs/casillas.md` had two wrong casilla numbers, now corrected:
- Interest is **Casilla 0027** (was mislabeled 0033).
- Added notes: genuine custody/admin fees are deductible in **Casilla 0037** (Art. 26.1.a); flat broker subscriptions are not.

## Tests

- Unit (`tests/parsers/scalable.test.ts`): positive→Received, negative→Paid, German `Zinsen`, Spanish `Intereses`, zero-amount skip, trade-count invariance, and a "description contains interest but type=Buy" row that must parse as a **trade** (zero interest rows).
- Integration (`tests/integration/scalable-interest-e2e.test.ts`, new): drives `scalableParser.parse` → `generateTaxReport` and pins `report.interest.earned === 7.45` for a EUR interest row; negative → `interest.paid`.
- Fixture: one anonymized interest row appended to `scalable-sample.csv`.
- **Full suite: 82 files, 1585 tests, all passing. Typecheck clean. Zero regressions.**

Refs #48