### PR TITLE
fix(fx): monodivisa reproduces traditional cost basis (Art. 35.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,7 +252,7 @@ When adding a new section (like 721), follow this checklist:
 ### Monodivisa Mode
 - Optional toggle in fiscal profile (`monodivisa: boolean`) + CLI `--monodivisa` flag
 - When active: skips the FX FIFO engine entirely (`skipFx: true` in `ReportOptions`)
-- Capital gains still computed correctly in EUR via ECB rates — only separate FX lot tracking is skipped
+- `skipFx` ALSO sets `FifoEngine({traditionalCostBasis:true})` → a same-fiat FCY security's cost converts at the ACQUISITION-date rate (Art. 35.1), embedding the buy→sale FX drift in the stock line (the FX engine being off). Drift counted exactly once (stock line here, FX engine in default); capital gains deliberately DIFFER from the FX-on case — don't "fix" back to sale-date cost. Also affects option-exercise delivery + same-stablecoin permutas.
 - Matches behavior of Autodeclaro/Taxdown (competitors don't calculate Art. 37.1.l FX gains)
 - Warning text must say "distorsionar" not "infraestimar" — monodivisa can both understate (miss FX gains) and overstate (miss FX losses)
 - Art. 80 double taxation deduction is subtly affected (lower `totalSavingsBase` when FX gains are skipped) — accepted known limitation matching competitors

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -127,7 +127,7 @@ program
   .option("-f, --format <format>", "Output format: json, csv, or pdf", "json")
   .option("-b, --broker <name>", `Broker name. Auto-detected if omitted. Available: ${brokerParsers.map((p) => p.name).join(", ")}`)
   .option("--prior-losses <file>", "JSON file with prior year losses for carryforward (Art. 49 LIRPF)")
-  .option("--monodivisa", "Disable FX FIFO engine — treat all as EUR (like Autodeclaro/Taxdown)")
+  .option("--monodivisa", "Modo tradicional (como Autodeclaro/Taxdown/asesor): apaga el motor de divisa y valora el coste FCY al tipo del día de COMPRA (Art. 35.1), embebiendo el efecto divisa en la línea de la acción")
   .option("--skip-auto-convert", "No tratar las autoconversiones del bróker (AFx/FXCONV) como conversiones de divisa. Por defecto SÍ se procesan (IBKR no reconvierte a EUR al vender, así que el saldo en divisa es real). Actívalo solo si tu bróker hace round-trip completo y quieres ignorar el efecto divisa.")
   .option("--titulares <n>", "Number of account holders. >1 splits all amounts equally per contribuyente (Art. 11.3 LIRPF)", parseInt)
   .option("--crypto-rates <json>", "Manual EUR-per-unit quotes for crypto↔crypto swaps without an ECB rate. Inline JSON or path to a JSON file: [{ \"currency\": \"SOL\", \"date\": \"2024-03-01\", \"eurPerUnit\": \"120.50\" }]")

--- a/src/engine/fifo.ts
+++ b/src/engine/fifo.ts
@@ -31,6 +31,21 @@ export class FifoEngine {
   private shortLots: Map<string, Lot[]> = new Map();
   private disposals: FifoDisposal[] = [];
   private nextLotId = 1;
+  /**
+   * Monodivisa (traditional) mode. When true, a foreign-currency security's cost
+   * basis is converted at the ACQUISITION-date rate (Art. 35.1 "importe real por
+   * el que la adquisición se hubiese efectuado"), embedding the buy→sale FX drift
+   * in the stock line — what some advisors do. When false (rigorous
+   * default), a same-fiat security uses the sale-date rate (DGT V2422-20) and the
+   * drift is realized separately by the FX engine. Driven by `skipFx` (monodivisa)
+   * in report.ts; the two states are coherent (never traditional-cost WITH the FX
+   * engine on, which would double-count the drift). See disposalEur().
+   */
+  private traditionalCostBasis: boolean;
+
+  constructor(options?: { traditionalCostBasis?: boolean }) {
+    this.traditionalCostBasis = options?.traditionalCostBasis ?? false;
+  }
   /** Warnings for issues that don't block execution */
   warnings: string[] = [];
   /** Structured messages with severity, hint, and context */
@@ -424,6 +439,11 @@ export class FifoEngine {
    * currency AND that currency is genuinely ECB-resolvable (fiat/stablecoin);
    * otherwise the acquisition-date rate is used. Proceeds always use the sale-date
    * rate; the gain is their difference (Art. 37.1.h).
+   *
+   * Monodivisa (`traditionalCostBasis`): even for a same-fiat security the cost
+   * uses the ACQUISITION-date rate (Art. 35.1), so the buy→sale FX drift stays
+   * embedded in the stock line instead of being deferred to the (disabled) FX
+   * engine — reproducing the traditional method some advisors use.
    */
   private disposalEur(
     proceedsFcy: Decimal, costBasisFcy: Decimal,
@@ -436,7 +456,9 @@ export class FifoEngine {
     // (cross-currency permuta, or the same VOLATILE coin on both sides) → cost
     // at the acquisition-date rate (the real EUR paid, Art. 35.1).
     const sameFiat = lot.currency === sell.currency && isEcbResolvable(sell.currency);
-    const costBasisEur = costBasisFcy.mul(sameFiat ? sell.rate : lot.rate);
+    const costBasisEur = costBasisFcy.mul(
+      sameFiat && !this.traditionalCostBasis ? sell.rate : lot.rate,
+    );
     return { proceedsEur, costBasisEur, gainLossEur: proceedsEur.minus(costBasisEur) };
   }
 

--- a/src/generators/report.ts
+++ b/src/generators/report.ts
@@ -330,8 +330,12 @@ export function generateTaxReport(
   const rewardLots = synthesizeRewardLots(statement.cashTransactions, resolvedRateMap, manualRates);
   const resolvedTrades = [...valuation.trades, ...rewardLots];
 
-  // 1. FIFO capital gains (process ALL years, filter to target year)
-  const fifoEngine = new FifoEngine();
+  // 1. FIFO capital gains (process ALL years, filter to target year).
+  //    Monodivisa (skipFx) → traditional cost basis: a FCY security's cost is
+  //    converted at the ACQUISITION-date rate (Art. 35.1), embedding the buy→sale
+  //    FX drift in the stock line since the FX engine is off. Default (rigorous):
+  //    same-fiat cost at the sale-date rate (V2422-20), drift to the FX engine.
+  const fifoEngine = new FifoEngine({ traditionalCostBasis: options?.skipFx });
   fifoEngine.processTrades(
     resolvedTrades,
     resolvedRateMap,

--- a/src/i18n/locales/ca.ts
+++ b/src/i18n/locales/ca.ts
@@ -181,7 +181,7 @@ const ca: TranslationKeys = {
   "profile.phone_label": "Telèfon:",
   "profile.phone_placeholder": "600123456",
   "profile.monodivisa_label": "Mode simplificat (monodivisa EUR)",
-  "profile.monodivisa_detail": "No calcula guanys per tipus de canvi de forma separada (caselles 1633/1637). Compatible amb Autodeclaro, Taxdown i altres serveis que tracten totes les operacions com a moneda única EUR.",
+  "profile.monodivisa_detail": "No calcula guanys per tipus de canvi de forma separada (caselles 1633/1637): l'efecte divisa queda embegut en el cost de l'acció, valorat al tipus del dia de COMPRA (Art. 35.1). Compatible amb Autodeclaro, Taxdown i altres serveis (i amb el mètode tradicional que fan servir alguns assessors) que tracten totes les operacions com a moneda única EUR.",
   "profile.monodivisa_warning": "⚠ Aquest mode pot distorsionar els guanys patrimonials declarats (infraestimar o sobreestimar). El mode complet (per defecte) és més rigorós segons l'Art. 33.1 LIRPF (DGT V2324-10).",
   "profile.track_autoconvert_label": "Processar les autoconversions del bróker (AFx/FXCONV)",
   "profile.track_autoconvert_detail": "Activat per defecte. Interactive Brokers no reconverteix a euros en vendre una acció, així que el saldo en divisa és real i convertir-lo després genera un guany o pèrdua patrimonial (art. 33.1 LIRPF). Desactiva-ho només si el teu bróker fa un round-trip complet EUR↔divisa i vols ignorar l'efecte de la divisa.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -182,7 +182,7 @@ const en: TranslationKeys = {
   "profile.phone_label": "Phone:",
   "profile.phone_placeholder": "600123456",
   "profile.monodivisa_label": "Simplified mode (single-currency EUR)",
-  "profile.monodivisa_detail": "Does not calculate FX gains separately (casillas 1633/1637). Compatible with Autodeclaro, Taxdown, and other services that treat all operations as single-currency EUR.",
+  "profile.monodivisa_detail": "Does not calculate FX gains separately (casillas 1633/1637): the currency effect is embedded in the stock cost, valued at the BUY-date rate (Art. 35.1). Compatible with Autodeclaro, Taxdown, and other services (and the traditional method some advisors use) that treat all operations as single-currency EUR.",
   "profile.monodivisa_warning": "⚠ This mode may distort reported capital gains (understate or overstate). The full mode (default) is more rigorous per Art. 33.1 LIRPF (DGT V2324-10).",
   "profile.track_autoconvert_label": "Process broker auto-conversions (AFx/FXCONV)",
   "profile.track_autoconvert_detail": "On by default. Interactive Brokers does not convert back to euros when you sell a stock, so the currency balance is real and converting it later produces a capital gain or loss (Art. 33.1 LIRPF). Turn it off only if your broker does a full EUR↔currency round-trip and you want to ignore the currency effect.",

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -193,7 +193,7 @@ const es = {
   "profile.phone_label": "Teléfono:",
   "profile.phone_placeholder": "600123456",
   "profile.monodivisa_label": "Modo simplificado (monodivisa EUR)",
-  "profile.monodivisa_detail": "No calcula ganancias por tipo de cambio de forma separada (casillas 1633/1637). Compatible con el enfoque de Autodeclaro, Taxdown y otros servicios que tratan todas las operaciones como moneda única EUR.",
+  "profile.monodivisa_detail": "No calcula ganancias por tipo de cambio de forma separada (casillas 1633/1637): el efecto divisa queda embebido en el coste de la acción, valorado al tipo del día de COMPRA (Art. 35.1). Compatible con el enfoque de Autodeclaro, Taxdown y otros servicios (y con el método tradicional que usan algunos asesores) que tratan todas las operaciones como moneda única EUR.",
   "profile.monodivisa_warning": "⚠ Este modo puede distorsionar las ganancias patrimoniales declaradas (infraestimar o sobreestimar). El modo completo (por defecto) es más riguroso según el Art. 33.1 LIRPF (DGT V2324-10).",
   "profile.track_autoconvert_label": "Procesar autoconversiones del bróker (AFx/FXCONV)",
   "profile.track_autoconvert_detail": "Activado por defecto. Interactive Brokers no reconvierte a euros al vender una acción, así que el saldo en divisa es real y su conversión posterior genera ganancia o pérdida patrimonial (Art. 33.1 LIRPF). Desactívalo solo si tu bróker hace un round-trip completo EUR↔divisa y quieres ignorar el efecto de la divisa.",

--- a/src/i18n/locales/eu.ts
+++ b/src/i18n/locales/eu.ts
@@ -181,7 +181,7 @@ const eu: TranslationKeys = {
   "profile.phone_label": "Telefonoa:",
   "profile.phone_placeholder": "600123456",
   "profile.monodivisa_label": "Modu sinplifikatua (monodibisa EUR)",
-  "profile.monodivisa_detail": "Ez ditu kanbio-tasaren irabaziak bereizita kalkulatzen (1633/1637 laukitxoak). Autodeclaro, Taxdown eta eragiketa guztiak EUR moneta bakar gisa tratatzen dituzten beste zerbitzu batzuekin bateragarria.",
+  "profile.monodivisa_detail": "Ez ditu kanbio-tasaren irabaziak bereizita kalkulatzen (1633/1637 laukitxoak): dibisaren eragina akzioaren kostuan txertatuta geratzen da, EROSKETA-eguneko tasarekin balioetsita (35.1 art.). Autodeclaro, Taxdown eta eragiketa guztiak EUR moneta bakar gisa tratatzen dituzten beste zerbitzu batzuekin bateragarria (eta aholkulari batzuek erabiltzen duten metodo tradizionalarekin).",
   "profile.monodivisa_warning": "⚠ Modu honek adierazitako ondare-irabaziak distortsionatu ditzake (gutxietsi edo gehiegietsi). Modu osoa (lehenetsita) zorrotzagoa da 33.1 Art. LIRPF (DGT V2324-10) arabera.",
   "profile.track_autoconvert_label": "Prozesatu artekariaren auto-bihurketak (AFx/FXCONV)",
   "profile.track_autoconvert_detail": "Lehenetsita aktibatuta. Interactive Brokersek ez du eurotara berriz bihurtzen akzio bat saltzean, beraz dibisa-saldoa erreala da eta gero bihurtzeak ondare-irabazi edo -galera sortzen du (LIRPF 33.1 art.). Desaktibatu soilik zure artekariak EUR↔dibisa round-trip osoa egiten badu eta dibisaren eragina alde batera utzi nahi baduzu.",

--- a/src/i18n/locales/gl.ts
+++ b/src/i18n/locales/gl.ts
@@ -181,7 +181,7 @@ const gl: TranslationKeys = {
   "profile.phone_label": "Teléfono:",
   "profile.phone_placeholder": "600123456",
   "profile.monodivisa_label": "Modo simplificado (monodivisa EUR)",
-  "profile.monodivisa_detail": "Non calcula ganancias por tipo de cambio de forma separada (casillas 1633/1637). Compatible con Autodeclaro, Taxdown e outros servizos que tratan todas as operacións como moeda única EUR.",
+  "profile.monodivisa_detail": "Non calcula ganancias por tipo de cambio de forma separada (casillas 1633/1637): o efecto divisa queda embebido no custo da acción, valorado ao tipo do día de COMPRA (Art. 35.1). Compatible con Autodeclaro, Taxdown e outros servizos (e co método tradicional que usan algúns asesores) que tratan todas as operacións como moeda única EUR.",
   "profile.monodivisa_warning": "⚠ Este modo pode distorsionar as ganancias patrimoniais declaradas (infraestimar ou sobreestimar). O modo completo (por defecto) é máis rigoroso segundo o Art. 33.1 LIRPF (DGT V2324-10).",
   "profile.track_autoconvert_label": "Procesar as autoconversións do bróker (AFx/FXCONV)",
   "profile.track_autoconvert_detail": "Activado por defecto. Interactive Brokers non reconverte a euros ao vender unha acción, así que o saldo en divisa é real e convertelo despois xera unha ganancia ou perda patrimonial (art. 33.1 LIRPF). Desactívao só se o teu bróker fai un round-trip completo EUR↔divisa e queres ignorar o efecto da divisa.",

--- a/tests/engine/fifo-permuta-cost-basis.test.ts
+++ b/tests/engine/fifo-permuta-cost-basis.test.ts
@@ -155,3 +155,89 @@ describe("FIFO — cross-currency permuta cost basis (€35M bug regression)", (
     expect(ds[1]!.costBasisEur.toFixed(2)).toBe("40.00"); // lot2: 50 × 0.80 (USDT→USD)
   });
 });
+
+// Monodivisa (traditional method, Art. 35.1): FifoEngine({traditionalCostBasis})
+// converts a SAME-FIAT security's cost at the ACQUISITION-date rate (not the
+// sale-date rate of the rigorous V2422-20 default), embedding the buy→sale FX
+// drift in the stock line. Pins that the flag (a) flips same-fiat stocks, (b)
+// ALSO flips same-stablecoin permutas (isEcbResolvable true for USDT/USDC), and
+// (c) leaves cross-currency crypto permutas — which already use lot.rate —
+// byte-identical regardless of the flag.
+describe("FIFO — monodivisa traditionalCostBasis (Art. 35.1)", () => {
+  it("flips a same-fiat USD stock cost to the BUY-date rate", () => {
+    // Buy 1000 USD @ 0.77, sell 1000 USD @ 0.67 (0 USD price move).
+    const buy = trade({
+      symbol: "AAPL", assetCategory: "STK", currency: "USD", buySell: "BUY",
+      tradeDate: "2025-01-10", settlementDate: "2025-01-10",
+      quantity: "10", tradePrice: "100", cost: "1000", commissionCurrency: "USD",
+    });
+    const sell = trade({
+      symbol: "AAPL", assetCategory: "STK", currency: "USD", buySell: "SELL",
+      openCloseIndicator: "C", tradeDate: "2025-06-01", settlementDate: "2025-06-01",
+      quantity: "-10", tradePrice: "100", proceeds: "1000", cost: "0", commissionCurrency: "USD",
+    });
+    const rateMap = makeRateMap({
+      "2025-01-10": { USD: "0.77" },
+      "2025-06-01": { USD: "0.67" },
+    });
+
+    // Default (rigorous, V2422-20): both legs at the sale rate → 0 EUR gain.
+    const def = new FifoEngine().processTrades([buy, sell], rateMap)[0]!;
+    expect(def.costBasisEur.toFixed(2)).toBe("670.00");
+    expect(def.gainLossEur.toFixed(2)).toBe("0.00");
+
+    // Monodivisa (traditional): cost at the BUY rate (1000 × 0.77 = 770),
+    // proceeds at the sale rate (670) → the −100 FX drift embeds in the stock.
+    const trad = new FifoEngine({ traditionalCostBasis: true }).processTrades([buy, sell], rateMap)[0]!;
+    expect(trad.costBasisEur.toFixed(2)).toBe("770.00");
+    expect(trad.proceedsEur.toFixed(2)).toBe("670.00");
+    expect(trad.gainLossEur.toFixed(2)).toBe("-100.00");
+  });
+
+  it("ALSO flips a same-stablecoin permuta cost to the BUY-date rate (USDT both legs)", () => {
+    // BUY 100 USDC paying 100 USDT, SELL 100 USDC for 110 USDT. Both legs carry
+    // currency USDT (→ USD, isEcbResolvable). USD/EUR: 0.90 (buy) → 1.00 (sell).
+    const buy = trade({ buySell: "BUY", currency: "USDT", symbol: "USDC", quantity: "100", tradePrice: "1", cost: "100", commissionCurrency: "USDT" });
+    const sell = trade({
+      buySell: "SELL", openCloseIndicator: "C", currency: "USDT", symbol: "USDC",
+      tradeDate: "2025-04-06", settlementDate: "2025-04-06",
+      quantity: "-100", tradePrice: "1.1", proceeds: "110", cost: "0", commissionCurrency: "USDT",
+    });
+    const rateMap = makeRateMap({
+      "2025-03-14": { USD: "0.90" },
+      "2025-04-06": { USD: "1.00" },
+    });
+
+    // Default: cost at the sale rate (100 × 1.00 = 100), gain 10.
+    const def = new FifoEngine().processTrades([buy, sell], rateMap)[0]!;
+    expect(def.costBasisEur.toFixed(2)).toBe("100.00");
+    expect(def.gainLossEur.toFixed(2)).toBe("10.00");
+
+    // Monodivisa: cost at the BUY rate (100 × 0.90 = 90), proceeds 110 → gain 20.
+    const trad = new FifoEngine({ traditionalCostBasis: true }).processTrades([buy, sell], rateMap)[0]!;
+    expect(trad.costBasisEur.toFixed(2)).toBe("90.00");
+    expect(trad.proceedsEur.toFixed(2)).toBe("110.00");
+    expect(trad.gainLossEur.toFixed(2)).toBe("20.00");
+  });
+
+  it("leaves a cross-currency crypto permuta byte-identical with or without the flag", () => {
+    // BUY 300 USDC paying 277.5 EUR, SELL for BTC. Already on the lot.rate path
+    // (buy-ccy ≠ sell-ccy), so traditionalCostBasis must NOT change anything.
+    const buy = trade({ buySell: "BUY", currency: "EUR", quantity: "300", tradePrice: "0.925", cost: "277.5" });
+    const sell = trade({
+      buySell: "SELL", openCloseIndicator: "C", currency: "BTC", symbol: "USDC",
+      tradeDate: "2025-04-06", settlementDate: "2025-04-06",
+      quantity: "-300", tradePrice: "0.00001259", proceeds: "0.003777", cost: "0",
+      commissionCurrency: "BTC",
+    });
+    const rateMap = makeRateMap({
+      "2025-03-14": { EUR: "1", BTC: "70000" },
+      "2025-04-06": { EUR: "1", BTC: "78890.273739" },
+    });
+    const def = new FifoEngine().processTrades([buy, sell], rateMap)[0]!;
+    const trad = new FifoEngine({ traditionalCostBasis: true }).processTrades([buy, sell], rateMap)[0]!;
+    expect(trad.costBasisEur.toFixed(2)).toBe(def.costBasisEur.toFixed(2));
+    expect(trad.gainLossEur.toFixed(2)).toBe(def.gainLossEur.toFixed(2));
+    expect(trad.costBasisEur.toFixed(2)).toBe("277.50");
+  });
+});

--- a/tests/generators/report.test.ts
+++ b/tests/generators/report.test.ts
@@ -295,10 +295,44 @@ describe("generateTaxReport", () => {
     expect(report.fxGains.transmissionValue.toFixed(2)).toBe("0.00");
     expect(report.fxGains.acquisitionValue.toFixed(2)).toBe("0.00");
     expect(report.fxGains.netGainLoss.toFixed(2)).toBe("0.00");
-    // Capital gains still computed normally — gain in USD (200) converted at the
-    // SALE-date rate (0.91, DGT V2422-20): 200 × 0.91 = 182.00 EUR
+    // Capital gains still computed normally. Monodivisa → traditional method
+    // (Art. 35.1): cost at the BUY-date rate, proceeds at the SALE-date rate, FX
+    // drift embedded in the stock line (the FX engine is off).
+    //   proceeds = 10 × 120 USD × 0.91 (sale) = 1092.00 EUR
+    //   cost     = 10 × 100 USD × 0.92 (buy)  =  920.00 EUR
+    //   gain     = 172.00 EUR
     expect(report.capitalGains.disposals).toHaveLength(1);
-    expect(report.capitalGains.netGainLoss.toFixed(2)).toBe("182.00");
+    expect(report.capitalGains.netGainLoss.toFixed(2)).toBe("172.00");
+  });
+
+  it("monodivisa reproduces the traditional method (advisor) — ISSUE.md example", () => {
+    // Canonical reconciliation from ISSUE.md: a FCY stock round-trip.
+    //   BUY  100 @ $20.00 on 2025-05-15  (1 USD = 0.8780 EUR)
+    //   SELL 100 @ $25.00 on 2025-10-15  (1 USD = 0.8547 EUR)
+    // Traditional (Art. 35.1): cost at the buy rate, proceeds at the sale rate,
+    // FX drift embedded in the stock line; the FX engine is off.
+    //   cost     = 2000 USD × 0.8780 = 1756.00 EUR
+    //   proceeds = 2500 USD × 0.8547 = 2136.75 EUR
+    //   gain     =  380.75 EUR  ← exactly what an advisor (and the rigorous
+    //              default after USD→EUR conversion) reconciles to.
+    const rates = makeRateMap({
+      "2025-05-15": "0.8780",
+      "2025-10-15": "0.8547",
+    });
+    const statement = makeStatement({
+      trades: [
+        makeTrade({ tradeID: "1", tradeDate: "2025-05-15", quantity: "100", tradePrice: "20", buySell: "BUY" }),
+        makeTrade({ tradeID: "2", tradeDate: "2025-10-15", quantity: "-100", tradePrice: "25", buySell: "SELL" }),
+      ],
+    });
+
+    const report = generateTaxReport(statement, rates, 2025, { skipFx: true });
+
+    expect(report.fxGains.netGainLoss.toFixed(2)).toBe("0.00");
+    expect(report.capitalGains.disposals).toHaveLength(1);
+    expect(report.capitalGains.transmissionValue.toFixed(2)).toBe("2136.75");
+    expect(report.capitalGains.acquisitionValue.toFixed(2)).toBe("1756.00");
+    expect(report.capitalGains.netGainLoss.toFixed(2)).toBe("380.75");
   });
 
   it("should produce non-zero FX gains when skipFx is false with manual CASH trades", () => {

--- a/tests/integration/fx-carry-basis-e2e.test.ts
+++ b/tests/integration/fx-carry-basis-e2e.test.ts
@@ -499,10 +499,12 @@ describe("carry-basis e2e #3: buy consumes the cheap tranche → leftover micro-
 //
 // Monodivisa mode (Autodeclaro/Taxdown parity) disables the whole FX FIFO
 // engine — including the carry-basis stock-buy/sell producers (they live inside
-// the same `skipFx` block in report.ts). So the headline scenario that produces
-// €155 of carry-basis FX gain with FX ON produces ZERO FX with FX OFF, while the
-// EUR stock gain (computed via ECB rates) is unchanged at €100.
-describe("carry-basis e2e #4: monodivisa (skipFx) zeroes the carry-basis FX, keeps the stock gain", () => {
+// the same `skipFx` block in report.ts) — AND values the stock cost at the
+// ACQUISITION-date rate (traditional method, Art. 35.1). So the headline scenario
+// that produces €155 of carry-basis FX gain with FX ON produces ZERO FX with FX
+// OFF, while the buy→sale FX drift on the AAPL principal (1000 USD × (1.00 − 0.95)
+// = 50) is EMBEDDED in the stock gain, which becomes €150 (€100 + €50).
+describe("carry-basis e2e #4: monodivisa (skipFx) → traditional cost basis (Art. 35.1)", () => {
   const rates = makeRateMap({
     "2024-02-01": { USD: "0.90" },
     "2024-03-15": { USD: "0.95" },
@@ -525,11 +527,14 @@ describe("carry-basis e2e #4: monodivisa (skipFx) zeroes the carry-basis FX, kee
     expect(report.fxGains.netGainLoss.toFixed(2)).toBe("0.00");
   });
 
-  it("keeps the stock capital gain identical to the FX-on case (€100.00)", () => {
+  it("embeds the buy→sale FX drift in the stock gain (€150.00)", () => {
+    // cost     = 1000 USD × 0.95 (buy rate)  =  950.00 EUR  (Art. 35.1)
+    // proceeds = 1100 USD × 1.00 (sale rate) = 1100.00 EUR
+    // gain     = 150.00 EUR  (= FX-on stock gain 100 + embedded drift 50)
     expect(report.capitalGains.disposals).toHaveLength(1);
     expect(report.capitalGains.transmissionValue.toFixed(2)).toBe("1100.00");
-    expect(report.capitalGains.acquisitionValue.toFixed(2)).toBe("1000.00");
-    expect(report.capitalGains.netGainLoss.toFixed(2)).toBe("100.00");
+    expect(report.capitalGains.acquisitionValue.toFixed(2)).toBe("950.00");
+    expect(report.capitalGains.netGainLoss.toFixed(2)).toBe("150.00");
   });
 });
 

--- a/tests/integration/fx-stock-proceeds-e2e.test.ts
+++ b/tests/integration/fx-stock-proceeds-e2e.test.ts
@@ -240,14 +240,18 @@ describe("issue #230 e2e: sell foreign stock but never convert → FX deferred (
 });
 
 // ===========================================================================
-// 3. MONODIVISA — same as #1 but skipFx:true → no stock-FX, stock gain intact.
+// 3. MONODIVISA — same as #1 but skipFx:true → traditional method (Art. 35.1).
 // ===========================================================================
 //
 // Monodivisa mode (Autodeclaro/Taxdown parity) disables the FX FIFO engine
-// entirely. The foreign-stock-proceeds producer lives inside the same skipFx
-// block, so it is suppressed too: no FX disposal, all FX casillas zero. The
-// EUR stock gain is unaffected (still computed via ECB rates).
-describe("issue #230 e2e: monodivisa (skipFx) suppresses stock-FX, keeps the stock gain", () => {
+// entirely AND values the stock cost at the ACQUISITION-date rate (the
+// traditional method some advisors use, Art. 35.1). The foreign-stock-proceeds
+// producer lives inside the same skipFx block, so it is suppressed too: no FX
+// disposal, all FX casillas zero. The buy→sale FX drift is NOT lost — it is
+// EMBEDDED in the stock line (cost at the buy rate, proceeds at the sale rate),
+// so the monodivisa stock gain INTENTIONALLY differs from the FX-on case by
+// exactly that drift (15000 USD × (0.95 − 0.90) = 750.00).
+describe("issue #230 e2e: monodivisa (skipFx) → traditional cost basis (Art. 35.1)", () => {
   const rates = makeRateMap({
     "2024-03-15": { USD: "0.90" },
     "2024-06-20": { USD: "0.95" },
@@ -256,11 +260,14 @@ describe("issue #230 e2e: monodivisa (skipFx) suppresses stock-FX, keeps the sto
   const statement = makeStatement([AAPL_BUY, AAPL_SELL, usdToEurConversion("2024-09-10")]);
   const report = generateTaxReport(statement, rates, 2024, { skipFx: true });
 
-  it("keeps the stock capital gain identical to the FX-on case (4750.00)", () => {
+  it("embeds the buy→sale FX drift in the stock gain (5500.00)", () => {
+    // cost     = 15000 USD × 0.90 (buy rate)  = 13500.00 EUR  (Art. 35.1)
+    // proceeds = 20000 USD × 0.95 (sale rate) = 19000.00 EUR
+    // gain     = 5500.00 EUR  (= FX-on stock gain 4750 + embedded drift 750)
     expect(report.capitalGains.disposals).toHaveLength(1);
     expect(report.capitalGains.transmissionValue.toFixed(2)).toBe("19000.00");
-    expect(report.capitalGains.acquisitionValue.toFixed(2)).toBe("14250.00");
-    expect(report.capitalGains.netGainLoss.toFixed(2)).toBe("4750.00");
+    expect(report.capitalGains.acquisitionValue.toFixed(2)).toBe("13500.00");
+    expect(report.capitalGains.netGainLoss.toFixed(2)).toBe("5500.00");
   });
 
   it("zeroes the entire FX block (no separate FX saldo in monodivisa)", () => {

--- a/tests/integration/fx-trace-e2e.test.ts
+++ b/tests/integration/fx-trace-e2e.test.ts
@@ -413,7 +413,9 @@ describe("fx-trace e2e #3: loss-sell with NO conversion → trace shows a discar
 // mode disables the WHOLE FX FIFO engine (the `if (!options?.skipFx)` block in
 // report.ts never runs), so the engine — and therefore the trace — never exists.
 // Even with `fxTrace: true` ALSO set, `report.fxTrace` is gracefully `undefined`
-// (the trace is captured only inside the FX block). The stock gain is unchanged.
+// (the trace is captured only inside the FX block). The stock cost uses the
+// ACQUISITION-date rate (traditional method, Art. 35.1), so the buy→sale FX
+// drift on the principal is embedded in the stock loss.
 // ===========================================================================
 describe("fx-trace e2e #4: monodivisa (skipFx) → fxTrace is gracefully absent even if requested", () => {
   const rates = makeRateMap({
@@ -431,10 +433,15 @@ describe("fx-trace e2e #4: monodivisa (skipFx) → fxTrace is gracefully absent 
     expect(report.fxTrace).toBeUndefined();
   });
 
-  it("zeroes the FX block and keeps the stock loss in EUR (−€160.00)", () => {
+  it("zeroes the FX block; the stock loss embeds the buy→sale FX drift (−€560.00)", () => {
+    // Traditional method (Art. 35.1): cost at the buy-date rate, proceeds at the
+    // sale-date rate, FX drift embedded in the stock line (FX engine off).
+    //   cost     = 1000 USD × 1.20 (buy)  = 1200.00 EUR
+    //   proceeds =  800 USD × 0.80 (sale) =  640.00 EUR
+    //   loss     = −560.00 EUR  (= USD stock loss −160 + USD-depreciation −400)
     expect(report.fxGains.disposals).toHaveLength(0);
     expect(report.fxGains.netGainLoss.toFixed(2)).toBe("0.00");
-    expect(report.capitalGains.netGainLoss.toFixed(2)).toBe("-160.00");
+    expect(report.capitalGains.netGainLoss.toFixed(2)).toBe("-560.00");
   });
 });
 


### PR DESCRIPTION
Closes #242.

## Problem

When a foreign-currency stock is sold, `disposalEur` (`src/engine/fifo.ts`) values the cost at the **sale-date** rate (DGT V2422-20) and the buy→sale FX drift is realized separately by the FX engine into casillas 1633/1637 (Art. 14.2.e).

PR #220 made that the behavior **always** — but `skipFx` (monodivisa) only disables the FX engine, it never touched the cost line. So in monodivisa the cost still went to the **sale rate** while the FX engine was **off** → the buy→sale FX drift was **booked nowhere**. Monodivisa reconciled with neither an advisor nor the rigorous default.

Canonical example (from a user's advisor reconciliation): BUY 100 @ \$20 on 2025-05-15 (1 USD = 0.8780 EUR), SELL 100 @ \$25 on 2025-10-15 (1 USD = 0.8547 EUR):

| Mode | Stock cost (EUR) | Stock gain | FX | Total |
|---|---|---|---|---|
| **Traditional (advisor, Art. 35.1)** — cost at buy rate | €1,756.00 | €380.75 | embedded | **€380.75** |
| **Default rigorous (V2422-20)** — cost at sale rate | €1,709.40 | €427.35 | −€46.60 on USD→EUR | **€380.75** |
| **Monodivisa pre-this-PR (broken)** — cost at sale rate, FX off | €1,709.40 | €427.35 | **dropped** | **€427.35** ❌ |

## Fix

Restore the traditional method under monodivisa: a FCY security's cost is converted at the **acquisition-date** rate (Art. 35.1 "importe real por el que la adquisición se hubiese efectuado"), embedding the buy→sale FX drift in the stock line since the FX engine is off.

- `FifoEngine` gains a self-descriptive `traditionalCostBasis` param, driven by `skipFx` in `report.ts` — **no new `ReportOptions` flag**. The two coherent states are sale-rate+FX-on and buy-rate+FX-off; an independent flag would double-count the drift.
- `disposalEur`: `sameFiat && !traditionalCostBasis ? sell.rate : lot.rate`. The default rigorous path is **byte-identical** (flag defaults `false`).
- Crypto cross-currency permutas (already on `lot.rate`), shorts and worthless-expiration (bypass `disposalEur`) are **untouched** — pinned by a test that asserts byte-identical output with/without the flag.

### Deliberately NOT changed
- The **default** (non-monodivisa) cost basis stays V2422-20 + FX engine — maximum rigor by default (project posture). Monodivisa is the opt-out that reconciles with an advisor / Autodeclaro / Taxdown.
- No new toggle: "don't compute FX separately" already implies the traditional embedded cost — they are the same lever.

## Tests

New `tests/engine/fifo-permuta-cost-basis.test.ts` block pins, with hand-computed figures:
- same-fiat USD stock → default cost **€670.00** / monodivisa cost **€770.00** (flag flips the rate).
- same-stablecoin permuta (USDT both legs) → default gain **€10.00** / monodivisa gain **€20.00**.
- cross-currency crypto permuta → **byte-identical** with/without flag (cost **€277.50**).

`report.test.ts` pins the ISSUE.md canonical example end-to-end: monodivisa → acquisition **€1,756.00**, transmission **€2,136.75**, gain **€380.75**, FX block **€0.00**.

3 monodivisa e2e tests whose "identical to the FX-on case" premise is now false by design were updated to assert the embedded drift (€150.00 / €5,500.00 / −€560.00).

The monodivisa profile detail text was updated in all 5 locales (es/en/ca/eu/gl) to state the currency effect is now embedded in the stock cost at the buy-date rate.

Full suite green: **1681 tests pass**, typecheck clean.

## Legal basis
- **Art. 35.1 LIRPF** — valor de adquisición = importe real de la adquisición (→ traditional, buy rate).
- **DGT V2422-20 / V0152-26** — gain computed in the share currency, converted at the sale rate (→ rigorous default).
- **Art. 14.2.e LIRPF** — FX gain imputed "en el momento del cobro o del pago" (→ deferral to the effective EUR conversion, what the FX engine does).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Monodivisa mode documentation and translations across all supported languages with clarification on FX effect treatment.
  * Updated CLI descriptions for Monodivisa option with legal references and cost-basis behavior details.

* **Features**
  * Refined Monodivisa cost-basis calculation to embed FX effects using acquisition-date rates per Article 35.1 regulations, affecting capital gains computation and compatibility with third-party services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->