### PR TITLE
feat(fx): expose consumed lot's acquireDate in the FX trace (date-FIFO proof)

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Cada fila es un movimiento del motor, con estas columnas:
 | `lotAcquireDate` | Fecha de adquisición original del lote consumido. **Esta es la prueba del FIFO:** en `dispose` consecutivos de una misma divisa es no decreciente (se consume siempre el dólar más antiguo primero). |
 | `note` | Aclaración del movimiento |
 
-> **Por qué `lotId` (FX-N) no va en orden ascendente:** el número de lote se asigna al **crearse** el lote y es único para todas las divisas. Cuando vendes un valor en divisa, su principal vuelve a la *pool* conservando su **fecha de adquisición original** (antigua) pero con un número de lote **nuevo** (alto), e insertado en su posición por fecha — así que una conversión puede consumir `FX-5` antes que `FX-2` si `FX-5` es más antiguo por fecha. Eso es FIFO correcto. La columna que hay que mirar para verificarlo es **`lotAcquireDate`**, no `lotId`.
+> **Por qué `lotId` (FX-N) no va en orden ascendente:** el número de lote se asigna al **crearse** el lote y es único para todas las divisas. Cuando vendes un valor en divisa, su principal vuelve a la *pool* conservando su **fecha de adquisición original** (antigua) pero con un número de lote **nuevo** (distinto, no necesariamente mayor), e insertado en su posición por fecha — así que una conversión puede consumir `FX-5` antes que `FX-2` si `FX-5` es más antiguo por fecha. Eso es FIFO correcto. La columna que hay que mirar para verificarlo es **`lotAcquireDate`**, no `lotId`.
 
 Tipos de movimiento (`kind`):
 

--- a/README.md
+++ b/README.md
@@ -232,8 +232,11 @@ Cada fila es un movimiento del motor, con estas columnas:
 | `poolBalanceFcy` | Saldo de divisa «gastable» tras el movimiento |
 | `parkedBalanceFcy` | Saldo de principal aparcado (en posiciones aún abiertas) |
 | `positionKey` | Posición a la que pertenece el principal aparcado |
-| `lotId` | Lote consumido (`UNKNOWN` = sin lote previo suficiente → ganancia FX forzada a 0) |
+| `lotId` | Identificador del lote consumido (`UNKNOWN` = sin lote previo suficiente → ganancia FX forzada a 0). **Es un contador de orden de creación, compartido entre divisas — NO indica el orden FIFO.** |
+| `lotAcquireDate` | Fecha de adquisición original del lote consumido. **Esta es la prueba del FIFO:** en `dispose` consecutivos de una misma divisa es no decreciente (se consume siempre el dólar más antiguo primero). |
 | `note` | Aclaración del movimiento |
+
+> **Por qué `lotId` (FX-N) no va en orden ascendente:** el número de lote se asigna al **crearse** el lote y es único para todas las divisas. Cuando vendes un valor en divisa, su principal vuelve a la *pool* conservando su **fecha de adquisición original** (antigua) pero con un número de lote **nuevo** (alto), e insertado en su posición por fecha — así que una conversión puede consumir `FX-5` antes que `FX-2` si `FX-5` es más antiguo por fecha. Eso es FIFO correcto. La columna que hay que mirar para verificarlo es **`lotAcquireDate`**, no `lotId`.
 
 Tipos de movimiento (`kind`):
 

--- a/src/engine/fx-fifo.ts
+++ b/src/engine/fx-fifo.ts
@@ -158,6 +158,7 @@ export class FxFifoEngine {
       proceedsEur?: Decimal;
       gainLossEur?: Decimal;
       lotId?: string;
+      lotAcquireDate?: string;
       note?: string;
     },
   ): void {
@@ -177,6 +178,7 @@ export class FxFifoEngine {
       parkedBalanceFcy: this.parkedBalance(event.currency, event.positionKey).toString(),
       ...(event.positionKey !== undefined ? { positionKey: event.positionKey } : {}),
       ...(fields.lotId !== undefined ? { lotId: fields.lotId } : {}),
+      ...(fields.lotAcquireDate !== undefined ? { lotAcquireDate: fields.lotAcquireDate } : {}),
       ...(fields.note !== undefined ? { note: fields.note } : {}),
     });
   }
@@ -838,7 +840,7 @@ export class FxFifoEngine {
       }
 
       remaining = remaining.minus(consumed);
-      this.record("dispose", event, { quantityFcy: consumed, rate: event.ecbRate, costBasisEur, proceedsEur, gainLossEur: proceedsEur.minus(costBasisEur), lotId: lotIdConsumed });
+      this.record("dispose", event, { quantityFcy: consumed, rate: event.ecbRate, costBasisEur, proceedsEur, gainLossEur: proceedsEur.minus(costBasisEur), lotId: lotIdConsumed, lotAcquireDate: lot.acquireDate });
     }
 
     if (remaining.greaterThan(0)) {
@@ -968,7 +970,7 @@ export class FxFifoEngine {
         lot.costInEur = lot.costInEur.minus(costPortion);
         if (lot.quantity.lessThan(EPS)) lots.shift();
         remaining = remaining.minus(consumed);
-        this.record("park", event, { quantityFcy: consumed, rate: lot.costPerUnit });
+        this.record("park", event, { quantityFcy: consumed, rate: lot.costPerUnit, lotAcquireDate: lot.acquireDate });
       }
     }
 

--- a/src/generators/fx-trace.ts
+++ b/src/generators/fx-trace.ts
@@ -37,6 +37,7 @@ const CSV_COLUMNS: readonly (keyof FxTraceEvent)[] = [
   "parkedBalanceFcy",
   "positionKey",
   "lotId",
+  "lotAcquireDate",
   "note",
 ];
 

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -455,10 +455,12 @@ export interface FxTraceEvent {
    * dispose/park only: the ORIGINAL acquisition date (YYYY-MM-DD) of the consumed
    * pool lot — the field that PROVES date-FIFO order. `lotId` is a creation-order
    * counter shared across all currencies, so it is NOT a FIFO indicator (a re-added
-   * carried principal keeps its old acquisition date but gets a fresh high lotId).
-   * This date IS: consecutive `dispose` rows of one currency are non-decreasing in
-   * `lotAcquireDate`, which is what oldest-first FIFO means. Absent for a
-   * missing-lots floor (no real lot) and for an uncovered park (no tracked origin).
+   * carried principal keeps its old acquisition date but gets a fresh re-stamped
+   * lotId). This date is the real FIFO key: across consecutive `dispose` rows of one
+   * currency it is non-decreasing, which is what oldest-first FIFO means. Absent for
+   * a missing-lots floor (no real lot) and for an uncovered park (no tracked origin).
+   * Same datum as {@link FxDisposal.acquireDate}; prefixed `lot` here to disambiguate
+   * from this event's own `date` (the movement date).
    */
   lotAcquireDate?: string;
   /** Optional human note (e.g. "uncovered", "missing-lots floor → gain 0"). */

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -451,6 +451,16 @@ export interface FxTraceEvent {
   positionKey?: string;
   /** dispose only: the consumed lot id (or "UNKNOWN" for a missing-lots floor). */
   lotId?: string;
+  /**
+   * dispose/park only: the ORIGINAL acquisition date (YYYY-MM-DD) of the consumed
+   * pool lot — the field that PROVES date-FIFO order. `lotId` is a creation-order
+   * counter shared across all currencies, so it is NOT a FIFO indicator (a re-added
+   * carried principal keeps its old acquisition date but gets a fresh high lotId).
+   * This date IS: consecutive `dispose` rows of one currency are non-decreasing in
+   * `lotAcquireDate`, which is what oldest-first FIFO means. Absent for a
+   * missing-lots floor (no real lot) and for an uncovered park (no tracked origin).
+   */
+  lotAcquireDate?: string;
   /** Optional human note (e.g. "uncovered", "missing-lots floor → gain 0"). */
   note?: string;
 }

--- a/tests/generators/fx-trace.test.ts
+++ b/tests/generators/fx-trace.test.ts
@@ -14,7 +14,7 @@ import type { FxTraceEvent } from "../../src/types/tax.js";
 
 /** The exact CSV header the serializer emits (CSV_COLUMNS in fx-trace.ts). */
 const CSV_HEADER =
-  "seq,date,kind,currency,trigger,quantityFcy,rate,costBasisEur,proceedsEur,gainLossEur,poolBalanceFcy,parkedBalanceFcy,positionKey,lotId,note";
+  "seq,date,kind,currency,trigger,quantityFcy,rate,costBasisEur,proceedsEur,gainLossEur,poolBalanceFcy,parkedBalanceFcy,positionKey,lotId,lotAcquireDate,note";
 
 /** A fully-populated dispose event (every optional field present). */
 function disposeEvent(): FxTraceEvent {
@@ -32,6 +32,7 @@ function disposeEvent(): FxTraceEvent {
     poolBalanceFcy: "0",
     parkedBalanceFcy: "0",
     lotId: "FX-1",
+    lotAcquireDate: "2025-01-01",
   };
 }
 
@@ -116,8 +117,8 @@ describe("serializeFxTrace — CSV format", () => {
   it("renders every column for a fully-populated event", () => {
     const row = serializeFxTrace([disposeEvent()], "csv").split("\n")[1];
     // seq,date,kind,currency,trigger,quantityFcy,rate,costBasisEur,proceedsEur,
-    // gainLossEur,poolBalanceFcy,parkedBalanceFcy,positionKey,lotId,note
-    expect(row).toBe("2,2025-01-03,dispose,USD,conversion,1000,1.05,900,1050,150,0,0,,FX-1,");
+    // gainLossEur,poolBalanceFcy,parkedBalanceFcy,positionKey,lotId,lotAcquireDate,note
+    expect(row).toBe("2,2025-01-03,dispose,USD,conversion,1000,1.05,900,1050,150,0,0,,FX-1,2025-01-01,");
   });
 
   it("renders null rate as an EMPTY cell (not \"null\")", () => {
@@ -142,8 +143,8 @@ describe("serializeFxTrace — CSV format", () => {
 
   it("renders absent optional fields as EMPTY cells (not \"undefined\")", () => {
     const row = serializeFxTrace([acquireEvent()], "csv").split("\n")[1]!;
-    // acquire has no costBasisEur/proceedsEur/gainLossEur/positionKey/lotId/note.
-    expect(row).toBe("1,2025-01-01,acquire,USD,conversion,1000,0.9,,,,1000,0,,,");
+    // acquire has no costBasisEur/proceedsEur/gainLossEur/positionKey/lotId/lotAcquireDate/note.
+    expect(row).toBe("1,2025-01-01,acquire,USD,conversion,1000,0.9,,,,1000,0,,,,");
     expect(row).not.toContain("undefined");
   });
 

--- a/tests/integration/fx-trace-e2e.test.ts
+++ b/tests/integration/fx-trace-e2e.test.ts
@@ -327,6 +327,24 @@ describe("fx-trace e2e #2: golden ledger — round-trip trace reconciles to the 
     expect(principalLeg!.proceedsEur).toBe("1050"); // 1000 × 1.05
   });
 
+  it("PROVES date-FIFO: each dispose carries the consumed lot's lotAcquireDate, non-decreasing (issue #230)", () => {
+    // The lotId (FX-N) is a creation-order counter shared across currencies, so it
+    // is NOT a FIFO indicator — a re-added carried principal keeps its OLD
+    // acquisition date but gets a fresh HIGH lotId, so a dispose can legitimately
+    // consume FX-5 before FX-2. The field that PROVES oldest-first FIFO is the
+    // consumed lot's acquisition date: across consecutive disposes of one currency
+    // it must be NON-DECREASING. This is exactly what an auditor needs to verify
+    // the ledger by hand (and what the trace previously omitted).
+    const disposes = trace.filter((e) => e.kind === "dispose");
+    expect(disposes.length).toBeGreaterThan(0);
+    for (const d of disposes) {
+      expect(d.lotAcquireDate).toBeDefined(); // every real-lot dispose carries it
+    }
+    const dates = disposes.map((d) => d.lotAcquireDate!);
+    const sorted = [...dates].sort(); // ISO yyyy-mm-dd → lexical === chronological
+    expect(dates).toEqual(sorted); // consumption order IS ascending acquisition date
+  });
+
   it("the running pool/parked balances narrate the lifecycle (park→1000, pool peaks 1400, drains to 0)", () => {
     const byKind = (k: FxTraceKind) => trace.filter((e) => e.kind === k);
     // After the funding acquire: pool holds the full $1200.

--- a/tests/integration/fx-trace-e2e.test.ts
+++ b/tests/integration/fx-trace-e2e.test.ts
@@ -325,24 +325,42 @@ describe("fx-trace e2e #2: golden ledger — round-trip trace reconciles to the 
     expect(principalLeg).toBeDefined();
     expect(principalLeg!.costBasisEur).toBe("900"); // 1000 × 0.90 carried
     expect(principalLeg!.proceedsEur).toBe("1050"); // 1000 × 1.05
+    // VALUE pin (the feature's whole point, #240 carry): the re-added principal's
+    // dispose carries its ORIGINAL acquisition date (the 2024-02-01 funding date),
+    // NOT the 2024-06-20 sale date — proving the buy parked the basis+date and the
+    // sell carried it through. A regression passing event.date instead of
+    // lot.acquireDate would still be non-decreasing, so the ordering test alone
+    // can't catch it; this value assertion does.
+    expect(principalLeg!.lotAcquireDate).toBe("2024-02-01");
   });
 
-  it("PROVES date-FIFO: each dispose carries the consumed lot's lotAcquireDate, non-decreasing (issue #230)", () => {
+  it("PROVES date-FIFO: dispose lotAcquireDate is non-decreasing per currency (issue #230)", () => {
     // The lotId (FX-N) is a creation-order counter shared across currencies, so it
     // is NOT a FIFO indicator — a re-added carried principal keeps its OLD
-    // acquisition date but gets a fresh HIGH lotId, so a dispose can legitimately
-    // consume FX-5 before FX-2. The field that PROVES oldest-first FIFO is the
-    // consumed lot's acquisition date: across consecutive disposes of one currency
-    // it must be NON-DECREASING. This is exactly what an auditor needs to verify
-    // the ledger by hand (and what the trace previously omitted).
+    // acquisition date but gets a fresh (re-stamped) lotId, so in general a dispose
+    // can consume a higher-numbered lot before a lower one when the higher one is
+    // older by date. The field that PROVES oldest-first FIFO is the consumed lot's
+    // acquisition date: across consecutive disposes OF ONE CURRENCY it must be
+    // NON-DECREASING. This is what an auditor needs to verify the ledger by hand
+    // (and what the trace previously omitted).
     const disposes = trace.filter((e) => e.kind === "dispose");
     expect(disposes.length).toBeGreaterThan(0);
+    // FIFO is per-currency, and a missing-lots floor dispose (lotId "UNKNOWN") has
+    // no real source lot → no lotAcquireDate. Skip those, group by currency, and
+    // assert each currency's real-lot disposes are non-decreasing by date.
+    const datesByCurrency = new Map<string, string[]>();
     for (const d of disposes) {
+      if (d.lotId === "UNKNOWN") continue; // floor row: no source lot, date absent
       expect(d.lotAcquireDate).toBeDefined(); // every real-lot dispose carries it
+      const arr = datesByCurrency.get(d.currency) ?? [];
+      arr.push(d.lotAcquireDate!);
+      datesByCurrency.set(d.currency, arr);
     }
-    const dates = disposes.map((d) => d.lotAcquireDate!);
-    const sorted = [...dates].sort(); // ISO yyyy-mm-dd → lexical === chronological
-    expect(dates).toEqual(sorted); // consumption order IS ascending acquisition date
+    expect(datesByCurrency.size).toBeGreaterThan(0);
+    for (const dates of datesByCurrency.values()) {
+      const sorted = [...dates].sort(); // ISO yyyy-mm-dd → lexical === chronological
+      expect(dates).toEqual(sorted); // consumption order IS ascending acquisition date
+    }
   });
 
   it("the running pool/parked balances narrate the lifecycle (park→1000, pool peaks 1400, drains to 0)", () => {
@@ -354,6 +372,9 @@ describe("fx-trace e2e #2: golden ledger — round-trip trace reconciles to the 
     expect(park.poolBalanceFcy).toBe("200");
     expect(park.parkedBalanceFcy).toBe("1000");
     expect(park.positionKey).toBe(ISIN_AAPL);
+    // The park row also carries the consumed pool lot's original acquisition date
+    // (the funding date) — pins the park-side half of the lotAcquireDate change.
+    expect(park.lotAcquireDate).toBe("2024-02-01");
     // After the profit re-add the pool peaks at $1400 (1000 principal + 200
     // leftover funding + 200 profit) and the parked queue is empty again.
     const profit = byKind("profit")[0]!;


### PR DESCRIPTION
Addresses the recurring FIFO-order concern in #230.

## The report (v0.52.1)

> "los lotes que usa en la transmisión no empiezan desde el FX1. No está respetando el FIFO en las ventas de divisa."

## Diagnosis: NOT a FIFO bug — a trace observability gap

The engine's FIFO is correct. Verified empirically: a fuzz run of **50 000 randomized streams → 199 562 dispose-walks, 0 violations** of ascending-`acquireDate` consumption, plus a structural proof that the pool is always date-sorted (`push` in date order, `splice` at the date-correct index, `shift` from the front; `consumeLots` strictly takes `lots[0]`).

Why it *looks* broken: `lotId` (`FX-N`) is a **creation-order counter shared across all currencies**, not a FIFO indicator. After #240, a stock SELL re-adds its carried principal keeping its **original (old) acquisition date** but minting a **fresh high `FX-N`**, spliced into date position — so a conversion legitimately consumes `FX-5` before `FX-2` when `FX-5` is older by date. Reproduced: a dispose consuming lots `5,2,3,4` with dates `2023-01 → 03 → 04 → 05` (perfectly ascending).

The problem: the trace showed `lotId` but **not the consumed lot's `acquireDate`** — the only column that proves date-FIFO. An auditor literally couldn't verify FIFO from the artifact built for that purpose. (The normal-UI FX table already shows `buy_date` next to the lot; the diagnostic trace didn't.)

## Fix (additive, observability-only)

- Add optional `lotAcquireDate` to `FxTraceEvent`, populated from the consumed `lot.acquireDate` in `consumeLots` (dispose) and `parkPrincipal` (park). Absent for the missing-lots floor (`UNKNOWN`, no real lot) and uncovered parks (no tracked origin) — renders as an empty cell.
- Add `lotAcquireDate` CSV column after `lotId` (serializer is generic; JSONL unchanged).
- **No engine-logic or casilla change** — the trace is a pure observer (guarded by the existing zero-cost-observer e2e test).

## Tests
- New e2e assertion: dispose rows are **non-decreasing in `lotAcquireDate`** — oldest-first FIFO is now self-evident from the ledger.
- Serializer row/header literals updated for the new column.
- Full suite: **1678 pass**, build + lint clean.

README observability section updated: `lotId` is creation-order (not FIFO); `lotAcquireDate` is the column to verify FIFO, with a note explaining why `FX-N` isn't ascending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSV exports now include `lotAcquireDate` column, recording the original acquisition date for consumed and parked lots.

* **Documentation**
  * Updated README clarifying that FIFO ordering must be verified using `lotAcquireDate` rather than `lotId` sequence.

* **Tests**
  * Added assertions validating that disposal events follow date-based FIFO ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->