### PR TITLE
fix(dividends): net broker correction/reversal pairs before matching

### DIFF
--- a/src/engine/cash-corrections.ts
+++ b/src/engine/cash-corrections.ts
@@ -1,0 +1,76 @@
+/**
+ * Broker correction/reversal collapsing.
+ *
+ * Brokers (DEGIRO especially) sometimes credit a cash movement, then credit a
+ * DUPLICATE of it by mistake, then issue a CORRECTION (storno/reversal) that
+ * reverses the duplicate with an opposite-sign line of the same magnitude. The
+ * economic reality is the single original movement, but the raw transaction
+ * stream contains the original + duplicate + reversal.
+ *
+ * If those rows reach the dividend/interest engines unnetted, two things break:
+ *   • Gross income (Casilla 0029) double-counts the duplicate (only partially
+ *     self-correcting, because the reversal carries `type:"Dividends"` and is
+ *     summed with its sign — fragile, and wrong if the pair straddles a filter).
+ *   • Withholding is computed per matched entry as `.abs()` (dividends.ts), so a
+ *     −€19 original, a −€19 duplicate and a +€19 reversal all become +€19 and
+ *     ADD to €57 instead of netting to the real €19.
+ *
+ * The fix is to cancel exact reversal pairs at the SOURCE, before any consumer
+ * runs. A reversal is, by construction, an opposite-sign line of identical
+ * magnitude for the same (type, security, currency, date). We pair each positive
+ * with an equal-magnitude negative in its group and drop both. Whatever is left
+ * is the genuine net movement.
+ *
+ * DELIBERATELY CONSERVATIVE — only EXACT opposite-sign pairs cancel:
+ *   • Two SAME-sign rows of equal magnitude (e.g. two real −€19 withholdings on
+ *     two real dividends) are NOT a reversal and are left untouched.
+ *   • A +X cancels a −X only; a partial/rounded reversal whose magnitude differs
+ *     does not match and falls through to today's behavior (no worse than now).
+ * So a file with no reversals is byte-identical after this pass.
+ */
+
+import Decimal from "decimal.js";
+import type { CashTransaction } from "../types/ibkr.js";
+import { normalizeDate } from "./dates.js";
+
+/**
+ * Cancel exact opposite-sign reversal pairs in a cash-transaction stream.
+ *
+ * Groups by `(type, isin, currency, normalized date, |amount|)`. Within each
+ * group, cancels `min(#positive, #negative)` pairs (a reversal annihilates one
+ * same-magnitude movement of the opposite sign), preserving the original order
+ * of every surviving row (the dividend matcher relies on index order for its
+ * lowest-index tie-break, so order must be stable).
+ *
+ * Pure: returns a new array; never mutates the input.
+ */
+export function collapseCorrections(transactions: CashTransaction[]): CashTransaction[] {
+  // Bucket original indices by the reversal-pair key, split by sign.
+  const groups = new Map<string, { positives: number[]; negatives: number[] }>();
+
+  transactions.forEach((tx, index) => {
+    const amount = new Decimal(tx.amount);
+    if (amount.isZero()) return; // a zero line can't be (or cancel) a reversal
+    const key = `${tx.type}|${tx.isin}|${tx.currency}|${normalizeDate(tx.dateTime)}|${amount.abs().toString()}`;
+    const group = groups.get(key) ?? { positives: [], negatives: [] };
+    if (amount.isPositive()) group.positives.push(index);
+    else group.negatives.push(index);
+    groups.set(key, group);
+  });
+
+  // Mark min(pos,neg) pairs per group as cancelled, taking the HIGHEST indices
+  // on each side first. This preserves the EARLIEST (original) rows — both the
+  // intuitive outcome ("the duplicate and its reversal cancel, the original
+  // survives") and the one the dividend matcher's lowest-index tie-break expects.
+  const cancelled = new Set<number>();
+  for (const { positives, negatives } of groups.values()) {
+    const pairs = Math.min(positives.length, negatives.length);
+    for (let i = 0; i < pairs; i++) {
+      cancelled.add(positives[positives.length - 1 - i]!);
+      cancelled.add(negatives[negatives.length - 1 - i]!);
+    }
+  }
+
+  if (cancelled.size === 0) return transactions; // no reversals → unchanged (identity)
+  return transactions.filter((_, index) => !cancelled.has(index));
+}

--- a/src/generators/report.ts
+++ b/src/generators/report.ts
@@ -14,6 +14,7 @@ import { FifoEngine } from "../engine/fifo.js";
 import { FxFifoEngine } from "../engine/fx-fifo.js";
 import { detectWashSales } from "../engine/wash-sale.js";
 import { calculateDividends } from "../engine/dividends.js";
+import { collapseCorrections } from "../engine/cash-corrections.js";
 import { calculateDoubleTaxation } from "../engine/double-taxation.js";
 import { lookupRateInMap } from "../engine/ecb.js";
 import { resolveCryptoTradeValues } from "../engine/crypto-valuation.js";
@@ -375,7 +376,15 @@ export function generateTaxReport(
   const reintegratedLosses = disposals.reduce((sum, d) => sum.plus(d.reintegratedLossEur), new Decimal(0));
 
   // 2. Dividends (filter to target year)
-  const yearCashTransactions = statement.cashTransactions.filter((t) => t.dateTime.startsWith(yearStr));
+  // Collapse broker correction/reversal pairs (duplicate credit + its opposite-
+  // sign storno) BEFORE the dividend/interest engines run, so a duplicated-then-
+  // reversed payment nets to its real value in BOTH the gross (0029) and the
+  // withholding — instead of the reversal being .abs()'d into an addition
+  // (dividends.ts) that triples the retención. Only exact opposite-sign pairs
+  // cancel; a file with no reversals is unchanged.
+  const yearCashTransactions = collapseCorrections(
+    statement.cashTransactions.filter((t) => t.dateTime.startsWith(yearStr)),
+  );
   let dividendEntries = calculateDividends(yearCashTransactions, rateMap);
   if (titulares > 1) dividendEntries = dividendEntries.map((d) => splitDividend(d, titulares));
   const grossDividends = dividendEntries.reduce(

--- a/tests/engine/cash-corrections.test.ts
+++ b/tests/engine/cash-corrections.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import { collapseCorrections } from "../../src/engine/cash-corrections.js";
+import { calculateDividends } from "../../src/engine/dividends.js";
+import type { CashTransaction } from "../../src/types/ibkr.js";
+import type { EcbRateMap } from "../../src/types/ecb.js";
+
+// ===========================================================================
+// Broker correction/reversal collapsing (Giovanni's bug, issue: DEGIRO
+// duplicate dividend + storno). A duplicated cash movement and its opposite-
+// sign reversal must cancel BEFORE the dividend/interest engines run, so the
+// real payment nets correctly in both the gross (0029) and the withholding —
+// instead of the reversal being .abs()'d into an addition that triples the
+// retención (€19 → €57).
+// ===========================================================================
+
+function makeCashTx(overrides: Partial<CashTransaction>): CashTransaction {
+  return {
+    transactionID: "1",
+    accountId: "U1",
+    symbol: "TEF",
+    description: "TELEFONICA Dividendo",
+    isin: "ES0178430E18",
+    currency: "EUR",
+    dateTime: "2025-06-10",
+    settleDate: "2025-06-10",
+    amount: "100",
+    fxRateToBase: "1",
+    type: "Dividends",
+    ...overrides,
+  };
+}
+
+function makeRateMap(rates: Record<string, Record<string, string>>): EcbRateMap {
+  const map: EcbRateMap = new Map();
+  for (const [date, currencies] of Object.entries(rates)) {
+    map.set(date, new Map(Object.entries(currencies)));
+  }
+  return map;
+}
+
+describe("collapseCorrections", () => {
+  it("cancels an exact opposite-sign reversal pair (duplicate dividend + storno)", () => {
+    const txs: CashTransaction[] = [
+      makeCashTx({ transactionID: "d1", amount: "100" }), // real
+      makeCashTx({ transactionID: "d2", amount: "100" }), // duplicate
+      makeCashTx({ transactionID: "d3", amount: "-100" }), // reversal
+    ];
+    const out = collapseCorrections(txs);
+    // The duplicate (+100) and the reversal (−100) annihilate; the real +100 survives.
+    expect(out).toHaveLength(1);
+    expect(out[0]!.transactionID).toBe("d1");
+    expect(out[0]!.amount).toBe("100");
+  });
+
+  it("cancels a withholding reversal pair, leaving the single real withholding", () => {
+    const txs: CashTransaction[] = [
+      makeCashTx({ transactionID: "w1", amount: "-19", type: "Withholding Tax" }),
+      makeCashTx({ transactionID: "w2", amount: "-19", type: "Withholding Tax" }), // duplicate
+      makeCashTx({ transactionID: "w3", amount: "19", type: "Withholding Tax" }), // reversal
+    ];
+    const out = collapseCorrections(txs);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.amount).toBe("-19"); // one real −19 retención survives
+  });
+
+  it("does NOT cancel two same-sign rows (genuine duplicate payments are ambiguous)", () => {
+    // Two real −19 withholdings on two real dividends are NOT a reversal pair.
+    const txs: CashTransaction[] = [
+      makeCashTx({ transactionID: "w1", amount: "-19", type: "Withholding Tax" }),
+      makeCashTx({ transactionID: "w2", amount: "-19", type: "Withholding Tax" }),
+    ];
+    const out = collapseCorrections(txs);
+    expect(out).toHaveLength(2); // untouched — conservative
+  });
+
+  it("is the identity on a stream with no reversals (byte-identical, same reference)", () => {
+    const txs: CashTransaction[] = [
+      makeCashTx({ transactionID: "d1", amount: "100" }),
+      makeCashTx({ transactionID: "w1", amount: "-19", type: "Withholding Tax" }),
+    ];
+    const out = collapseCorrections(txs);
+    expect(out).toBe(txs); // returns the same array reference when nothing cancels
+  });
+
+  it("does not pair across different (type, isin, currency, date, |amount|)", () => {
+    const txs: CashTransaction[] = [
+      makeCashTx({ transactionID: "a", amount: "100", isin: "ES0178430E18" }),
+      makeCashTx({ transactionID: "b", amount: "-100", isin: "US0378331005" }), // different ISIN
+      makeCashTx({ transactionID: "c", amount: "100", dateTime: "2025-06-10" }),
+      makeCashTx({ transactionID: "d", amount: "-100", dateTime: "2025-09-10" }), // different date
+      makeCashTx({ transactionID: "e", amount: "50", type: "Withholding Tax" }),
+      makeCashTx({ transactionID: "f", amount: "-30", type: "Withholding Tax" }), // different magnitude
+    ];
+    const out = collapseCorrections(txs);
+    expect(out).toHaveLength(6); // no key matches → nothing cancels
+  });
+
+  it("preserves order and keeps the EARLIEST of identical survivors", () => {
+    const txs: CashTransaction[] = [
+      makeCashTx({ transactionID: "keep-before", amount: "50" }),
+      makeCashTx({ transactionID: "first100", amount: "100" }),
+      makeCashTx({ transactionID: "rev", amount: "-100" }),
+      makeCashTx({ transactionID: "second100", amount: "100" }),
+      makeCashTx({ transactionID: "keep-after", amount: "70" }),
+    ];
+    const out = collapseCorrections(txs).map((t) => t.transactionID);
+    // One +100/−100 pair cancels; the EARLIEST +100 (first100) is kept and the
+    // later one is cancelled with rev. The two distinct-amount rows are untouched
+    // and order is preserved. (first100 and second100 are identical-key rows, so
+    // which survives is economically irrelevant; keeping the earliest is the
+    // intended, matcher-friendly choice.)
+    expect(out).toEqual(["keep-before", "first100", "keep-after"]);
+  });
+});
+
+describe("calculateDividends with collapsed corrections (Giovanni's full DEGIRO case)", () => {
+  it("nets a duplicate dividend + reversal to ONE gross and ONE withholding (€100 / €19, not 3×)", () => {
+    const rates = makeRateMap({ "2025-06-10": { EUR: "1" } });
+    const raw: CashTransaction[] = [
+      makeCashTx({ transactionID: "d1", amount: "100", type: "Dividends" }),
+      makeCashTx({ transactionID: "d2", amount: "100", type: "Dividends" }), // duplicate
+      makeCashTx({ transactionID: "d3", amount: "-100", type: "Dividends" }), // reversal
+      makeCashTx({ transactionID: "w1", amount: "-19", type: "Withholding Tax" }),
+      makeCashTx({ transactionID: "w2", amount: "-19", type: "Withholding Tax" }), // duplicate
+      makeCashTx({ transactionID: "w3", amount: "19", type: "Withholding Tax" }), // reversal
+    ];
+    const entries = calculateDividends(collapseCorrections(raw), rates);
+    // One real dividend survives, with one real withholding.
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.grossAmountEur.toFixed(2)).toBe("100.00");
+    expect(entries[0]!.withholdingTaxEur.toFixed(2)).toBe("19.00"); // NOT 57.00
+    const totalGross = entries.reduce((s, e) => s.plus(e.grossAmountEur), entries[0]!.grossAmountEur.minus(entries[0]!.grossAmountEur));
+    expect(totalGross.toFixed(2)).toBe("100.00");
+  });
+
+  it("WITHOUT collapsing, the same input triples the withholding (pins the bug it fixes)", () => {
+    const rates = makeRateMap({ "2025-06-10": { EUR: "1" } });
+    const raw: CashTransaction[] = [
+      makeCashTx({ transactionID: "d1", amount: "100", type: "Dividends" }),
+      makeCashTx({ transactionID: "d2", amount: "100", type: "Dividends" }),
+      makeCashTx({ transactionID: "d3", amount: "-100", type: "Dividends" }),
+      makeCashTx({ transactionID: "w1", amount: "-19", type: "Withholding Tax" }),
+      makeCashTx({ transactionID: "w2", amount: "-19", type: "Withholding Tax" }),
+      makeCashTx({ transactionID: "w3", amount: "19", type: "Withholding Tax" }),
+    ];
+    const entries = calculateDividends(raw, rates); // no collapse
+    const total = entries.reduce((s, e) => s.plus(e.withholdingTaxEur), entries[0]!.withholdingTaxEur.minus(entries[0]!.withholdingTaxEur));
+    expect(total.toFixed(2)).toBe("57.00"); // the bug: 3 × |19|, abs destroys the reversal's sign
+  });
+});


### PR DESCRIPTION
Reported by **Giovanni** (via email) — DEGIRO duplicate dividend + storno.

## Problem

A dividend was credited, accidentally **duplicated** the same day, then **reversed** (storno). The raw stream is: dividend `+€100`, duplicate `+€100`, reversal `−€100`; withholding `−€19`, duplicate `−€19`, reversal `+€19`. The real economic event is **one** dividend: €100 gross, €19 withheld.

`dividends.ts` computes each matched withholding as `.abs()` **per entry**, so the `+€19` reversal becomes `+€19` and is *added* instead of cancelling its duplicate → the retención is reported as **€57 (3×)** instead of €19. (Reproduced on the real engine.) The gross 0029 only self-corrected by luck (the `−€100` reversal carries its sign).

Giovanni's two proposed fixes don't hold:
- **negate instead of abs** — works for DEGIRO but breaks brokers that emit withholding as a *positive* number (e.g. eToro) → would yield `−€19`.
- **abs on the sum** — with the current consume-once matcher (one withholding per dividend), "the sum" is a single element → still `€57`.

## Fix

A shared `collapseCorrections()` pre-pass over the year's `cashTransactions`, applied **before** the dividend and interest engines run. It cancels **exact opposite-sign reversal pairs** by `(type, isin, currency, date, |amount|)`, keeping the earliest survivor. This nets the duplicate+reversal at the source, fixing **both** the withholding and the gross in one place.

**Conservative by design:** only exact `+X` / `−X` pairs cancel. Two *same-sign* rows of equal magnitude (two genuine withholdings on two real dividends) are **not** a reversal and are left untouched. A file with no reversals is byte-identical (the helper returns the same array reference) — which is why all 43 existing dividend/double-taxation/casillas tests stay green unchanged.

## Tests
New `tests/engine/cash-corrections.test.ts` (8 cases): opposite-sign pair cancels, withholding pair cancels, same-sign duplicates do NOT cancel, identity on no-reversal streams, no cross-key pairing, order/earliest-survivor preservation, and Giovanni's full DEGIRO case through `calculateDividends` (€100 / €19, not 3×) — plus a test pinning the **€57 bug** on the un-collapsed input so the regression can't silently return.

Full suite: **1686 pass**, lint clean. No engine/matcher/abs logic changed — the fix is purely the upstream pre-pass.

> Note: Giovanni also reported a second, separate bug (Spanish retención on an ES stock at a foreign broker is lost — should be a retención a cuenta, not casilla 0588). That's a distinct feature and will be its own PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic cancellation of opposite-sign cash transaction pairs (reversals) to prevent duplicate entries in calculations.

* **Bug Fixes**
  * Fixed incorrect dividend, interest, and withholding calculations in tax reports caused by uncancelled reversal transaction pairs.

* **Tests**
  * Added comprehensive test suite for reversal pair cancellation logic and its impact on financial calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->