### PR TITLE
fix(parser): correct commission calculation for sell transactions in …

### DIFF
--- a/src/parsers/lightyear.ts
+++ b/src/parsers/lightyear.ts
@@ -319,7 +319,7 @@ function parseLightyearCsv(lines: string[]): Statement {
       openCloseIndicator: isSell ? "C" : "O",
       exchange: "LIGHTYEAR",
       commissionCurrency: currency,
-      commission: isSell ? feeDec.toString() : feeDec.neg().toString(),
+      commission: feeDec.isZero() ? "0" : feeDec.neg().toString(),
       taxes: "0",
       multiplier: "1",
     });

--- a/src/parsers/lightyear.ts
+++ b/src/parsers/lightyear.ts
@@ -319,7 +319,7 @@ function parseLightyearCsv(lines: string[]): Statement {
       openCloseIndicator: isSell ? "C" : "O",
       exchange: "LIGHTYEAR",
       commissionCurrency: currency,
-      commission: (feeDec.isZero() || isSell) ? "0" : feeDec.neg().toString(),
+      commission: isSell ? feeDec.toString() : feeDec.neg().toString(),
       taxes: "0",
       multiplier: "1",
     });

--- a/tests/parsers/lightyear-branches.test.ts
+++ b/tests/parsers/lightyear-branches.test.ts
@@ -101,7 +101,13 @@ describe("lightyearParser - branch coverage", () => {
     ].join("\n");
     const result = lightyearParser.parse(input);
     expect(result.trades).toHaveLength(1);
-    expect(result.trades[0].buySell).toBe("SELL");
+    const sell = result.trades[0]!;
+    expect(sell.buySell).toBe("SELL");
+    expect(sell.quantity).toBe("-5");
+    expect(sell.proceeds).toBe("898.5");
+    expect(sell.tradeMoney).toBe("898.5");
+    expect(sell.commissionCurrency).toBe("USD");
+    expect(sell.commission).toBe("-1.5");
   });
 
   it("should handle ISO date format fallback (YYYY-MM-DD)", () => {


### PR DESCRIPTION
…Lightyear CSV parser


El parse de Lightyear tenía una condición en la que ignoraba la comisión en las ventas de acciones y la forzaba a 0.

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected commission calculation for stock trades to properly account for fees based on transaction type (buy vs. sell).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->