### PR TITLE
fix(wash-sale): allow full-position loss sales

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,12 @@ The Binance "Generate all statements" export (`User_ID,UTC_Time,Account,Operatio
 - **Casillas**: 0327-0328 (capital gains), 0029 (dividends), 0027 (interest income), 0588 (double taxation). Real casilla 0032 = insurance income (Art. 25.3), not broker margin interest.
 - **Savings brackets (2025+, Ley 7/2024)**: 19% (0–6k), 21% (6k–50k), 23% (50k–200k), 27% (200k–300k), 30% (>300k)
 
+### Anti-Churning Total-Sale Carve-Out (Hard Trace — issue #249)
+- **DGT V3282-18 situation 1**: when a loss sale leaves **zero** homogeneous shares in the taxpayer's patrimony, the loss is fully deductible. The engine must not count the very pre-sale lots FIFO just sold as surviving "repurchases".
+- **Implementation invariant** (`src/engine/wash-sale.ts`): post-sale repurchases remain uncapped and block normally; pre-sale absorption is capped by `holdingAfter = max(0, net BUY/SELL position after the sale date)`. Same-day FIFO disposal splits share one `holdingAfter` budget, so a single SELL split across lots cannot over-block. Forward/reverse splits must be applied to this cap and to later deferred-loss release proration so pre-split buys, post-split disposals, and replacement-lot releases are all compared in the relevant sale's share units.
+- **Do NOT replace this with a naive total-sale shortcut**. `buy 100 → sell 100 at a loss → rebuy 100 within the window` is still a genuine wash sale because the post-sale rebuy remains after the loss sale.
+- **Single-year limitation**: if prior-year holdings are absent from the input, `holdingAfter` can understate the real position and is clamped at zero. This is the same data-window limitation as other FIFO paths; do not invent prior holdings inside the anti-churning detector.
+
 ### AEAT Formats
 - **Modelo 100**: No file import in Renta Web. Tool generates casilla values for manual entry. XSD published annually (`Renta20XX.xsd`).
 - **Modelo 720**: Fixed-width text file, 500 bytes/record, ISO-8859-15 encoding. Submitted via TGVI.

--- a/docs/antichurning-proportional-design.md
+++ b/docs/antichurning-proportional-design.md
@@ -26,7 +26,12 @@ securities within **±2 calendar months** (listed, letter f) / **±1 year**
    **NOT** added to the repurchased lot's cost basis.
 4. **Per-lot ("por paquetes")** proration base (V0913-08), matching our per-lot
    `FifoDisposal` granularity (one disposal per consumed FIFO lot).
-5. FIFO (Art. 37.2) decides **which** lots are sold and the loss; the homogeneity
+5. **Total-sale carve-out.** If, after the transmission, no homogeneous shares
+   remain in the taxpayer's patrimony, the loss is deductible in full (DGT
+   V3282-18 situation 1). Pre-sale buys only block up to the shares that still
+   remain after the sale; a later post-sale repurchase is still a genuine
+   replacement and can block normally.
+6. FIFO (Art. 37.2) decides **which** lots are sold and the loss; the homogeneity
    test (Art. 33.5.f/g) is a **separate** overlay deciding whether that loss is
    blocked. Two independent steps.
 
@@ -50,21 +55,35 @@ Operates on the **full, all-year** disposal set in **one chronological pass**
 homogeneous key:
 
 - **Buy budget**: sorted buy events `{time, qty}`; `qty` is consumable.
-- **Deferred ledger**: `Map<acquireTime, {qty, deferredEur}>` — deferred loss
-  attached to the repurchased lots (keyed by the repurchase buy's normalized
-  date), released when a future disposal sells shares acquired on that date.
+- **Remaining-position budget**: signed BUY/SELL movements compute
+  `holdingAfter = max(0, net position after the sale date)`. This caps only
+  PRE-sale absorption and is shared across same-date FIFO disposal splits.
+  Forward/reverse splits are applied to compare every movement in the sale's
+  share units, matching the FIFO engine's split-adjusted disposal quantities.
+- **Deferred ledger**: `Map<buyDate, DeferredLot[]>` — deferred loss attached
+  to the repurchased lots (keyed by the repurchase buy's normalized date).
+  Each entry carries `{qty, deferredEur, availableAfterTime}` so multiple
+  deferrals can share one buy date, same-sale FIFO splits do not immediately
+  release a loss created by another split, and later split-adjusted releases can
+  prorate from the right blocking sale.
 
 For each disposal (chronological):
 1. **Reintegration (all disposals, gain or loss).** If it sells shares whose
    `acquireDate` matches a deferred-ledger entry, release proportionally:
    `reintegratedLossEur = entry.deferredEur × min(qty, entry.qty)/entry.qty`;
-   decrement the entry.
-2. **Blocking (loss disposals only).** Sum in-window homogeneous repurchase qty
-   (excluding buys on the sell date — the lot being sold), `absorbed =
-   min(repurchasedQtyAvailable, disposal.qty)`,
+   decrement the entry. If the replacement lot split after the block, convert
+   the deferred-lot quantity into the release sale's share units before
+   prorating, so a 2-for-1 split releases half the loss when half the
+   post-split shares are sold.
+2. **Blocking (loss disposals only).** Consume POST-sale in-window buys first,
+   uncapped, because they are genuine replacement lots. Then consume PRE-sale
+   in-window buys only up to the remaining-position budget:
+   `preAbsorbed ≤ holdingAfter`. A full exit with no later repurchase therefore
+   blocks `0`, while a full exit followed by a later repurchase still blocks the
+   post-sale repurchase quantity. Final formula:
    `blockedLossEur = |gainLossEur| × absorbed/qty`. Consume `absorbed` from the
-   in-window buys (FIFO), attaching the deferred loss to each consumed buy's
-   date in the ledger.
+   in-window buys, attaching the deferred loss to each consumed buy's date in
+   the ledger.
 
 ### New `FifoDisposal` fields
 
@@ -130,3 +149,12 @@ homogéneos"*, and integrate deferred losses when the surviving lot is sold.
 - **Multiple loss-sales, one repurchase**: budget consumed **chronologically**
   (earliest loss-sale first), the most defensible reading (DGT lot-tracking is
   chronological; AEAT gives no explicit tiebreak).
+- **Single-year files**: if the user omits prior-year buys, `holdingAfter` can
+  understate the real position and is clamped at zero. This is the same data
+  window limitation the FIFO engine already surfaces elsewhere; this fix does
+  not reconstruct prior-year holdings from absent input.
+- **Corporate actions**: forward/reverse splits are reflected in both the
+  remaining-position cap and deferred-loss release proration. More complex
+  tax-neutral transformations (mergers, spin-offs, scrip dividends) still rely
+  on the FIFO disposal stream for the actual gain/loss and should get dedicated
+  anti-churning tests if a real case reaches this path.

--- a/src/engine/wash-sale.ts
+++ b/src/engine/wash-sale.ts
@@ -20,7 +20,7 @@
  */
 
 import type { FifoDisposal } from "../types/tax.js";
-import type { Trade } from "../types/ibkr.js";
+import type { Trade, CorporateAction } from "../types/ibkr.js";
 import Decimal from "decimal.js";
 import { parseDate } from "./dates.js";
 
@@ -60,12 +60,26 @@ interface BuyEvent {
   remainingQty: Decimal;
 }
 
+/** Signed position movement used to compute shares remaining after a disposal. */
+interface PositionEvent {
+  time: number;
+  qty: Decimal;
+}
+
+/** Corporate split ratio that changes share quantities without changing cost basis. */
+interface SplitEvent {
+  time: number;
+  ratio: Decimal;
+}
+
 /** A deferred loss attached to a repurchased lot, released as that lot is later sold. */
 interface DeferredLot {
   /** Repurchased shares still carrying deferred loss. */
   qty: Decimal;
   /** Deferred loss (EUR, positive) still attached to those shares. */
   deferredEur: Decimal;
+  /** The deferred loss can release only on transmissions after the sale that created it. */
+  availableAfterTime: number;
 }
 
 /**
@@ -88,32 +102,55 @@ interface DeferredLot {
  *
  * @param disposals - FIFO disposals to check (pass all years for cross-year reintegration)
  * @param allTrades - All trades for the period (homogeneous repurchases)
+ * @param corporateActions - Corporate actions for split-adjusted remaining-position caps
  * @returns Disposals with `blockedLossEur`, `reintegratedLossEur`, and `washSaleBlocked` set
  */
-export function detectWashSales(disposals: FifoDisposal[], allTrades: Trade[]): FifoDisposal[] {
-  // Index in-window-eligible BUY events (time, date, consumable qty) by key.
+export function detectWashSales(
+  disposals: FifoDisposal[],
+  allTrades: Trade[],
+  corporateActions: CorporateAction[] = [],
+): FifoDisposal[] {
+  // Index in-window-eligible BUY events and signed position movements by key.
   const buysByAsset = new Map<string, BuyEvent[]>();
+  const positionEventsByAsset = new Map<string, PositionEvent[]>();
   for (const trade of allTrades) {
-    if (trade.buySell !== "BUY" || WASH_SALE_EXEMPT.has(trade.assetCategory)) continue;
+    if (WASH_SALE_EXEMPT.has(trade.assetCategory)) continue;
     const key = homogeneousKey(trade.isin, trade.symbol, trade.assetCategory);
     if (!key) continue;
     const qty = parseQty(trade.quantity);
     if (qty.lessThanOrEqualTo(0)) continue;
     const d = parseDate(trade.tradeDate);
-    let events = buysByAsset.get(key);
-    if (!events) {
-      events = [];
-      buysByAsset.set(key, events);
+    const time = d.getTime();
+
+    let positionEvents = positionEventsByAsset.get(key);
+    if (!positionEvents) {
+      positionEvents = [];
+      positionEventsByAsset.set(key, positionEvents);
     }
-    events.push({ time: d.getTime(), date: normalizeDay(trade.tradeDate), remainingQty: qty });
+
+    if (trade.buySell === "BUY") {
+      positionEvents.push({ time, qty });
+      let events = buysByAsset.get(key);
+      if (!events) {
+        events = [];
+        buysByAsset.set(key, events);
+      }
+      events.push({ time, date: normalizeDay(trade.tradeDate), remainingQty: qty });
+    } else {
+      positionEvents.push({ time, qty: qty.neg() });
+    }
   }
   for (const events of buysByAsset.values()) {
     events.sort((a, b) => a.time - b.time);
   }
+  for (const events of positionEventsByAsset.values()) {
+    events.sort((a, b) => a.time - b.time);
+  }
+  const splitsByAsset = buildSplitEvents(corporateActions);
 
-  // Deferred-loss ledger: key → (buy date → deferred lot). A loss blocked by a
+  // Deferred-loss ledger: key → (buy date → deferred lots). A loss blocked by a
   // repurchase on date D is recoverable when shares acquired on D are later sold.
-  const deferredByAsset = new Map<string, Map<string, DeferredLot>>();
+  const deferredByAsset = new Map<string, Map<string, DeferredLot[]>>();
 
   // Process disposals oldest-first so a block is recorded before the later
   // disposal that releases it (stable sort by sell date; preserve input order
@@ -132,6 +169,50 @@ export function detectWashSales(disposals: FifoDisposal[], allTrades: Trade[]): 
     washSaleBlocked: false,
   }));
 
+  const holdingAfterByAssetTime = new Map<string, Map<number, Decimal>>();
+  const holdingAfterBudgetByAssetTime = new Map<string, Map<number, Decimal>>();
+
+  const holdingAfter = (key: string, sellTime: number): Decimal => {
+    let perTime = holdingAfterByAssetTime.get(key);
+    if (!perTime) {
+      perTime = new Map();
+      holdingAfterByAssetTime.set(key, perTime);
+    }
+    const cached = perTime.get(sellTime);
+    if (cached) return cached;
+
+    let position = new Decimal(0);
+    for (const ev of positionEventsByAsset.get(key) ?? []) {
+      if (ev.time > sellTime) break;
+      position = position.plus(ev.qty.mul(splitFactorBetween(splitsByAsset, key, ev.time, sellTime)));
+    }
+    const remaining = Decimal.max(position, 0);
+    perTime.set(sellTime, remaining);
+    return remaining;
+  };
+
+  const remainingHoldingBudget = (key: string, sellTime: number): Decimal => {
+    let perTime = holdingAfterBudgetByAssetTime.get(key);
+    if (!perTime) {
+      perTime = new Map();
+      holdingAfterBudgetByAssetTime.set(key, perTime);
+    }
+    let budget = perTime.get(sellTime);
+    if (!budget) {
+      budget = holdingAfter(key, sellTime);
+      perTime.set(sellTime, budget);
+    }
+    return budget;
+  };
+
+  const consumeHoldingBudget = (key: string, sellTime: number, consumedQty: Decimal): void => {
+    if (consumedQty.lessThanOrEqualTo(0)) return;
+    const perTime = holdingAfterBudgetByAssetTime.get(key);
+    if (!perTime) return;
+    const current = perTime.get(sellTime) ?? new Decimal(0);
+    perTime.set(sellTime, Decimal.max(current.minus(consumedQty), 0));
+  };
+
   for (const idx of order) {
     const disposal = result[idx]!;
     if (WASH_SALE_EXEMPT.has(disposal.assetCategory)) continue;
@@ -139,28 +220,47 @@ export function detectWashSales(disposals: FifoDisposal[], allTrades: Trade[]): 
     if (!key) continue;
 
     const qty = disposal.quantity.abs();
+    const disposalSellDate = parseDate(disposal.sellDate);
+    const disposalSellTime = disposalSellDate.getTime();
 
     // 1. RELEASE: this disposal sells shares acquired on a date that carries a
     //    deferred loss → reintegrate proportionally to the quantity now sold.
     const deferredLots = deferredByAsset.get(key);
     if (deferredLots) {
-      const lot = deferredLots.get(normalizeDay(disposal.acquireDate));
-      if (lot && lot.qty.greaterThan(0)) {
-        const releasedQty = Decimal.min(qty, lot.qty);
-        const releasedEur = lot.qty.isZero()
-          ? new Decimal(0)
-          : lot.deferredEur.mul(releasedQty).div(lot.qty);
-        disposal.reintegratedLossEur = releasedEur;
-        lot.qty = lot.qty.minus(releasedQty);
-        lot.deferredEur = lot.deferredEur.minus(releasedEur);
-        if (lot.qty.lessThanOrEqualTo(0)) deferredLots.delete(normalizeDay(disposal.acquireDate));
+      const acquireDate = normalizeDay(disposal.acquireDate);
+      const lots = deferredLots.get(acquireDate);
+      if (lots) {
+        let remainingReleaseQty = qty;
+        for (const lot of lots) {
+          if (remainingReleaseQty.lessThanOrEqualTo(0)) break;
+          if (disposalSellTime <= lot.availableAfterTime) continue;
+          if (lot.qty.lessThanOrEqualTo(0)) continue;
+          const releaseConversion = splitFactorBetween(splitsByAsset, key, lot.availableAfterTime, disposalSellTime);
+          const lotQtyAtRelease = lot.qty.mul(releaseConversion);
+          if (lotQtyAtRelease.lessThanOrEqualTo(0)) continue;
+          const releasedQty = Decimal.min(remainingReleaseQty, lotQtyAtRelease);
+          const releasedOriginalQty = releasedQty.div(releaseConversion);
+          const releasedEur = lot.qty.isZero()
+            ? new Decimal(0)
+            : lot.deferredEur.mul(releasedOriginalQty).div(lot.qty);
+          disposal.reintegratedLossEur = disposal.reintegratedLossEur.plus(releasedEur);
+          lot.qty = lot.qty.minus(releasedOriginalQty);
+          lot.deferredEur = lot.deferredEur.minus(releasedEur);
+          remainingReleaseQty = remainingReleaseQty.minus(releasedQty);
+        }
+        const remainingLots = lots.filter((lot) => lot.qty.greaterThan(0));
+        if (remainingLots.length > 0) {
+          deferredLots.set(acquireDate, remainingLots);
+        } else {
+          deferredLots.delete(acquireDate);
+        }
       }
     }
 
     // 2. BLOCK: only loss disposals, proportional to the in-window repurchase qty.
     if (disposal.gainLossEur.greaterThanOrEqualTo(0)) continue;
 
-    const sellDate = parseDate(disposal.sellDate);
+    const sellDate = disposalSellDate;
     const months = windowMonths(disposal.assetCategory, disposal.isin);
     const windowStart = addMonths(sellDate, -months).getTime();
     const windowEnd = addMonths(sellDate, months).getTime();
@@ -172,34 +272,41 @@ export function detectWashSales(disposals: FifoDisposal[], allTrades: Trade[]): 
     // Consume repurchase quantity from in-window buys, excluding any buy on the
     // sell day (the lot being sold, not a repurchase). `absorbed` ≤ sold qty.
     //
-    // Order matters for REINTEGRATION keying (not for the blocked amount): the
-    // deferred loss must attach to shares that REMAIN in the patrimony so a later
-    // sale can release it ("se integrarán a medida que se transmitan los valores
-    // que permanezcan"). A genuine replacement is a POST-sale repurchase, whereas
-    // an in-window PRE-sale buy is often the very lot FIFO just sold (which will
-    // never be sold again → the deferred loss would be stranded). So we consume
-    // post-sale buys (ascending) FIRST, then pre-sale buys — the total absorbed
-    // (and thus the proportional block) is identical either way, but the deferred
-    // loss lands on the surviving lot. (Residual, conservative: if the ONLY
-    // in-window homogeneous acquisition is the partially-sold lot itself, the
-    // block keys there and may not reintegrate — over-deferral, never under-pay.)
+    // Order matters. A POST-sale buy is a genuine surviving replacement, so it
+    // remains uncapped and is consumed first. A PRE-sale buy can only block the
+    // portion that still remains after this sale; if the sale fully exits the
+    // position, DGT V3282-18(1) allows the loss in full because no homogeneous
+    // shares remain in the patrimony. Same-day FIFO disposal splits share one
+    // holdingAfter budget so they cannot collectively block more pre-sale shares
+    // than remain after the full sale date.
     let remainingToAbsorb = qty;
     const consumed: { date: string; qty: Decimal }[] = [];
-    const consume = (predicate: (evTime: number) => boolean): void => {
-      for (const ev of buyEvents) {
+    const consume = (predicate: (evTime: number) => boolean, maxQty?: Decimal, reverse = false): Decimal => {
+      let remainingBudget = maxQty ?? qty;
+      const events = reverse ? [...buyEvents].reverse() : buyEvents;
+      for (const ev of events) {
         if (remainingToAbsorb.lessThanOrEqualTo(0)) break;
+        if (remainingBudget.lessThanOrEqualTo(0)) break;
         if (ev.time < windowStart || ev.time > windowEnd) continue;
         if (ev.time === sellTime) continue;
         if (!predicate(ev.time)) continue;
         if (ev.remainingQty.lessThanOrEqualTo(0)) continue;
-        const take = Decimal.min(ev.remainingQty, remainingToAbsorb);
-        ev.remainingQty = ev.remainingQty.minus(take);
+        const conversion = buyQtyConversionToSellUnits(splitsByAsset, key, ev.time, sellTime);
+        const availableAtSell = ev.remainingQty.mul(conversion);
+        if (availableAtSell.lessThanOrEqualTo(0)) continue;
+        const take = Decimal.min(availableAtSell, remainingToAbsorb, remainingBudget);
+        ev.remainingQty = ev.remainingQty.minus(take.div(conversion));
         remainingToAbsorb = remainingToAbsorb.minus(take);
+        remainingBudget = remainingBudget.minus(take);
         consumed.push({ date: ev.date, qty: take });
       }
+      return (maxQty ?? qty).minus(remainingBudget);
     };
     consume((evTime) => evTime > sellTime); // post-sale repurchases first (surviving replacements)
-    consume((evTime) => evTime < sellTime); // then pre-sale in-window buys
+    // FIFO leaves the newest pre-sale lots behind after a partial sale, so attach
+    // capped pre-sale deferrals newest-first to the lots that actually survive.
+    const preSaleConsumed = consume((evTime) => evTime < sellTime, remainingHoldingBudget(key, sellTime), true);
+    consumeHoldingBudget(key, sellTime, preSaleConsumed);
 
     const absorbed = qty.minus(remainingToAbsorb);
     if (absorbed.lessThanOrEqualTo(0)) continue;
@@ -214,17 +321,17 @@ export function detectWashSales(disposals: FifoDisposal[], allTrades: Trade[]): 
     // quantity consumed there, so a later sale of those shares releases it.
     let lots = deferredByAsset.get(key);
     if (!lots) {
-      lots = new Map<string, DeferredLot>();
+      lots = new Map<string, DeferredLot[]>();
       deferredByAsset.set(key, lots);
     }
     for (const c of consumed) {
       const share = absorbed.isZero() ? new Decimal(0) : blocked.mul(c.qty).div(absorbed);
       const existing = lots.get(c.date);
+      const deferredLot = { qty: c.qty, deferredEur: share, availableAfterTime: sellTime };
       if (existing) {
-        existing.qty = existing.qty.plus(c.qty);
-        existing.deferredEur = existing.deferredEur.plus(share);
+        existing.push(deferredLot);
       } else {
-        lots.set(c.date, { qty: c.qty, deferredEur: share });
+        lots.set(c.date, [deferredLot]);
       }
     }
   }
@@ -247,6 +354,77 @@ function normalizeDay(date: string): string {
   const t = date.trim();
   if (/^\d{8}$/.test(t)) return `${t.slice(0, 4)}-${t.slice(4, 6)}-${t.slice(6, 8)}`;
   return t.slice(0, 10);
+}
+
+function buildSplitEvents(corporateActions: CorporateAction[]): Map<string, SplitEvent[]> {
+  const splitsByAsset = new Map<string, SplitEvent[]>();
+  const seen = new Set<string>();
+
+  for (const action of corporateActions) {
+    if (action.type !== "FS") continue;
+    const ratioMatch = action.description.match(/SPLIT\s+(\d+)\s+FOR\s+(\d+)/i);
+    if (!ratioMatch) continue;
+    const numerator = new Decimal(ratioMatch[1]!);
+    const denominator = new Decimal(ratioMatch[2]!);
+    if (numerator.lessThanOrEqualTo(0) || denominator.lessThanOrEqualTo(0)) continue;
+
+    const key = corporateActionKey(action);
+    if (!key) continue;
+    const date = normalizeDay(action.dateTime);
+    const dedupeKey = `${key}:${date}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+
+    let splits = splitsByAsset.get(key);
+    if (!splits) {
+      splits = [];
+      splitsByAsset.set(key, splits);
+    }
+    splits.push({ time: parseDate(date).getTime(), ratio: numerator.div(denominator) });
+  }
+
+  for (const splits of splitsByAsset.values()) {
+    splits.sort((a, b) => a.time - b.time);
+  }
+  return splitsByAsset;
+}
+
+function corporateActionKey(action: CorporateAction): string {
+  if (action.isin) return action.isin;
+  if (action.symbol) return `STK:${action.symbol.toUpperCase()}`;
+  return "";
+}
+
+function splitFactorBetween(
+  splitsByAsset: Map<string, SplitEvent[]>,
+  key: string,
+  fromTime: number,
+  toTime: number,
+): Decimal {
+  if (fromTime >= toTime) return new Decimal(1);
+
+  let factor = new Decimal(1);
+  for (const split of splitsByAsset.get(key) ?? []) {
+    if (split.time <= fromTime) continue;
+    if (split.time > toTime) break;
+    factor = factor.mul(split.ratio);
+  }
+  return factor;
+}
+
+function buyQtyConversionToSellUnits(
+  splitsByAsset: Map<string, SplitEvent[]>,
+  key: string,
+  buyTime: number,
+  sellTime: number,
+): Decimal {
+  if (buyTime < sellTime) {
+    return splitFactorBetween(splitsByAsset, key, buyTime, sellTime);
+  }
+  if (buyTime > sellTime) {
+    return new Decimal(1).div(splitFactorBetween(splitsByAsset, key, sellTime, buyTime));
+  }
+  return new Decimal(1);
 }
 
 /**

--- a/src/generators/report.ts
+++ b/src/generators/report.ts
@@ -358,7 +358,7 @@ export function generateTaxReport(
   // set, so this is identical to before. Then keep only the target year's
   // disposals for the figures (a block/release is attributed to the year of the
   // disposal that carries it).
-  const allDisposals = detectWashSales(fifoEngine.getDisposals(), statement.trades);
+  const allDisposals = detectWashSales(fifoEngine.getDisposals(), statement.trades, statement.corporateActions);
   let disposals = allDisposals.filter((d) => d.sellDate.startsWith(yearStr));
   if (titulares > 1) disposals = disposals.map((d) => splitDisposal(d, titulares));
 

--- a/tests/engine/wash-sale.test.ts
+++ b/tests/engine/wash-sale.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import Decimal from "decimal.js";
 import { detectWashSales, addMonths } from "../../src/engine/wash-sale.js";
 import type { FifoDisposal } from "../../src/types/tax.js";
-import type { Trade } from "../../src/types/ibkr.js";
+import type { CorporateAction, Trade } from "../../src/types/ibkr.js";
 
 function makeDisposal(overrides: Partial<FifoDisposal>): FifoDisposal {
   return {
@@ -41,6 +41,23 @@ function makeTrade(isin: string, date: string, buySell: "BUY" | "SELL", quantity
     fifoPnlRealized: "0", fxRateToBase: "1", buySell,
     openCloseIndicator: buySell === "BUY" ? "O" : "C",
     exchange: "NASDAQ", commissionCurrency: "USD", commission: "0", taxes: "0", multiplier: "1",
+  };
+}
+
+function makeSplit(isin: string, date: string, description = "AAPL(US0378331005) SPLIT 10 FOR 1"): CorporateAction {
+  return {
+    transactionID: "CA1",
+    accountId: "U1",
+    symbol: "AAPL",
+    description,
+    isin,
+    currency: "USD",
+    reportDate: date,
+    dateTime: date,
+    quantity: "0",
+    amount: "0",
+    type: "FS",
+    actionDescription: "Split",
   };
 }
 
@@ -93,7 +110,7 @@ describe("detectWashSales", () => {
   it("should block loss when purchased within 2 months before sale", () => {
     const disposals = [makeDisposal({ sellDate: "2025-06-15", gainLossEur: new Decimal(-100) })];
     const trades = [
-      makeTrade("US0378331005", "2025-05-20", "BUY"), // Purchase 26 days before
+      makeTrade("US0378331005", "2025-05-20", "BUY", "20"), // 10 shares still remain after the sale
       makeTrade("US0378331005", "2025-06-15", "SELL"),
     ];
 
@@ -406,6 +423,151 @@ describe("proportional blocking + reintegration", () => {
     const result = detectWashSales(disposals, trades);
     expect(result[0]!.blockedLossEur.toFixed(2)).toBe("0.00");
     expect(result[0]!.washSaleBlocked).toBe(false);
+  });
+
+  it("blocks NOTHING when a full-position sale leaves no pre-sale shares in the patrimony", () => {
+    // DGT V3282-18(1): if no homogeneous shares remain after the sale, the loss
+    // is fully deductible. The pre-sale buy is the lot being sold, not a
+    // surviving repurchase that can carry a deferred loss.
+    const disposals = [makeDisposal({
+      isin: AAPL, symbol: "AAPL", acquireDate: "2025-03-11", sellDate: "2025-04-10",
+      quantity: new Decimal(100), gainLossEur: new Decimal(-1000),
+    })];
+    const trades = [
+      makeTrade(AAPL, "2025-03-11", "BUY", "100"),
+      makeTrade(AAPL, "2025-04-10", "SELL", "100"),
+    ];
+
+    const result = detectWashSales(disposals, trades);
+    expect(result[0]!.blockedLossEur.toFixed(2)).toBe("0.00");
+    expect(result[0]!.washSaleBlocked).toBe(false);
+  });
+
+  it("caps pre-sale blocking by the shares that remain after a partial sale", () => {
+    // Buy 150, sell 100 at a €1000 loss, keep 50. Only the 50 surviving
+    // homogeneous shares can carry deferred loss, so the block is 50/100.
+    const disposals = [makeDisposal({
+      isin: AAPL, symbol: "AAPL", acquireDate: "2025-03-11", sellDate: "2025-04-10",
+      quantity: new Decimal(100), gainLossEur: new Decimal(-1000),
+    })];
+    const trades = [
+      makeTrade(AAPL, "2025-03-11", "BUY", "150"),
+      makeTrade(AAPL, "2025-04-10", "SELL", "100"),
+    ];
+
+    const result = detectWashSales(disposals, trades);
+    expect(result[0]!.blockedLossEur.toFixed(2)).toBe("500.00");
+    expect(result[0]!.washSaleBlocked).toBe(true);
+  });
+
+  it("still blocks a full exit when there is a later post-sale repurchase", () => {
+    // The total-sale carve-out caps only pre-sale buys. A later buy is a genuine
+    // replacement that remains after the loss-sale and must still block.
+    const disposals = [makeDisposal({
+      isin: AAPL, symbol: "AAPL", acquireDate: "2025-03-11", sellDate: "2025-04-10",
+      quantity: new Decimal(100), gainLossEur: new Decimal(-1000),
+    })];
+    const trades = [
+      makeTrade(AAPL, "2025-03-11", "BUY", "100"),
+      makeTrade(AAPL, "2025-04-10", "SELL", "100"),
+      makeTrade(AAPL, "2025-04-17", "BUY", "50"),
+    ];
+
+    const result = detectWashSales(disposals, trades);
+    expect(result[0]!.blockedLossEur.toFixed(2)).toBe("500.00");
+    expect(result[0]!.washSaleBlocked).toBe(true);
+  });
+
+  it("shares the holdingAfter budget across same-day FIFO splits and releases from the surviving lot", () => {
+    // One SELL trade can split into multiple FIFO disposals. The sale leaves only
+    // 30 shares in the patrimony, so the two loss disposals may block 30 shares
+    // total, not 30 each. FIFO leaves the newest 2025-03-12 lot behind, so the
+    // deferred loss must attach there and release when that remainder is sold.
+    const disposals = [
+      makeDisposal({
+        isin: AAPL, symbol: "AAPL", acquireDate: "2025-03-11", sellDate: "2025-04-10",
+        quantity: new Decimal(40), gainLossEur: new Decimal(-400),
+      }),
+      makeDisposal({
+        isin: AAPL, symbol: "AAPL", acquireDate: "2025-03-12", sellDate: "2025-04-10",
+        quantity: new Decimal(30), gainLossEur: new Decimal(-300),
+      }),
+      makeDisposal({
+        isin: AAPL, symbol: "AAPL", acquireDate: "2025-03-12", sellDate: "2025-05-10",
+        quantity: new Decimal(30), gainLossEur: new Decimal(50),
+      }),
+    ];
+    const trades = [
+      makeTrade(AAPL, "2025-03-11", "BUY", "40"),
+      makeTrade(AAPL, "2025-03-12", "BUY", "60"),
+      makeTrade(AAPL, "2025-04-10", "SELL", "70"),
+      makeTrade(AAPL, "2025-05-10", "SELL", "30"),
+    ];
+
+    const result = detectWashSales(disposals, trades);
+    const totalBlocked = result.reduce((sum, disposal) => sum.plus(disposal.blockedLossEur), new Decimal(0));
+    expect(totalBlocked.toFixed(2)).toBe("300.00");
+    expect(result[0]!.blockedLossEur.toFixed(2)).toBe("300.00");
+    expect(result[1]!.blockedLossEur.toFixed(2)).toBe("0.00");
+    expect(result[2]!.reintegratedLossEur.toFixed(2)).toBe("300.00");
+  });
+
+  it("uses split-adjusted quantities for the pre-sale remaining-position cap", () => {
+    // Buy 10 inside the 2-month window, 10-for-1 split to 100, sell 50 at a loss and keep 50. The
+    // remaining-position cap is 50 post-split shares, not raw 10 - 50 = 0.
+    const disposals = [
+      makeDisposal({
+        isin: AAPL, symbol: "AAPL", acquireDate: "2025-03-01", sellDate: "2025-04-10",
+        quantity: new Decimal(50), gainLossEur: new Decimal(-1000),
+      }),
+      makeDisposal({
+        isin: AAPL, symbol: "AAPL", acquireDate: "2025-03-01", sellDate: "2025-05-10",
+        quantity: new Decimal(50), gainLossEur: new Decimal(50),
+      }),
+    ];
+    const trades = [
+      makeTrade(AAPL, "2025-03-01", "BUY", "10"),
+      makeTrade(AAPL, "2025-04-10", "SELL", "50"),
+      makeTrade(AAPL, "2025-05-10", "SELL", "50"),
+    ];
+
+    const result = detectWashSales(disposals, trades, [makeSplit(AAPL, "2025-03-10")]);
+    expect(result[0]!.blockedLossEur.toFixed(2)).toBe("1000.00");
+    expect(result[1]!.reintegratedLossEur.toFixed(2)).toBe("1000.00");
+  });
+
+  it("prorates deferred-loss release when the replacement lot splits after the block", () => {
+    // Sell 100 at a €1000 loss, rebuy 100, then a 2-for-1 split turns that
+    // replacement lot into 200 shares. Selling 100 post-split shares releases
+    // half of the deferred loss, and the remaining 100 releases the rest.
+    const disposals = [
+      makeDisposal({
+        isin: AAPL, symbol: "AAPL", acquireDate: "2025-01-10", sellDate: "2025-06-01",
+        quantity: new Decimal(100), gainLossEur: new Decimal(-1000),
+      }),
+      makeDisposal({
+        isin: AAPL, symbol: "AAPL", acquireDate: "2025-07-01", sellDate: "2025-09-01",
+        quantity: new Decimal(100), gainLossEur: new Decimal(50),
+      }),
+      makeDisposal({
+        isin: AAPL, symbol: "AAPL", acquireDate: "2025-07-01", sellDate: "2025-10-01",
+        quantity: new Decimal(100), gainLossEur: new Decimal(50),
+      }),
+    ];
+    const trades = [
+      makeTrade(AAPL, "2025-01-10", "BUY", "100"),
+      makeTrade(AAPL, "2025-06-01", "SELL", "100"),
+      makeTrade(AAPL, "2025-07-01", "BUY", "100"),
+      makeTrade(AAPL, "2025-09-01", "SELL", "100"),
+      makeTrade(AAPL, "2025-10-01", "SELL", "100"),
+    ];
+
+    const result = detectWashSales(disposals, trades, [
+      makeSplit(AAPL, "2025-08-01", "AAPL(US0378331005) SPLIT 2 FOR 1"),
+    ]);
+    expect(result[0]!.blockedLossEur.toFixed(2)).toBe("1000.00");
+    expect(result[1]!.reintegratedLossEur.toFixed(2)).toBe("500.00");
+    expect(result[2]!.reintegratedLossEur.toFixed(2)).toBe("500.00");
   });
 
   it("blocks NOTHING when the repurchase falls outside the window (listed ISIN, 2-month window)", () => {

--- a/tests/integration/antichurning-proportional-e2e.test.ts
+++ b/tests/integration/antichurning-proportional-e2e.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { generateTaxReport } from "../../src/generators/report.js";
+import { lightyearParser } from "../../src/parsers/lightyear.js";
 import type { FlexStatement, Trade } from "../../src/types/ibkr.js";
 import type { EcbRateMap } from "../../src/types/ecb.js";
 
@@ -219,5 +220,57 @@ describe("antichurning e2e: cross-year defer (2024) then reintegrate (2025)", ()
       .plus(report.capitalGains.blockedLosses)
       .minus(report.capitalGains.reintegratedLosses);
     expect(fiscal.toFixed(2)).toBe("2000.00");
+  });
+});
+
+// ===========================================================================
+// 3. TOTAL-POSITION SALE — no pre-sale shares remain, so the loss is deductible.
+// ===========================================================================
+//
+// Reporter-shaped Lightyear CSV:
+//   BUY  66 AAPL (2025-03-11) @ $19.869
+//   BUY 150 AAPL (2025-04-07)
+//   SELL 216 AAPL (2025-04-10) @ $19.63
+//
+// FIFO splits the 216-share sale into two disposals. The first 66-share disposal
+// is a real loss, but after the sale the AAPL position is zero. DGT V3282-18(1)
+// allows the loss in full: no anti-churning block, in both rigorous and
+// monodivisa modes. This fixture goes through the Lightyear parser in memory.
+describe("antichurning e2e: full-position Lightyear sale does not block the loss", () => {
+  const lightyearCsv = [
+    "Date,Reference,Ticker,ISIN,Type,Quantity,CCY,Price/share,Gross Amount,FX Rate,Fee,Net Amt.,Tax Amt.",
+    "11/03/2025 15:30:00,OR-249-1,AAPL,US0378331005,Buy,66.000000000,USD,19.869000000,1311.354,,0.00,1311.354,",
+    "07/04/2025 16:00:00,OR-249-2,AAPL,US0378331005,Buy,150.000000000,USD,19.500000000,2925.00,,0.00,2925.00,",
+    "10/04/2025 17:00:00,OR-249-3,AAPL,US0378331005,Sell,216.000000000,USD,19.630000000,4240.08,,0.00,4240.08,",
+  ].join("\n");
+
+  const rates = makeRateMap({
+    "2025-03-11": { USD: "0.96" },
+    "2025-04-07": { USD: "0.96" },
+    "2025-04-10": { USD: "0.96" },
+  });
+
+  it("parses the reporter-shaped CSV into the full 216-share AAPL sale", () => {
+    const statement = lightyearParser.parse(lightyearCsv);
+    const aaplTrades = statement.trades.filter((trade) => trade.symbol === "AAPL");
+    expect(aaplTrades.map((trade) => `${trade.buySell}:${trade.quantity}`)).toEqual([
+      "BUY:66",
+      "BUY:150",
+      "SELL:-216",
+    ]);
+  });
+
+  it("rigorous mode reports zero blocked losses for the full-position sale", () => {
+    const report = generateTaxReport(lightyearParser.parse(lightyearCsv), rates, 2025);
+    expect(report.capitalGains.disposals).toHaveLength(2);
+    expect(report.capitalGains.blockedLosses.toFixed(2)).toBe("0.00");
+    expect(report.capitalGains.disposals.every((disposal) => !disposal.washSaleBlocked)).toBe(true);
+  });
+
+  it("monodivisa mode also reports zero blocked losses for the full-position sale", () => {
+    const report = generateTaxReport(lightyearParser.parse(lightyearCsv), rates, 2025, { skipFx: true });
+    expect(report.capitalGains.disposals).toHaveLength(2);
+    expect(report.capitalGains.blockedLosses.toFixed(2)).toBe("0.00");
+    expect(report.capitalGains.disposals.every((disposal) => !disposal.washSaleBlocked)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Cap pre-sale anti-churning absorption by the split-adjusted position remaining after the sale date, while leaving post-sale repurchases blocking normally.
- Prevent same-day FIFO split disposals from immediately reintegrating newly deferred losses, and prorate release correctly across stock splits.
- Add focused unit and Lightyear parser-to-report regressions for issue #249.

## Test plan
- `npm run typecheck`
- `npm run typecheck:tests`
- `npm run lint`
- `npm test`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wash-sale loss blocking now uses proportional allocation based on repurchase quantity.
  * Added support for corporate actions in wash-sale detection calculations.

* **Documentation**
  * Updated anti-churning design documentation with multi-budget model and deferred loss reintegration details.

* **Tests**
  * Added comprehensive test coverage for proportional loss blocking and full-position sale scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->