### PR TITLE
fix(parsers): stop dropping Degiro trades quoted in GBX pence

### DIFF
--- a/src/parsers/csv-utils.ts
+++ b/src/parsers/csv-utils.ts
@@ -170,6 +170,31 @@ export function convertDateISO(date: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Fractional (minor-unit) currency normalization
+// Some venues quote in the minor unit: GBX (penny sterling, LSE), ZAc (South
+// African cents), ILA (Israeli agorot). The ECB only publishes the major unit
+// (GBP/ZAR/ILS), so parsers must normalize the code and divide the quoted
+// price/amount by 100 before anything downstream sees the trade — otherwise
+// the valuation pre-pass drops it as an unresolvable currency (issue #282).
+// ---------------------------------------------------------------------------
+
+const FRACTIONAL_CURRENCIES: Record<string, { base: string; divisor: Decimal }> = {
+  GBX: { base: "GBP", divisor: new Decimal(100) },
+  ZAC: { base: "ZAR", divisor: new Decimal(100) },
+  ILA: { base: "ILS", divisor: new Decimal(100) },
+};
+
+/**
+ * Map a minor-unit currency code to its ECB major unit and the divisor to
+ * apply to amounts quoted in it. Unknown codes pass through with divisor 1.
+ */
+export function normalizeFractionalCurrency(code: string): { currency: string; divisor: Decimal } {
+  const entry = FRACTIONAL_CURRENCIES[code.trim().toUpperCase()];
+  if (entry) return { currency: entry.base, divisor: entry.divisor };
+  return { currency: code, divisor: new Decimal(1) };
+}
+
+// ---------------------------------------------------------------------------
 // Column finding
 // ---------------------------------------------------------------------------
 

--- a/src/parsers/degiro.ts
+++ b/src/parsers/degiro.ts
@@ -15,6 +15,7 @@
 import type { BrokerParser, Statement } from "../types/broker.js";
 import type { Trade, CashTransaction } from "../types/ibkr.js";
 import type { TaxMessage } from "../types/tax.js";
+import Decimal from "decimal.js";
 import {
   detectDelimiter,
   parseCsvLine,
@@ -22,6 +23,7 @@ import {
   toFiniteDecimal,
   convertDateDMY,
   findColumn,
+  normalizeFractionalCurrency,
   stripBom,
 } from "./csv-utils.js";
 
@@ -260,6 +262,38 @@ function parseTransactionsCsv(lines: string[], delimiter: string): Statement {
     const isSell = valueDec.greaterThan(0) || qtyDec.lessThan(0);
     const absQtyStr = qtyDec.abs().toString();
 
+    // Degiro quotes LSE instruments in GBX (pence). ECB only publishes GBP,
+    // so normalize the code and divide the per-share price, the local value
+    // and the FX rate by 100 (issue #282). The "Valor local" column is by
+    // definition in the instrument's quote currency, so it divides with it;
+    // a 16-col fallback value (already the EUR column) is left untouched.
+    let tradeCurrency = currency || "EUR";
+    let tradePrice = price;
+    let tradeValue = value;
+    let tradeFxRate = fxRate;
+    const fractional = normalizeFractionalCurrency(tradeCurrency);
+    if (!fractional.divisor.equals(1)) {
+      tradeCurrency = fractional.currency;
+      tradePrice = new Decimal(price).div(fractional.divisor).toString();
+      if (localValue) tradeValue = new Decimal(localValue).div(fractional.divisor).toString();
+      if (tradeFxRate !== "0" && tradeFxRate !== "1") {
+        tradeFxRate = new Decimal(tradeFxRate).div(fractional.divisor).toString();
+      }
+    }
+
+    // Commission currency may itself be a minor unit in older layouts with a
+    // per-costs currency column (fallback = the raw quote currency, so an
+    // unlabeled pence commission is divided too) — normalize it the same way.
+    let commissionValue = commission;
+    let commissionCcy = commCurrency || currency || "EUR";
+    const commFractional = normalizeFractionalCurrency(commissionCcy);
+    if (!commFractional.divisor.equals(1)) {
+      commissionCcy = commFractional.currency;
+      if (commissionValue !== "0") {
+        commissionValue = new Decimal(commissionValue).div(commFractional.divisor).toString();
+      }
+    }
+
     trades.push({
       tradeID: orderId,
       accountId: "",
@@ -267,21 +301,21 @@ function parseTransactionsCsv(lines: string[], delimiter: string): Statement {
       description: product,
       isin,
       assetCategory: "STK",
-      currency: currency || "EUR",
+      currency: tradeCurrency,
       tradeDate,
       settlementDate: tradeDate, // T+2 estimated, but we use tradeDate for FIFO
       quantity: isSell ? `-${absQtyStr}` : absQtyStr,
-      tradePrice: price,
-      tradeMoney: value,
-      proceeds: isSell ? value : "0",
-      cost: isSell ? "0" : value,
+      tradePrice,
+      tradeMoney: tradeValue,
+      proceeds: isSell ? tradeValue : "0",
+      cost: isSell ? "0" : tradeValue,
       fifoPnlRealized: "0",
-      fxRateToBase: fxRate === "0" ? "1" : fxRate || "1",
+      fxRateToBase: tradeFxRate === "0" ? "1" : tradeFxRate || "1",
       buySell: isSell ? "SELL" : "BUY",
       openCloseIndicator: isSell ? "C" : "O",
       exchange,
-      commissionCurrency: commCurrency || currency || "EUR",
-      commission,
+      commissionCurrency: commissionCcy,
+      commission: commissionValue,
       taxes: "0",
       multiplier: "1",
     });
@@ -388,9 +422,16 @@ function parseAccountCsv(lines: string[], delimiter: string): Statement {
     const description = (fields[cols.description] ?? "").trim();
     const isin = (fields[cols.isin] ?? "").trim();
     const product = (fields[cols.product] ?? "").trim();
-    const amount = parseNumber(fields[cols.amount] ?? "0");
-    const currency = cols.currency >= 0 ? (fields[cols.currency] ?? "EUR").trim() : "EUR";
+    let amount = parseNumber(fields[cols.amount] ?? "0");
+    let currency = cols.currency >= 0 ? (fields[cols.currency] ?? "EUR").trim() : "EUR";
     const fx = cols.fx >= 0 ? parseNumber(fields[cols.fx] ?? "1") : "1";
+
+    // Minor-unit amounts (GBX pence, etc.) → ECB major unit, same as trades.
+    const fractional = normalizeFractionalCurrency(currency || "EUR");
+    if (!fractional.divisor.equals(1)) {
+      currency = fractional.currency;
+      if (amount !== "0") amount = new Decimal(amount).div(fractional.divisor).toString();
+    }
 
     if (!description) continue;
 

--- a/src/parsers/trading212.ts
+++ b/src/parsers/trading212.ts
@@ -26,7 +26,13 @@ import Decimal from "decimal.js";
 import type { BrokerParser, Statement } from "../types/broker.js";
 import type { Trade, CashTransaction } from "../types/ibkr.js";
 import type { TaxMessage } from "../types/tax.js";
-import { parseCsvLine, toFiniteDecimalString, findColumn, stripBom } from "./csv-utils.js";
+import {
+  parseCsvLine,
+  toFiniteDecimalString,
+  findColumn,
+  normalizeFractionalCurrency,
+  stripBom,
+} from "./csv-utils.js";
 
 // ---------------------------------------------------------------------------
 // Header detection
@@ -116,25 +122,9 @@ function isSkippedAction(action: string): boolean {
   return /deposit|withdrawal|currency conversion|card debit|spending cashback/i.test(action);
 }
 
-// ---------------------------------------------------------------------------
-// Fractional currency normalization
-// Trading 212 reports GBX (pence), ZAc (South African cents), ILA (Israeli
-// agorot) as-is. ECB only publishes GBP/ZAR/ILS so we normalize and ÷100.
-// ---------------------------------------------------------------------------
-
-const FRACTIONAL_CURRENCIES: Record<string, { base: string; divisor: Decimal }> = {
-  GBX: { base: "GBP", divisor: new Decimal(100) },
-  ZAC: { base: "ZAR", divisor: new Decimal(100) },
-  ILA: { base: "ILS", divisor: new Decimal(100) },
-};
-
-function normalizeCurrency(code: string): { currency: string; divisor: Decimal } {
-  const entry = FRACTIONAL_CURRENCIES[code.toUpperCase()];
-  if (entry && code.toUpperCase() !== entry.base) {
-    return { currency: entry.base, divisor: entry.divisor };
-  }
-  return { currency: code, divisor: new Decimal(1) };
-}
+// Fractional currency normalization (GBX pence, ZAc cents, ILA agorot →
+// ECB major unit ÷100) is shared with the Degiro parser: see
+// normalizeFractionalCurrency in csv-utils.ts.
 
 // ---------------------------------------------------------------------------
 // Parser
@@ -172,12 +162,12 @@ function parseTrading212Csv(lines: string[]): Statement {
     const sharesStr = toFiniteDecimalString(fields[cols.shares] ?? "0");
     const priceStr = toFiniteDecimalString(fields[cols.pricePerShare] ?? "0");
     const rawCurrency = (fields[cols.priceCurrency] ?? "").trim() || "EUR";
-    const { currency: priceCurrency, divisor: priceDivisor } = normalizeCurrency(rawCurrency);
+    const { currency: priceCurrency, divisor: priceDivisor } = normalizeFractionalCurrency(rawCurrency);
     const currency = priceCurrency;
     // Currency (Total) is authoritative for cash transaction amounts: in EUR-primary accounts
     // the Total column holds the credited EUR amount, not the instrument's native currency.
     const rawCashCurrency = (fields[cols.totalCurrency] ?? "").trim() || rawCurrency;
-    const { currency: cashCurrency, divisor: cashDivisor } = normalizeCurrency(rawCashCurrency);
+    const { currency: cashCurrency, divisor: cashDivisor } = normalizeFractionalCurrency(rawCashCurrency);
     const totalStr = toFiniteDecimalString(fields[cols.total] ?? "0");
     const txId = (fields[cols.id] ?? "").trim();
 

--- a/tests/integration/degiro-gbx-e2e.test.ts
+++ b/tests/integration/degiro-gbx-e2e.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { generateTaxReport } from "../../src/generators/report.js";
+import { degiroParser } from "../../src/parsers/degiro.js";
+import type { FlexStatement } from "../../src/types/ibkr.js";
+import type { EcbRateMap } from "../../src/types/ecb.js";
+
+// ===========================================================================
+// End-to-end: Degiro GBX (pence) import — issue #282.
+// ---------------------------------------------------------------------------
+// THE BUG: Degiro quotes LSE instruments in GBX (penny sterling). The ECB only
+// publishes GBP, so an un-normalized "GBX" trade is unresolvable: the
+// crypto-valuation pre-pass (resolveCryptoTradeValues) dropped ALL of them.
+// The visible symptom was asymmetric — the buys silently created no FIFO lots
+// while the user could rescue the sale via a manual rate, so the report showed
+// the 510-share sale with cost basis 0 (`fifo.sell_without_lots`) and the
+// manual-opening-lots panel asked for lots the file actually contains.
+//
+// THE FIX: the Degiro parser normalizes GBX→GBP (price and local value ÷100,
+// shared `normalizeFractionalCurrency` helper, same as Trading 212), so the
+// engine only ever sees a real ISO currency and the whole pipeline just works.
+//
+// This test runs the EXACT export from the issue through degiroParser →
+// generateTaxReport with a fixed in-memory GBP rate map and pins the
+// hand-computed EUR figures (V2422-20: same-fiat security → both legs at the
+// sale-date rate 1.16):
+//   lot A (swap-in 2022): 110 × 4.5889 GBP                 = 504.779 GBP
+//   lot B (buy 2024):     400 × 1.0956 + 5.37 EUR/1.20     = 442.715 GBP
+//   sale (2026):          510 × 3.3345 − 10.66 EUR/1.16    = 1691.40534... GBP
+//   proceeds = 1691.40534 × 1.16 = 1962.03 €
+//   cost     = 947.494    × 1.16 = 1099.09 €
+//   gain     =                      862.94 €
+// ===========================================================================
+
+const GBX_CSV = [
+  "Fecha,Hora,Producto,ISIN,Bolsa de referencia,Centro de ejecución,Número,Precio,,Valor local,,Valor EUR,Tipo de cambio,Comisión AutoFX,Costes de transacción y/o externos EUR,Total EUR,ID Orden",
+  '26-05-2026,09:12,KISTOS HOLDINGS PLC,GB00BP7NQJ77,LSE,AIMX,-510,"333,4500",GBX,"170059,50",GBX,"1969,88","86,3297","-4,93","-5,73","1959,22",00000000-0000-4000-8000-000000000001',
+  '12-07-2024,13:02,KISTOS HOLDINGS PLC,GB00BP7NQJ77,LSE,AIMX,400,"109,5600",GBX,"-43824,00",GBX,"-521,59","84,0202","-1,30","-4,07","-526,96",00000000-0000-4000-8000-000000000002',
+  '29-12-2022,14:34,KISTOS HOLDINGS PLC,GB00BP7NQJ77,LSE,,110,"458,8900",GBX,"-50477,90",GBX,"-576,11","87,6194","0,00",,"-576,11",',
+  '29-12-2022,14:34,KISTOS PLC,GB00BLF7NX68,LSE,,-110,"458,8900",GBX,"50477,90",GBX,"576,11","87,6194","0,00",,"576,11",',
+  '22-09-2021,10:35,KISTOS PLC,GB00BLF7NX68,LSE,AIMX,110,"316,7800",GBX,"-34845,80",GBX,"-405,33","85,9697","-0,40","-3,97","-409,70",00000000-0000-4000-8000-000000000003',
+].join("\n");
+
+/** Fixed GBP rates (EUR per 1 GBP) for the four trade dates — all business days. */
+function makeRateMap(): EcbRateMap {
+  const map: EcbRateMap = new Map();
+  map.set("2021-09-22", new Map([["GBP", "1.17"]]));
+  map.set("2022-12-29", new Map([["GBP", "1.13"]]));
+  map.set("2024-07-12", new Map([["GBP", "1.20"]]));
+  map.set("2026-05-26", new Map([["GBP", "1.16"]]));
+  return map;
+}
+
+describe("Degiro GBX end-to-end (issue #282)", () => {
+  const statement = degiroParser.parse(GBX_CSV) as FlexStatement;
+  const report = generateTaxReport(statement, makeRateMap(), 2026);
+
+  it("consumes the buys as FIFO lots — no sell_without_lots / insufficient_lots", () => {
+    const ids = report.messages.map((m) => m.id);
+    expect(ids).not.toContain("fifo.sell_without_lots");
+    expect(ids).not.toContain("fifo.insufficient_lots");
+  });
+
+  it("produces the two 2026 disposals covering all 510 shares", () => {
+    const disposals = report.capitalGains.disposals;
+    expect(disposals).toHaveLength(2);
+    const quantities = disposals.map((d) => d.quantity.toString()).sort();
+    expect(quantities).toEqual(["110", "400"]);
+    for (const d of disposals) {
+      expect(d.currency).toBe("GBP");
+      expect(d.costBasisEur.greaterThan(0)).toBe(true);
+    }
+  });
+
+  it("pins the hand-computed EUR figures (V2422-20 sale-date rate)", () => {
+    expect(report.capitalGains.transmissionValue.toFixed(2)).toBe("1962.03");
+    expect(report.capitalGains.acquisitionValue.toFixed(2)).toBe("1099.09");
+    expect(report.capitalGains.netGainLoss.toFixed(2)).toBe("862.94");
+  });
+
+  it("books no divisa gain (no EUR conversion ever happens in the file)", () => {
+    expect(report.fxGains.netGainLoss.toFixed(2)).toBe("0.00");
+    expect(report.fxGains.disposals).toHaveLength(0);
+  });
+});

--- a/tests/integration/degiro-gbx-e2e.test.ts
+++ b/tests/integration/degiro-gbx-e2e.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { generateTaxReport } from "../../src/generators/report.js";
 import { degiroParser } from "../../src/parsers/degiro.js";
-import type { FlexStatement } from "../../src/types/ibkr.js";
 import type { EcbRateMap } from "../../src/types/ecb.js";
 
 // ===========================================================================
@@ -51,7 +50,7 @@ function makeRateMap(): EcbRateMap {
 }
 
 describe("Degiro GBX end-to-end (issue #282)", () => {
-  const statement = degiroParser.parse(GBX_CSV) as FlexStatement;
+  const statement = degiroParser.parse(GBX_CSV);
   const report = generateTaxReport(statement, makeRateMap(), 2026);
 
   it("consumes the buys as FIFO lots — no sell_without_lots / insufficient_lots", () => {

--- a/tests/parsers/degiro.test.ts
+++ b/tests/parsers/degiro.test.ts
@@ -387,4 +387,87 @@ describe("degiroParser", () => {
       expect(noComm.commission).toBe("0");
     });
   });
+
+  // -------------------------------------------------------------------------
+  // GBX (penny sterling) normalization — issue #282.
+  // Degiro quotes LSE instruments in GBX (pence). ECB only publishes GBP, so
+  // without normalization every GBX trade is dropped as an unresolvable
+  // currency by the crypto-valuation pre-pass: the buys create no FIFO lots
+  // and a later sale fires `fifo.sell_without_lots` with cost basis 0.
+  // Fixture = the exact export from the issue (order IDs synthetic): a 2021
+  // buy, a 2022 ISIN swap (KISTOS PLC → KISTOS HOLDINGS PLC), a 2024 buy and
+  // the 2026 sale of the combined 510 shares.
+  // -------------------------------------------------------------------------
+
+  describe("GBX fractional currency (issue #282)", () => {
+    const GBX_CSV = [
+      "Fecha,Hora,Producto,ISIN,Bolsa de referencia,Centro de ejecución,Número,Precio,,Valor local,,Valor EUR,Tipo de cambio,Comisión AutoFX,Costes de transacción y/o externos EUR,Total EUR,ID Orden",
+      '26-05-2026,09:12,KISTOS HOLDINGS PLC,GB00BP7NQJ77,LSE,AIMX,-510,"333,4500",GBX,"170059,50",GBX,"1969,88","86,3297","-4,93","-5,73","1959,22",00000000-0000-4000-8000-000000000001',
+      '12-07-2024,13:02,KISTOS HOLDINGS PLC,GB00BP7NQJ77,LSE,AIMX,400,"109,5600",GBX,"-43824,00",GBX,"-521,59","84,0202","-1,30","-4,07","-526,96",00000000-0000-4000-8000-000000000002',
+      '29-12-2022,14:34,KISTOS HOLDINGS PLC,GB00BP7NQJ77,LSE,,110,"458,8900",GBX,"-50477,90",GBX,"-576,11","87,6194","0,00",,"-576,11",',
+      '29-12-2022,14:34,KISTOS PLC,GB00BLF7NX68,LSE,,-110,"458,8900",GBX,"50477,90",GBX,"576,11","87,6194","0,00",,"576,11",',
+      '22-09-2021,10:35,KISTOS PLC,GB00BLF7NX68,LSE,AIMX,110,"316,7800",GBX,"-34845,80",GBX,"-405,33","85,9697","-0,40","-3,97","-409,70",00000000-0000-4000-8000-000000000003',
+    ].join("\n");
+
+    it("should parse all 5 rows without dropping any (buys included)", () => {
+      const result = degiroParser.parse(GBX_CSV);
+      expect(result.trades).toHaveLength(5);
+      expect(result.parserMessages).toBeUndefined();
+      expect(result.trades.filter((t) => t.buySell === "BUY")).toHaveLength(3);
+      expect(result.trades.filter((t) => t.buySell === "SELL")).toHaveLength(2);
+    });
+
+    it("should normalize GBX to GBP with price ÷100", () => {
+      const result = degiroParser.parse(GBX_CSV);
+      for (const t of result.trades) {
+        expect(t.currency).toBe("GBP");
+      }
+      const sell = result.trades.find((t) => t.quantity === "-510")!;
+      expect(sell.tradePrice).toBe("3.3345"); // 333.4500 GBX
+      const buy2024 = result.trades.find((t) => t.quantity === "400")!;
+      expect(buy2024.tradePrice).toBe("1.0956"); // 109.5600 GBX
+      const buy2021 = result.trades.find(
+        (t) => t.isin === "GB00BLF7NX68" && t.buySell === "BUY",
+      )!;
+      expect(buy2021.tradePrice).toBe("3.1678"); // 316.7800 GBX
+    });
+
+    it("should normalize the local value (tradeMoney) ÷100", () => {
+      const result = degiroParser.parse(GBX_CSV);
+      const sell = result.trades.find((t) => t.quantity === "-510")!;
+      expect(sell.tradeMoney).toBe("1700.595"); // 170059.50 GBX
+      const buy2024 = result.trades.find((t) => t.quantity === "400")!;
+      expect(buy2024.tradeMoney).toBe("-438.24"); // -43824.00 GBX
+    });
+
+    it("should keep EUR commissions untouched (Comisión AutoFX + Costes EUR)", () => {
+      const result = degiroParser.parse(GBX_CSV);
+      const sell = result.trades.find((t) => t.quantity === "-510")!;
+      expect(sell.commission).toBe("-10.66"); // -4.93 AutoFX + -5.73 costes
+      expect(sell.commissionCurrency).toBe("EUR");
+      const buy2024 = result.trades.find((t) => t.quantity === "400")!;
+      expect(buy2024.commission).toBe("-5.37"); // -1.30 + -4.07
+    });
+
+    it("should express fxRateToBase in the major unit (GBP per EUR)", () => {
+      const result = degiroParser.parse(GBX_CSV);
+      const sell = result.trades.find((t) => t.quantity === "-510")!;
+      expect(sell.fxRateToBase).toBe("0.863297"); // 86.3297 GBX per EUR
+    });
+
+    it("should parse the ISIN-swap pair (no order ID, empty venue)", () => {
+      const result = degiroParser.parse(GBX_CSV);
+      const swapIn = result.trades.find(
+        (t) => t.isin === "GB00BP7NQJ77" && t.quantity === "110",
+      )!;
+      expect(swapIn.buySell).toBe("BUY");
+      expect(swapIn.tradePrice).toBe("4.5889");
+      expect(swapIn.commission).toBe("0");
+      const swapOut = result.trades.find(
+        (t) => t.isin === "GB00BLF7NX68" && t.quantity === "-110",
+      )!;
+      expect(swapOut.buySell).toBe("SELL");
+      expect(swapOut.tradePrice).toBe("4.5889");
+    });
+  });
 });


### PR DESCRIPTION
## Problem

Importing a Degiro Transactions CSV with LSE trades "doesn't take into account the buy operations" (#282): the report shows the sale with cost basis 0 (`fifo.sell_without_lots`) and the manual-opening-lots panel asks for lots the file actually contains.

Root cause: Degiro quotes LSE instruments in **GBX (penny sterling)**. The ECB only publishes GBP, so the crypto-valuation pre-pass treated GBX as an unresolvable currency and silently dropped every GBX trade — buys never created FIFO lots, and the sale could only be rescued via a manual rate, producing a cost-0 gain.

## Fix

Normalize minor-unit currencies to their ECB major unit at the parser boundary, the same way the Trading 212 parser already does:

- `normalizeFractionalCurrency` (GBX→GBP, ZAc→ZAR, ILA→ILS, ÷100) hoisted into `csv-utils.ts` and shared by both parsers, so the rule can't drift between them.
- Degiro Transactions CSV: currency code, per-share price, local value (`Valor local` is by definition in the quote currency) and `Tipo de cambio` all normalized. EUR-denominated commissions (`Comisión AutoFX` + `Costes … EUR`) untouched; a commission labeled in a minor unit is normalized too.
- Degiro Account CSV (dividends/withholding): same normalization, mirroring the trades path.

## Verification

- New parser tests use the exact export from the issue: all 5 rows parse (3 buys + 2 sells), GBP everywhere, prices ÷100, commissions intact.
- New end-to-end test `degiro-gbx-e2e`: parser → `generateTaxReport` with a fixed GBP rate map — no `sell_without_lots`, the two 2026 disposals cover all 510 shares, and the hand-computed figures pin exactly (proceeds €1962.03, cost €1099.09, gain €862.94, V2422-20 sale-date rate on both legs).
- Red→green proven: the same tests fail 6 ways against the unfixed parser.
- Full suite: 93 files / 1778 tests green, typecheck clean.

Closes #282.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of fractional currencies such as GBX, ZAC, and ILA by converting values to their corresponding major currencies.
  * Improved normalization of trade prices, cash amounts, commissions, and exchange rates during imports.
  * Preserved support for transactions with missing order IDs or execution venues.

* **Tests**
  * Added regression coverage for fractional-currency imports, tax calculations, FIFO lot handling, and foreign-exchange gains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->