### PR TITLE
fix(web): keep the section fade-in restarting under stricter lint rules

### DIFF
--- a/src/web/sidebar.ts
+++ b/src/web/sidebar.ts
@@ -58,7 +58,9 @@ export function navigateToSection(section: Section): void {
       el.hidden = s !== section;
       if (s === section) {
         el.classList.remove("fade-in");
-        void el.offsetHeight;
+        // Force a synchronous reflow so the browser does not batch the class
+        // remove+add, which would leave the animation never restarting.
+        void el.getBoundingClientRect();
         el.classList.add("fade-in");
       }
     }


### PR DESCRIPTION
The `typescript-eslint` 8.69.0 bump in #286 turns the CI `test` job red on a single lint error, and the error is in code that PR never touched:

```
src/web/sidebar.ts
  61:9  error  void operator is useless here; it should only discard a call's return value
              @typescript-eslint/no-meaningless-void-operator
```

8.69.0 tightened `no-meaningless-void-operator` so it rejects `void` applied to anything that is not a call. Here it was applied to `el.offsetHeight`, and that read is not decorative: touching a layout property forces a synchronous reflow, which is the only reason removing and re-adding the `fade-in` class restarts the animation instead of being batched into a no-op. Deleting the `void`, or the line, would have quietly killed the animation.

So this reads layout through a call instead. `void` on a call expression is exactly what the rule allows, so the reflow survives and no suppression comment is needed.

Verified locally against the 8.69.0 tree from #286: `typecheck`, `typecheck:tests`, `lint`, `test:coverage` (93 files, 1778 tests), `build` and the CLI smoke test all pass. As a control, `main` on 8.68.0 lints clean, which is why this only shows up alongside the bump.

Merging this first lets #286 go green on a rebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar fade-in animation reliability by ensuring the animation restarts consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->